### PR TITLE
Add recipe ci cd

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,6 +122,12 @@ jobs:
     working_directory: ~/howardism/apps/minecraft
     steps:
       - node-build-steps
+  build-recipe:
+    docker:
+      - image: cimg/node:lts
+    working_directory: ~/howardism/apps/recipe
+    steps:
+      - node-build-steps
 workflows:
   version: 2
   blog:
@@ -133,3 +139,6 @@ workflows:
   minecraft:
     jobs:
       - build-minecraft
+  recipe:
+    jobs:
+      - build-recipe

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn type-check && yarn build
+yarn type-check && yarn test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+<a name="1.0.8"></a>
+## 1.0.8 (2021-04-20)
+
+### Added
+
+- 👷‍♂️ add recipe build [[108c4a9](https://github.com/Howard86/howardism/commit/108c4a91af5e3382990d1225611a5eadedd99141)]
+
+### Changed
+
+- 🔧 update pre-push hooks [[9eebf23](https://github.com/Howard86/howardism/commit/9eebf236ddf4766084351effde62ebbe2933b5b4)]
+
+### Miscellaneous
+
+-  Merge pull request [#17](https://github.com/Howard86/howardism/issues/17) from Howard86/feature/add-recipe-site [[972758b](https://github.com/Howard86/howardism/commit/972758b3ddf83a1f3fe0a9a1a67e5ca3fe7b062f)]
+- 📝 update CHANGELOG [[5e05fd9](https://github.com/Howard86/howardism/commit/5e05fd996b0449f66d99c97cba6ffaed5847ed4b)]
+
+
 <a name="1.0.7"></a>
 ## 1.0.7 (2021-04-19)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "howardism",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "private": true,
   "repository": "https://github.com/howard86/howardism",
   "workspaces": {


### PR DESCRIPTION
# Changelog

 <a name="1.0.8"></a>
 ## 1.0.8 (2021-04-20)

 ### Added

 - 👷‍♂️ add recipe build [[108c4a9](https://github.com/Howard86/howardism/commit/108c4a91af5e3382990d1225611a5eadedd99141)]

 ### Changed

 - 🔧 update pre-push hooks [[9eebf23](https://github.com/Howard86/howardism/commit/9eebf236ddf4766084351effde62ebbe2933b5b4)]

 ### Miscellaneous

 -  Merge pull request [#17](https://github.com/Howard86/howardism/issues/17) from Howard86/feature/add-recipe-site [[972758b](https://github.com/Howard86/howardism/commit/972758b3ddf83a1f3fe0a9a1a67e5ca3fe7b062f)]
 - 📝 update CHANGELOG [[5e05fd9](https://github.com/Howard86/howardism/commit/5e05fd996b0449f66d99c97cba6ffaed5847ed4b)]