### PR TITLE
fix: Next.js 16 async params + Prisma schema fixes (#509, #514, #510)

### DIFF
--- a/apps/blog/prisma/schema.prisma
+++ b/apps/blog/prisma/schema.prisma
@@ -192,7 +192,7 @@ model CommerceProduct {
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
   title     String
-  price     Float
+  price     Decimal @db.Decimal(10, 2)
   color     String
   size      String
   imageUrl  String
@@ -208,7 +208,7 @@ model CommerceOrder {
   email      String
   name       String
   status     String
-  totalPrice Float
+  totalPrice Decimal @db.Decimal(10, 2)
 
   transactions CommerceTransaction[]
   products     CommerceOrderOnProduct[]
@@ -232,7 +232,7 @@ model CommerceTransaction {
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
   channelId String?
-  amount    Float
+  amount    Decimal @db.Decimal(10, 2)
   currency  String
   status    String
   orderId   String

--- a/apps/blog/prisma/schema.prisma
+++ b/apps/blog/prisma/schema.prisma
@@ -54,6 +54,7 @@ model account {
 
   user user @relation(fields: [userId], references: [id], onDelete: Cascade)
 
+  @@unique([providerId, accountId])
   @@index([userId])
 }
 

--- a/apps/blog/src/app/(blog)/articles/[slug]/page.tsx
+++ b/apps/blog/src/app/(blog)/articles/[slug]/page.tsx
@@ -10,16 +10,17 @@ import {
 import { ArticleLayout } from "./ArticleLayout";
 
 interface ArticlePageProps {
-  params: {
+  params: Promise<{
     slug: string;
-  };
+  }>;
 }
 
 export const dynamic = "error";
 
 export async function generateMetadata({
-  params: { slug },
+  params,
 }: ArticlePageProps): Promise<Metadata> {
+  const { slug } = await params;
   const meta = await import(`./(docs)/${slug}/page.mdx`).then(
     (file) => file.meta
   );
@@ -44,9 +45,8 @@ const getSiblingSlug = (
   return articles.ids[selectedArticle.position + difference];
 };
 
-export default async function ArticlePage({
-  params: { slug },
-}: ArticlePageProps) {
+export default async function ArticlePage({ params }: ArticlePageProps) {
+  const { slug } = await params;
   const mod = (await import(`./(docs)/${slug}/page.mdx`)) as {
     meta: ArticleMeta;
     default: FC;
@@ -68,7 +68,5 @@ export default async function ArticlePage({
 export async function generateStaticParams() {
   const articles = await getArticles();
 
-  return articles.ids.map((slug) => ({
-    params: { slug },
-  }));
+  return articles.ids.map((slug) => ({ slug }));
 }

--- a/apps/blog/src/app/(blog)/profile/resume/[profileId]/clone/page.tsx
+++ b/apps/blog/src/app/(blog)/profile/resume/[profileId]/clone/page.tsx
@@ -3,8 +3,9 @@ import type { ResumeProfilePageProps } from "../page";
 import { getResumeById, mapResumeToResumeSchema } from "../utils";
 
 export default async function CloneResumePage({
-  params: { profileId },
+  params,
 }: ResumeProfilePageProps) {
+  const { profileId } = await params;
   const resume = await getResumeById(profileId);
 
   return <ResumeEditor resume={mapResumeToResumeSchema(resume)} />;

--- a/apps/blog/src/app/(blog)/profile/resume/[profileId]/edit/page.tsx
+++ b/apps/blog/src/app/(blog)/profile/resume/[profileId]/edit/page.tsx
@@ -3,8 +3,9 @@ import type { ResumeProfilePageProps } from "../page";
 import { getResumeById, mapResumeToResumeSchema } from "../utils";
 
 export default async function EditResumePage({
-  params: { profileId },
+  params,
 }: ResumeProfilePageProps) {
+  const { profileId } = await params;
   const resume = await getResumeById(profileId);
 
   return (

--- a/apps/blog/src/app/(blog)/profile/resume/[profileId]/page.tsx
+++ b/apps/blog/src/app/(blog)/profile/resume/[profileId]/page.tsx
@@ -4,14 +4,15 @@ import ResumeDocument from "../ResumeDocument";
 import { getResumeById, mapResumeToResumeSchema } from "./utils";
 
 export interface ResumeProfilePageProps {
-  params: {
+  params: Promise<{
     profileId: string;
-  };
+  }>;
 }
 
 export default async function ResumeProfilePage({
-  params: { profileId },
+  params,
 }: ResumeProfilePageProps) {
+  const { profileId } = await params;
   const rawResume = await getResumeById(profileId);
 
   return (

--- a/apps/blog/src/app/(blog)/tools/checkout/[orderId]/page.tsx
+++ b/apps/blog/src/app/(blog)/tools/checkout/[orderId]/page.tsx
@@ -58,7 +58,7 @@ export default async function OrderPage({ params }: OrderPageProps) {
   const shortenedOrderId = orderId.slice(0, 6);
 
   const subTotal = order.products.reduce(
-    (sum, cur) => sum + cur.product.price * cur.quantity,
+    (sum, cur) => sum + cur.product.price.toNumber() * cur.quantity,
     0
   );
 
@@ -105,7 +105,7 @@ export default async function OrderPage({ params }: OrderPageProps) {
                     <div className="flex pl-4 sm:pl-6">
                       <dt className="font-medium">Price</dt>
                       <dd className="ml-2">
-                        {numberFormat.format(product.price)}
+                        {numberFormat.format(product.price.toNumber())}
                       </dd>
                     </div>
                   </dl>
@@ -154,13 +154,13 @@ export default async function OrderPage({ params }: OrderPageProps) {
               <dt className="font-medium">Tax</dt>
               <dd className="text-muted-foreground">
                 {numberFormat.format(
-                  order.totalPrice - DEFAULT_SHIPPING_COST - subTotal
+                  order.totalPrice.toNumber() - DEFAULT_SHIPPING_COST - subTotal
                 )}
               </dd>
             </div>
             <div className="flex justify-between">
               <dt className="font-medium">Total</dt>
-              <dd>{numberFormat.format(order.totalPrice)}</dd>
+              <dd>{numberFormat.format(order.totalPrice.toNumber())}</dd>
             </div>
           </dl>
         </div>

--- a/apps/blog/src/app/(blog)/tools/checkout/[orderId]/page.tsx
+++ b/apps/blog/src/app/(blog)/tools/checkout/[orderId]/page.tsx
@@ -8,14 +8,13 @@ import { DEFAULT_SHIPPING_COST } from "../constants";
 import { numberFormat } from "../utils";
 
 export interface OrderPageProps {
-  params: {
+  params: Promise<{
     orderId: string;
-  };
+  }>;
 }
 
-export default async function OrderPage({
-  params: { orderId },
-}: OrderPageProps) {
+export default async function OrderPage({ params }: OrderPageProps) {
+  const { orderId } = await params;
   const order = await prisma.commerceOrder.findUnique({
     where: {
       id: orderId,


### PR DESCRIPTION
## Summary

- **#509**: Migrate 5 dynamic route pages to Next.js 16 async `params` — `await params` before destructuring, fix `generateStaticParams` to return flat objects
- **#514**: Add `@@unique([providerId, accountId])` constraint to `account` model to prevent duplicate OAuth links
- **#510**: Change `Float` to `Decimal @db.Decimal(10, 2)` for monetary fields (`price`, `totalPrice`, `amount`) to prevent floating-point precision errors

### Breaking changes

The Prisma schema changes (#514, #510) require a database migration before deployment:
```bash
cd apps/blog && bun run prisma:migrate
```

For #514, verify no duplicate rows exist first:
```sql
SELECT "providerId", "accountId", COUNT(*)
FROM account
GROUP BY "providerId", "accountId"
HAVING COUNT(*) > 1;
```

## Test plan

- [x] `bun run type-check` — all packages pass (after `prisma generate`)
- [x] `bun run lint` — all packages clean
- [ ] Run `prisma migrate` on staging database before production

Closes #509, Closes #514, Closes #510

🤖 Generated with [Claude Code](https://claude.ai/code)