### PR TITLE
fix(blog): restore LINE Pay checkout + harden payment flow end-to-end

### DIFF
--- a/apps/blog/bunfig.toml
+++ b/apps/blog/bunfig.toml
@@ -1,1 +1,2 @@
 [test]
+preload = ["@howardism/test-config/preload.ts", "./test-preload.ts"]

--- a/apps/blog/src/app/(blog)/profile/resume/ResumeEditor.tsx
+++ b/apps/blog/src/app/(blog)/profile/resume/ResumeEditor.tsx
@@ -56,6 +56,7 @@ export default function ResumeEditor({
     register,
     control,
     handleSubmit,
+    setError,
     formState: { errors },
   } = useForm<ResumeSchema>({
     mode: "onBlur",
@@ -63,28 +64,50 @@ export default function ResumeEditor({
     defaultValues: resume,
   });
 
-  // TODO: add error handling
   const handleCreate = handleSubmit(async (values) => {
-    const response = await fetch(
-      profileId ? `/api/resume?profileId=${profileId}` : "/api/resume",
-      {
-        method: profileId ? "PUT" : "POST",
-        body: JSON.stringify(values),
-        headers: {
-          "Content-Type": "application/json",
-        },
+    try {
+      const response = await fetch(
+        profileId ? `/api/resume?profileId=${profileId}` : "/api/resume",
+        {
+          method: profileId ? "PUT" : "POST",
+          body: JSON.stringify(values),
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
+
+      if (!response.ok) {
+        setError("root", {
+          message: "Something went wrong. Please try again.",
+        });
+        return;
       }
-    );
 
-    const result = (await response.json()) as SuccessApiResponse<string>;
+      const result = (await response.json()) as SuccessApiResponse<string> & {
+        message?: string;
+      };
 
-    if (result.success) {
-      router.push(`/profile/resume/${result.data}`);
+      if (result.success) {
+        router.push(`/profile/resume/${result.data}`);
+      } else {
+        setError("root", {
+          message: result.message ?? "Something went wrong. Please try again.",
+        });
+      }
+    } catch (err) {
+      setError("root", {
+        message:
+          err instanceof Error
+            ? err.message
+            : "Something went wrong. Please try again.",
+      });
     }
-  }, console.error);
+  });
 
   return (
     <Container className="mt-6 flex-1 sm:mt-12">
+      {errors.root?.message && <p role="alert">{errors.root.message}</p>}
       <ResumeForm
         control={control}
         errors={errors}

--- a/apps/blog/src/app/(blog)/profile/resume/__tests__/ResumeEditor.test.tsx
+++ b/apps/blog/src/app/(blog)/profile/resume/__tests__/ResumeEditor.test.tsx
@@ -1,0 +1,183 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import React from "react";
+
+// ---------------------------------------------------------------------------
+// Module mocks — registered before dynamic import
+// ---------------------------------------------------------------------------
+
+const mockPush = mock(() => undefined);
+
+mock.module("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+// Lightweight pass-through for Container to avoid @howardism/ui deps
+mock.module("@/app/(common)/Container", () => ({
+  Container: ({
+    children,
+    className,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => React.createElement("div", { className }, children),
+}));
+
+// ResumeDocument is heavy (complex layout); return null in tests
+mock.module("@/app/(blog)/profile/resume/ResumeDocument", () => ({
+  default: () => null,
+}));
+
+// Button stub: avoid pulling in @howardism/ui and Tailwind in the test env
+mock.module("@howardism/ui/components/button", () => ({
+  Button: (props: Record<string, unknown>) => {
+    const { children, ...rest } = props;
+    return React.createElement(
+      "button",
+      {
+        type: "button",
+        ...(rest as React.ButtonHTMLAttributes<HTMLButtonElement>),
+      },
+      children as React.ReactNode
+    );
+  },
+}));
+
+// ResumeForm stub: renders a plain form so onSubmit fires react-hook-form's
+// handleSubmit, which validates defaultValues then calls the inner async fn.
+mock.module("@/app/(blog)/profile/resume/ResumeForm", () => ({
+  default: ({
+    onSubmit,
+  }: {
+    onSubmit: React.FormEventHandler;
+    [k: string]: unknown;
+  }) =>
+    React.createElement(
+      "form",
+      { onSubmit, "data-testid": "resume-form" },
+      React.createElement(
+        "button",
+        { type: "submit", "data-testid": "submit-btn" },
+        "Submit"
+      )
+    ),
+  DEFAULT_RESUME_FORM: {
+    name: "",
+    address: "",
+    phone: "",
+    email: "",
+    github: "",
+    website: "",
+    company: "",
+    position: "",
+    summary: "",
+    experiences: [],
+    projects: [],
+    educations: [],
+    skills: [],
+    languages: [],
+  },
+}));
+
+// Dynamic import AFTER all mocks are registered
+const { default: ResumeEditor } = await import("../ResumeEditor");
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+// All required schema fields satisfied so zod validation passes on submit
+const validResume = {
+  name: "John Doe",
+  address: "123 Test St",
+  phone: "0912345678",
+  email: "john@example.com",
+  github: "johndoe",
+  website: "https://example.com",
+  company: "Test Corp",
+  position: "Engineer",
+  summary: "A concise professional summary.",
+  experiences: [],
+  projects: [],
+  educations: [],
+  skills: [],
+  languages: [],
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderAndSubmit(fetchImpl: () => Promise<Response>) {
+  global.fetch = fetchImpl as unknown as typeof fetch;
+  render(React.createElement(ResumeEditor, { resume: validResume }));
+  fireEvent.submit(screen.getByTestId("resume-form"));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ResumeEditor", () => {
+  afterEach(() => {
+    cleanup();
+    mockPush.mockClear();
+  });
+
+  beforeEach(() => {
+    // Restore real fetch before each test (individual tests override as needed)
+    global.fetch = fetch;
+  });
+
+  it("renders form-level alert and resets isSubmitting on fetch rejection", async () => {
+    await renderAndSubmit(() => Promise.reject(new Error("Network error")));
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeDefined();
+    });
+  });
+
+  it("renders generic error when response.ok is false (e.g., 500)", async () => {
+    await renderAndSubmit(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ success: false }), { status: 500 })
+      )
+    );
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeDefined();
+    });
+  });
+
+  it("renders message verbatim when API returns success:false with message", async () => {
+    await renderAndSubmit(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({ success: false, message: "Profile limit reached" }),
+          { status: 200 }
+        )
+      )
+    );
+    await waitFor(() => {
+      expect(screen.getByText("Profile limit reached")).toBeDefined();
+    });
+  });
+
+  it("calls router.push and does not render alert on success", async () => {
+    await renderAndSubmit(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ success: true, data: "profile-abc" }), {
+          status: 200,
+        })
+      )
+    );
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/profile/resume/profile-abc");
+    });
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+});

--- a/apps/blog/src/app/(blog)/profile/ubike/api/tdx-service.tsx
+++ b/apps/blog/src/app/(blog)/profile/ubike/api/tdx-service.tsx
@@ -51,11 +51,26 @@ export interface BikeAvailability {
   UpdateTime: string;
 }
 
+const FETCH_TIMEOUT_MS = 10_000;
+
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit
+): Promise<Response> {
+  const controller = new AbortController();
+  const timerId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timerId);
+  }
+}
+
 let accessToken: string | undefined;
 let expirationTimestamp: number | undefined;
 
 const refreshToken = async () => {
-  const response = await fetch(
+  const response = await fetchWithTimeout(
     `${env.TDX_API_ENDPOINT}/auth/realms/TDXConnect/protocol/openid-connect/token`,
     {
       method: "POST",
@@ -105,7 +120,7 @@ const tdxFetch = async <T, P extends ApiParam = ApiParam>(
     query.append(`$${key}`, params[key]);
   }
 
-  const response = await fetch(
+  const response = await fetchWithTimeout(
     `${env.TDX_API_ENDPOINT}${path}?${query.toString()}`,
     {
       headers: {

--- a/apps/blog/src/app/(blog)/tools/checkout/CheckoutForm.tsx
+++ b/apps/blog/src/app/(blog)/tools/checkout/CheckoutForm.tsx
@@ -43,7 +43,7 @@ export default function CheckoutForm({
   products,
   shippingCost,
 }: CheckoutFormProps) {
-  const { watch, register, formState, setValue, handleSubmit } =
+  const { watch, register, formState, setValue, handleSubmit, setError } =
     useForm<CheckoutSchema>({
       mode: "onBlur",
       resolver: zodResolver(checkoutSchema),
@@ -66,28 +66,48 @@ export default function CheckoutForm({
     return prev + product.price * cur.quantity;
   }, 0);
 
-  // TODO: redirect to correct page base on checkout result
   const handleCheckout = handleSubmit(async (data) => {
-    const response = await fetch("/api/checkout", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(data),
-    });
+    try {
+      const response = await fetch("/api/checkout", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(data),
+      });
 
-    const result = (await response.json()) as ApiResponse<string>;
+      if (!response.ok) {
+        setError("root", {
+          message: "Something went wrong. Please try again.",
+        });
+        return;
+      }
 
-    if (!result.success) {
-      throw new Error(result.message);
+      const result = (await response.json()) as ApiResponse<string> & {
+        message?: string;
+      };
+
+      if (!result.success) {
+        setError("root", {
+          message: result.message ?? "Something went wrong. Please try again.",
+        });
+        return;
+      }
+
+      if (result.data) {
+        window.location.assign(
+          validateRedirectUrl(result.data, window.location.origin)
+        );
+      }
+    } catch (err) {
+      setError("root", {
+        message:
+          err instanceof Error
+            ? err.message
+            : "Something went wrong. Please try again.",
+      });
     }
-    if (result.data) {
-      window.location.href = validateRedirectUrl(
-        result.data,
-        window.location.origin
-      );
-    }
-  }, console.error);
+  });
 
   return (
     <div className="rounded-xl border bg-background shadow-sm">
@@ -231,6 +251,11 @@ export default function CheckoutForm({
               </dl>
 
               <div className="border-t px-4 py-6 sm:px-6">
+                {formState.errors.root?.message && (
+                  <p className="mb-4 text-destructive text-sm" role="alert">
+                    {formState.errors.root.message}
+                  </p>
+                )}
                 <Button className="w-full" type="submit">
                   {formState.isSubmitting && (
                     <span className="loading loading-spinner" />

--- a/apps/blog/src/app/(blog)/tools/checkout/[orderId]/page.test.tsx
+++ b/apps/blog/src/app/(blog)/tools/checkout/[orderId]/page.test.tsx
@@ -82,7 +82,13 @@ mock.module("@/services/prisma", () => ({
 mock.module("next/image", () => ({ default: () => null }));
 
 mock.module("@/app/(common)/SimpleLayout", () => ({
-  SimpleLayout: ({ children }: { children: unknown }) => children,
+  SimpleLayout: ({
+    children,
+  }: {
+    children: unknown;
+    title: string;
+    intro: string;
+  }) => children,
 }));
 
 // Dynamic import after all mocks are registered.
@@ -148,5 +154,82 @@ describe("OrderPage", () => {
         where: { id: "order-abc", email: "owner@example.com" },
       })
     );
+  });
+
+  // ── Status-driven copy ────────────────────────────────────────────────────
+  // OrderPage is a React Server Component: it returns a React element tree,
+  // not rendered HTML. The SimpleLayout mock is not "called" as a function
+  // during this process — React component functions only run during rendering
+  // (reconciliation). We therefore inspect the returned element's props
+  // directly: { type: SimpleLayout, props: { title, intro, children } }.
+
+  it("COMPLETED status: shows thank-you title and shipped intro", async () => {
+    nextSession = fakeSession;
+    nextOrder = { ...fakeOrder, transactions: [{ status: "COMPLETED" }] };
+
+    const el = (await OrderPage({
+      params: Promise.resolve({ orderId: "order-1a2b3c" }),
+    })) as any;
+    expect(el.props.title).toBe("Thank you!");
+    expect(el.props.intro).toContain("shipped");
+  });
+
+  it("PENDING status: shows payment-pending title and pending intro", async () => {
+    nextSession = fakeSession;
+    nextOrder = { ...fakeOrder, transactions: [{ status: "PENDING" }] };
+
+    const el = (await OrderPage({
+      params: Promise.resolve({ orderId: "order-1a2b3c" }),
+    })) as any;
+    expect(el.props.title).toContain("Pending");
+    expect(el.props.intro).toContain("awaiting");
+  });
+
+  it("FAILED status: shows payment-failed title and retry intro", async () => {
+    nextSession = fakeSession;
+    nextOrder = { ...fakeOrder, transactions: [{ status: "FAILED" }] };
+
+    const el = (await OrderPage({
+      params: Promise.resolve({ orderId: "order-1a2b3c" }),
+    })) as any;
+    expect(el.props.title).toContain("Failed");
+    expect(el.props.intro).toContain("unable");
+  });
+
+  it("CANCELLED status: shows cancelled title and cancelled intro", async () => {
+    nextSession = fakeSession;
+    nextOrder = { ...fakeOrder, transactions: [{ status: "CANCELLED" }] };
+
+    const el = (await OrderPage({
+      params: Promise.resolve({ orderId: "order-1a2b3c" }),
+    })) as any;
+    expect(el.props.title).toContain("Cancelled");
+    expect(el.props.intro).toContain("cancelled");
+  });
+
+  it("empty transactions: falls back to NONE copy", async () => {
+    nextSession = fakeSession;
+    nextOrder = { ...fakeOrder, transactions: [] };
+
+    const el = (await OrderPage({
+      params: Promise.resolve({ orderId: "order-1a2b3c" }),
+    })) as any;
+    // Unknown/NONE status should produce a neutral fallback, not crash.
+    expect(el.props.title).toBeTruthy();
+    expect(el.props.intro).toBeTruthy();
+  });
+
+  it("unknown status: falls back to NONE copy without crashing", async () => {
+    nextSession = fakeSession;
+    nextOrder = {
+      ...fakeOrder,
+      transactions: [{ status: "SOME_FUTURE_STATUS" }],
+    };
+
+    const el = (await OrderPage({
+      params: Promise.resolve({ orderId: "order-1a2b3c" }),
+    })) as any;
+    expect(el.props.title).toBeTruthy();
+    expect(el.props.intro).toBeTruthy();
   });
 });

--- a/apps/blog/src/app/(blog)/tools/checkout/[orderId]/page.tsx
+++ b/apps/blog/src/app/(blog)/tools/checkout/[orderId]/page.tsx
@@ -1,5 +1,7 @@
+import type { Metadata } from "next";
 import Image from "next/image";
 import { notFound } from "next/navigation";
+import { cache } from "react";
 
 import { SimpleLayout } from "@/app/(common)/SimpleLayout";
 import { requireSessionForPage } from "@/lib/auth";
@@ -8,32 +10,55 @@ import prisma from "@/services/prisma";
 import { DEFAULT_SHIPPING_COST } from "../constants";
 import { numberFormat } from "../utils";
 
+const STATUS_COPY: Record<string, { title: string; intro: string }> = {
+  COMPLETED: {
+    title: "Thank you!",
+    intro: "Your order has shipped and will be with you soon.",
+  },
+  PENDING: {
+    title: "Payment Pending",
+    intro:
+      "Your order is awaiting payment confirmation. We'll notify you once it's processed.",
+  },
+  FAILED: {
+    title: "Payment Failed",
+    intro:
+      "We were unable to process your payment. Please try placing your order again.",
+  },
+  CANCELLED: {
+    title: "Order Cancelled",
+    intro:
+      "Your order has been cancelled. If you have questions, please contact support.",
+  },
+  NONE: {
+    title: "Order Received",
+    intro: "We've received your order and are processing it.",
+  },
+};
+
 export interface OrderPageProps {
   params: Promise<{
     orderId: string;
   }>;
 }
 
-export default async function OrderPage({ params }: OrderPageProps) {
-  const { orderId } = await params;
-  const session = await requireSessionForPage(`/tools/checkout/${orderId}`);
-  const order = await prisma.commerceOrder.findUnique({
-    where: {
-      id: orderId,
-      email: session.user.email,
-    },
+function resolveOrderStatus(transactions: { status: string }[]): string {
+  return transactions[0]?.status ?? "NONE";
+}
+
+// Memoized within a single server request via React.cache().
+// Both generateMetadata and OrderPage call this helper; the DB is hit once.
+const fetchOrder = cache(async (orderId: string, email: string) => {
+  return prisma.commerceOrder.findUnique({
+    where: { id: orderId, email },
     select: {
       email: true,
       name: true,
       totalPrice: true,
       transactions: {
         take: 1,
-        orderBy: {
-          createdAt: "desc",
-        },
-        select: {
-          status: true,
-        },
+        orderBy: { createdAt: "desc" },
+        select: { status: true },
       },
       products: {
         select: {
@@ -53,12 +78,39 @@ export default async function OrderPage({ params }: OrderPageProps) {
       },
     },
   });
+});
+
+export async function generateMetadata({
+  params,
+}: OrderPageProps): Promise<Metadata> {
+  const { orderId } = await params;
+  try {
+    const session = await requireSessionForPage(`/tools/checkout/${orderId}`);
+    const order = await fetchOrder(orderId, session.user.email);
+    if (!order) {
+      return { title: "Order Not Found" };
+    }
+    const status = resolveOrderStatus(order.transactions);
+    const { title } = STATUS_COPY[status] ?? STATUS_COPY.NONE;
+    return { title };
+  } catch {
+    // requireSessionForPage throws NEXT_REDIRECT when unauthenticated.
+    // Return generic metadata rather than propagating the redirect.
+    return { title: "Checkout" };
+  }
+}
+
+export default async function OrderPage({ params }: OrderPageProps) {
+  const { orderId } = await params;
+  const session = await requireSessionForPage(`/tools/checkout/${orderId}`);
+  const order = await fetchOrder(orderId, session.user.email);
 
   if (!order) {
     return notFound();
   }
 
-  const shortenedOrderId = orderId.slice(0, 6);
+  const status = resolveOrderStatus(order.transactions);
+  const { title, intro } = STATUS_COPY[status] ?? STATUS_COPY.NONE;
 
   const subTotal = order.products.reduce(
     (sum, cur) => sum + cur.product.price.toNumber() * cur.quantity,
@@ -66,10 +118,7 @@ export default async function OrderPage({ params }: OrderPageProps) {
   );
 
   return (
-    <SimpleLayout
-      intro={`Your order #${shortenedOrderId} has shipped and will be with you soon.`}
-      title="Thank you!"
-    >
+    <SimpleLayout intro={intro} title={title}>
       <section
         aria-labelledby="order-heading"
         className="mt-10 border-border border-t"

--- a/apps/blog/src/app/(blog)/tools/checkout/__tests__/CheckoutForm.test.tsx
+++ b/apps/blog/src/app/(blog)/tools/checkout/__tests__/CheckoutForm.test.tsx
@@ -1,0 +1,216 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import React from "react";
+
+// ---------------------------------------------------------------------------
+// Module mocks — registered before dynamic import
+// ---------------------------------------------------------------------------
+
+// zodResolver — always passes validation with fakeSubmitData so every test
+// drives the fetch/redirect path regardless of actual form field state.
+const fakeSubmitData = {
+  name: "John Doe",
+  email: "john@example.com",
+  items: [{ id: "clk496ee1000008jia9426s1z", quantity: 2 }],
+};
+
+mock.module("@hookform/resolvers/zod", () => ({
+  zodResolver: () => async () => ({ values: fakeSubmitData, errors: {} }),
+}));
+
+// Heavy UI / icon dependencies — stub so no Tailwind/UI bundle is needed.
+mock.module("@heroicons/react/24/outline", () => ({
+  TrashIcon: () => null,
+}));
+
+mock.module("@howardism/ui/components/button", () => ({
+  Button: (props: Record<string, unknown>) => {
+    const { children, onClick, disabled, type } = props;
+    return React.createElement(
+      "button",
+      {
+        type: (type as string) ?? "button",
+        onClick: onClick as React.MouseEventHandler,
+        disabled: disabled as boolean,
+      },
+      children as React.ReactNode
+    );
+  },
+}));
+
+mock.module("@/app/(common)/FormInput", () => ({
+  default: () => null,
+}));
+
+mock.module("@/app/(common)/FormSelect", () => ({
+  default: () => null,
+}));
+
+mock.module("@/app/(blog)/tools/checkout/ProductOption", () => ({
+  default: () => null,
+}));
+
+// validateRedirectUrl — controllable per-test via mockImplementationOnce.
+const mockValidateRedirectUrl = mock(
+  (_url: string, _origin: string): string =>
+    "https://sandbox-web-pay.line.me/pay/confirm?transactionId=99999"
+);
+
+mock.module("@/app/(blog)/tools/checkout/validateRedirectUrl", () => ({
+  validateRedirectUrl: mockValidateRedirectUrl,
+}));
+
+// Dynamic import AFTER all mocks are registered.
+const { default: CheckoutForm } = await import("../CheckoutForm");
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const fakeProducts = {
+  ids: ["clk496ee1000008jia9426s1z"],
+  entities: {
+    clk496ee1000008jia9426s1z: {
+      id: "clk496ee1000008jia9426s1z",
+      title: "Black T-Shirt M",
+      price: 1000,
+      color: "Black",
+      size: "M",
+      imageUrl: "/shirt.jpg",
+      imageAlt: "Black T-Shirt",
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderAndSubmit(fetchImpl: () => Promise<Response>) {
+  global.fetch = fetchImpl as unknown as typeof fetch;
+  render(
+    React.createElement(CheckoutForm, {
+      products: fakeProducts,
+      shippingCost: 60,
+    })
+  );
+  const form = document.querySelector("form");
+  if (!form) {
+    throw new Error("form element not found in rendered output");
+  }
+  fireEvent.submit(form);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("CheckoutForm", () => {
+  let mockAssign: ReturnType<typeof mock>;
+
+  beforeEach(() => {
+    global.fetch = fetch;
+    mockValidateRedirectUrl.mockClear();
+
+    // Replace window.location so we can spy on assign() without happy-dom
+    // actually navigating, and control window.location.origin.
+    mockAssign = mock(() => undefined);
+    Object.defineProperty(globalThis, "location", {
+      writable: true,
+      configurable: true,
+      value: {
+        href: "",
+        origin: "http://localhost",
+        assign: mockAssign,
+      },
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders form-level alert on fetch rejection", async () => {
+    renderAndSubmit(() => Promise.reject(new Error("Network failure")));
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeDefined();
+    });
+  });
+
+  it("renders generic error when response.ok is false (e.g. 502)", async () => {
+    renderAndSubmit(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ success: false }), { status: 502 })
+      )
+    );
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeDefined();
+    });
+  });
+
+  it("renders message verbatim when API returns success:false with message", async () => {
+    renderAndSubmit(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            success: false,
+            message: "Payment gateway unavailable",
+          }),
+          { status: 200 }
+        )
+      )
+    );
+    await waitFor(() => {
+      expect(screen.getByText("Payment gateway unavailable")).toBeDefined();
+    });
+  });
+
+  it("renders error and does not navigate when validateRedirectUrl throws", async () => {
+    mockValidateRedirectUrl.mockImplementationOnce(() => {
+      throw new Error("Redirect to external URL is not allowed");
+    });
+
+    renderAndSubmit(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({ success: true, data: "javascript:alert(1)" }),
+          { status: 200 }
+        )
+      )
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Redirect to external URL is not allowed")
+      ).toBeDefined();
+    });
+    expect(mockAssign).not.toHaveBeenCalled();
+  });
+
+  it("calls window.location.assign with the LINE Pay URL on success", async () => {
+    renderAndSubmit(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            success: true,
+            data: "https://sandbox-web-pay.line.me/pay/confirm?transactionId=99999",
+          }),
+          { status: 200 }
+        )
+      )
+    );
+
+    await waitFor(() => {
+      expect(mockAssign).toHaveBeenCalledWith(
+        "https://sandbox-web-pay.line.me/pay/confirm?transactionId=99999"
+      );
+    });
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+});

--- a/apps/blog/src/app/(blog)/tools/checkout/constants.tsx
+++ b/apps/blog/src/app/(blog)/tools/checkout/constants.tsx
@@ -1,1 +1,2 @@
 export const DEFAULT_SHIPPING_COST = 120;
+export const DEFAULT_TAX_RATE = 0.08;

--- a/apps/blog/src/app/(blog)/tools/checkout/trustedLinePayHosts.ts
+++ b/apps/blog/src/app/(blog)/tools/checkout/trustedLinePayHosts.ts
@@ -1,0 +1,4 @@
+export const TRUSTED_LINE_PAY_HOSTS = [
+  "web-pay.line.me",
+  "sandbox-web-pay.line.me",
+] as const satisfies readonly string[];

--- a/apps/blog/src/app/(blog)/tools/checkout/validateRedirectUrl.test.ts
+++ b/apps/blog/src/app/(blog)/tools/checkout/validateRedirectUrl.test.ts
@@ -4,6 +4,7 @@ import { validateRedirectUrl } from "./validateRedirectUrl";
 const ORIGIN = "https://example.com";
 
 describe("validateRedirectUrl", () => {
+  // Same-origin: always allowed
   it("allows relative paths", () => {
     expect(validateRedirectUrl("/success", ORIGIN)).toBe(
       "https://example.com/success"
@@ -16,7 +17,47 @@ describe("validateRedirectUrl", () => {
     );
   });
 
-  it("throws for external URLs", () => {
+  it("allows same-origin URL with path and query string", () => {
+    const url = validateRedirectUrl(
+      "https://example.com/checkout/success?ref=123",
+      ORIGIN
+    );
+    expect(url).toBe("https://example.com/checkout/success?ref=123");
+  });
+
+  // LINE Pay trusted hosts: https only
+  it("allows prod LINE Pay host (https)", () => {
+    const url = validateRedirectUrl(
+      "https://web-pay.line.me/pay/confirm?transactionId=123",
+      ORIGIN
+    );
+    expect(url).toBe("https://web-pay.line.me/pay/confirm?transactionId=123");
+  });
+
+  it("allows sandbox LINE Pay host (https)", () => {
+    const url = validateRedirectUrl(
+      "https://sandbox-web-pay.line.me/pay/confirm?transactionId=456",
+      ORIGIN
+    );
+    expect(url).toBe(
+      "https://sandbox-web-pay.line.me/pay/confirm?transactionId=456"
+    );
+  });
+
+  it("throws for LINE Pay host over http (must be https)", () => {
+    expect(() =>
+      validateRedirectUrl("http://web-pay.line.me/pay/confirm", ORIGIN)
+    ).toThrow("Redirect to external URL is not allowed");
+  });
+
+  it("throws for LINE Pay sandbox host over http (must be https)", () => {
+    expect(() =>
+      validateRedirectUrl("http://sandbox-web-pay.line.me/pay/confirm", ORIGIN)
+    ).toThrow("Redirect to external URL is not allowed");
+  });
+
+  // Untrusted external hosts: always rejected
+  it("throws for untrusted external URLs", () => {
     expect(() => validateRedirectUrl("https://evil.com/", ORIGIN)).toThrow(
       "Redirect to external URL is not allowed"
     );
@@ -28,6 +69,7 @@ describe("validateRedirectUrl", () => {
     );
   });
 
+  // Pseudo-protocols: always rejected
   it("throws for javascript: URLs", () => {
     expect(() => validateRedirectUrl("javascript:alert(1)", ORIGIN)).toThrow(
       "Redirect to external URL is not allowed"
@@ -40,11 +82,15 @@ describe("validateRedirectUrl", () => {
     ).toThrow("Redirect to external URL is not allowed");
   });
 
-  it("allows same-origin URL with path and query string", () => {
-    const url = validateRedirectUrl(
-      "https://example.com/checkout/success?ref=123",
-      ORIGIN
+  it("throws for file: URLs", () => {
+    expect(() => validateRedirectUrl("file:///etc/passwd", ORIGIN)).toThrow(
+      "Redirect to external URL is not allowed"
     );
-    expect(url).toBe("https://example.com/checkout/success?ref=123");
+  });
+
+  it("throws for vbscript: URLs", () => {
+    expect(() => validateRedirectUrl("vbscript:msgbox(1)", ORIGIN)).toThrow(
+      "Redirect to external URL is not allowed"
+    );
   });
 });

--- a/apps/blog/src/app/(blog)/tools/checkout/validateRedirectUrl.ts
+++ b/apps/blog/src/app/(blog)/tools/checkout/validateRedirectUrl.ts
@@ -1,7 +1,41 @@
+import { TRUSTED_LINE_PAY_HOSTS } from "./trustedLinePayHosts";
+
+const PSEUDO_PROTOCOLS = new Set([
+  "javascript:",
+  "data:",
+  "file:",
+  "vbscript:",
+]);
+
 export const validateRedirectUrl = (data: string, origin: string): string => {
+  // Reject pseudo-protocols before URL parsing — `new URL("javascript:alert(1)", origin)`
+  // resolves with protocol "javascript:" but some environments may vary.
+  const lower = data.trimStart().toLowerCase();
+  for (const proto of PSEUDO_PROTOCOLS) {
+    if (lower.startsWith(proto)) {
+      throw new Error("Redirect to external URL is not allowed");
+    }
+  }
+
   const redirectUrl = new URL(data, origin);
-  if (redirectUrl.origin !== origin) {
+
+  // Double-check after parsing: reject any pseudo-protocol that slipped through.
+  if (PSEUDO_PROTOCOLS.has(redirectUrl.protocol)) {
     throw new Error("Redirect to external URL is not allowed");
   }
-  return redirectUrl.href;
+
+  // Allow same-origin.
+  if (redirectUrl.origin === origin) {
+    return redirectUrl.href;
+  }
+
+  // Allow trusted LINE Pay hosts over https only.
+  if (
+    redirectUrl.protocol === "https:" &&
+    (TRUSTED_LINE_PAY_HOSTS as readonly string[]).includes(redirectUrl.hostname)
+  ) {
+    return redirectUrl.href;
+  }
+
+  throw new Error("Redirect to external URL is not allowed");
 };

--- a/apps/blog/src/app/api/checkout/__tests__/route.test.ts
+++ b/apps/blog/src/app/api/checkout/__tests__/route.test.ts
@@ -90,10 +90,12 @@ const mockFindMany = mock(() => Promise.resolve(fakeProducts));
 const mockPrismaTransaction = mock(
   (callback: (tx: typeof fakeTx) => Promise<unknown>) => callback(fakeTx)
 );
+const mockTransactionUpdate = mock(() => Promise.resolve({ id: "tx-1" }));
 
 mock.module("@/services/prisma", () => ({
   default: {
     commerceProduct: { findMany: mockFindMany },
+    commerceTransaction: { update: mockTransactionUpdate },
     $transaction: mockPrismaTransaction,
   },
 }));
@@ -153,6 +155,7 @@ describe("POST /api/checkout", () => {
     mockPrismaTransaction.mockClear();
     mockOrderCreate.mockClear();
     mockTransactionCreate.mockClear();
+    mockTransactionUpdate.mockClear();
     mockRequestApi.mockClear();
 
     mockRequireSessionForRoute.mockImplementation(
@@ -165,6 +168,9 @@ describe("POST /api/checkout", () => {
     );
     mockOrderCreate.mockImplementation(() => Promise.resolve(fakeOrder));
     mockTransactionCreate.mockImplementation(() =>
+      Promise.resolve({ id: "tx-1" })
+    );
+    mockTransactionUpdate.mockImplementation(() =>
       Promise.resolve({ id: "tx-1" })
     );
     mockRequestApi.mockImplementation(() =>
@@ -251,5 +257,56 @@ describe("POST /api/checkout", () => {
     expect(txCall.data.orderId).toBe(fakeOrder.id);
     expect(txCall.data.status).toBe("PENDING");
     expect(txCall.data.currency).toBe("TWD");
+  });
+
+  // ── T3b: LINE Pay failure branching ─────────────────────────────────────
+
+  it("returns 502 and marks transaction FAILED when LINE Pay returns non-0000 returnCode", async () => {
+    mockRequestApi.mockImplementationOnce(() =>
+      Promise.resolve({
+        returnCode: "9000",
+        returnMessage: "Internal error",
+        info: {} as never,
+      })
+    );
+
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(typeof body.message).toBe("string");
+
+    // Transaction must be updated to FAILED
+    expect(mockTransactionUpdate).toHaveBeenCalledTimes(1);
+    const updateCall = (
+      mockTransactionUpdate.mock.calls[0] as unknown as [
+        { where: { id: string }; data: { status: string } },
+      ]
+    )[0];
+    expect(updateCall.where.id).toBe("tx-1");
+    expect(updateCall.data.status).toBe("FAILED");
+  });
+
+  it("returns 502 and marks transaction FAILED when LINE Pay fetch throws", async () => {
+    const abortError = Object.assign(new Error("The operation was aborted"), {
+      name: "AbortError",
+    });
+    mockRequestApi.mockImplementationOnce(() => Promise.reject(abortError));
+
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.message).toContain("aborted");
+
+    // Transaction must be updated to FAILED even on fetch throw
+    expect(mockTransactionUpdate).toHaveBeenCalledTimes(1);
+    const updateCall = (
+      mockTransactionUpdate.mock.calls[0] as unknown as [
+        { where: { id: string }; data: { status: string } },
+      ]
+    )[0];
+    expect(updateCall.where.id).toBe("tx-1");
+    expect(updateCall.data.status).toBe("FAILED");
   });
 });

--- a/apps/blog/src/app/api/checkout/__tests__/route.test.ts
+++ b/apps/blog/src/app/api/checkout/__tests__/route.test.ts
@@ -1,0 +1,255 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import type { NextRequest } from "next/server";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const fakeSession = {
+  user: {
+    id: "user-1",
+    email: "owner@example.com",
+    name: "Owner User",
+    emailVerified: true,
+    createdAt: new Date("2024-01-01"),
+    updatedAt: new Date("2024-01-01"),
+  },
+  session: {
+    id: "sess-1",
+    userId: "user-1",
+    token: "tok-abc",
+    expiresAt: new Date("2099-01-01"),
+    createdAt: new Date("2024-01-01"),
+    updatedAt: new Date("2024-01-01"),
+  },
+};
+
+const fakeProducts = [
+  {
+    id: "prod-1",
+    title: "Black T-Shirt M",
+    price: { toNumber: () => 1000 },
+  },
+  {
+    id: "prod-2",
+    title: "White T-Shirt L",
+    price: { toNumber: () => 800 },
+  },
+];
+
+const fakeOrder = {
+  id: "order-abc",
+  email: "owner@example.com",
+  name: "Owner User",
+  status: "PENDING",
+  totalPrice: { toNumber: () => 1296 },
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const fakeLinePaySuccess = {
+  returnCode: "0000",
+  returnMessage: "Success",
+  info: {
+    transactionId: 99_999,
+    paymentAccessToken: "token-xyz",
+    paymentUrl: {
+      app: "linepay://pay",
+      web: "https://sandbox-web-pay.line.me/pay/confirm?transactionId=99999",
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+type SessionResult =
+  | { ok: true; session: typeof fakeSession }
+  | { ok: false; response: Response };
+
+const mockRequireSessionForRoute = mock(
+  (): Promise<SessionResult> =>
+    Promise.resolve({ ok: true as const, session: fakeSession })
+);
+
+mock.module("@/lib/auth", () => ({
+  requireSessionForRoute: mockRequireSessionForRoute,
+}));
+
+// Sub-mocks for the interactive $transaction callback
+const mockOrderCreate = mock(() => Promise.resolve(fakeOrder));
+const mockTransactionCreate = mock(() => Promise.resolve({ id: "tx-1" }));
+
+const fakeTx = {
+  commerceOrder: { create: mockOrderCreate },
+  commerceTransaction: { create: mockTransactionCreate },
+};
+
+const mockFindMany = mock(() => Promise.resolve(fakeProducts));
+const mockPrismaTransaction = mock(
+  (callback: (tx: typeof fakeTx) => Promise<unknown>) => callback(fakeTx)
+);
+
+mock.module("@/services/prisma", () => ({
+  default: {
+    commerceProduct: { findMany: mockFindMany },
+    $transaction: mockPrismaTransaction,
+  },
+}));
+
+const mockRequestApi = mock(() => Promise.resolve(fakeLinePaySuccess));
+
+mock.module("@/services/line-pay", () => ({
+  requestApi: mockRequestApi,
+  RequestApiReturnCode: { Success: "0000" },
+}));
+
+mock.module("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), {
+        ...init,
+        headers: {
+          "content-type": "application/json",
+          ...(init?.headers ?? {}),
+        },
+      }),
+  },
+}));
+
+// Dynamic import AFTER mocks
+const { POST } = await import("../route");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const validBody = {
+  name: "Owner User",
+  email: "owner@example.com",
+  items: [
+    { id: "prod-1", quantity: 1 },
+    { id: "prod-2", quantity: 1 },
+  ],
+};
+
+function makeRequest(body: unknown): NextRequest {
+  return new Request("http://localhost:3000/api/checkout", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }) as unknown as NextRequest;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("POST /api/checkout", () => {
+  beforeEach(() => {
+    mockRequireSessionForRoute.mockClear();
+    mockFindMany.mockClear();
+    mockPrismaTransaction.mockClear();
+    mockOrderCreate.mockClear();
+    mockTransactionCreate.mockClear();
+    mockRequestApi.mockClear();
+
+    mockRequireSessionForRoute.mockImplementation(
+      (): Promise<SessionResult> =>
+        Promise.resolve({ ok: true as const, session: fakeSession })
+    );
+    mockFindMany.mockImplementation(() => Promise.resolve(fakeProducts));
+    mockPrismaTransaction.mockImplementation(
+      (callback: (tx: typeof fakeTx) => Promise<unknown>) => callback(fakeTx)
+    );
+    mockOrderCreate.mockImplementation(() => Promise.resolve(fakeOrder));
+    mockTransactionCreate.mockImplementation(() =>
+      Promise.resolve({ id: "tx-1" })
+    );
+    mockRequestApi.mockImplementation(() =>
+      Promise.resolve(fakeLinePaySuccess)
+    );
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockRequireSessionForRoute.mockImplementationOnce(
+      (): Promise<SessionResult> =>
+        Promise.resolve({
+          ok: false as const,
+          response: new Response('{"message":"Unauthorized"}', {
+            status: 401,
+            headers: { "content-type": "application/json" },
+          }),
+        })
+    );
+
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for invalid body (empty items)", async () => {
+    const res = await POST(
+      makeRequest({ name: "User", email: "a@b.com", items: [] })
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+  });
+
+  it("returns 400 for invalid body (missing required fields)", async () => {
+    const res = await POST(makeRequest({ name: "Only Name" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+  });
+
+  it("returns 200 with LINE Pay web URL on happy path", async () => {
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data).toContain("sandbox-web-pay.line.me");
+  });
+
+  it("creates CommerceOrder + PENDING CommerceTransaction via $transaction BEFORE calling requestApi", async () => {
+    const callOrder: string[] = [];
+
+    mockPrismaTransaction.mockImplementationOnce(
+      (callback: (tx: typeof fakeTx) => Promise<unknown>) => {
+        callOrder.push("$transaction");
+        return callback(fakeTx);
+      }
+    );
+    mockRequestApi.mockImplementationOnce(() => {
+      callOrder.push("requestApi");
+      return Promise.resolve(fakeLinePaySuccess);
+    });
+
+    await POST(makeRequest(validBody));
+
+    // Persistence must happen before the LINE Pay network call
+    expect(callOrder).toEqual(["$transaction", "requestApi"]);
+
+    // Order created with correct ownership email from session
+    expect(mockOrderCreate).toHaveBeenCalledTimes(1);
+    const orderCall = (
+      mockOrderCreate.mock.calls[0] as unknown as [
+        { data: { email: string; status: string } },
+      ]
+    )[0];
+    expect(orderCall.data.email).toBe("owner@example.com");
+    expect(orderCall.data.status).toBe("PENDING");
+
+    // Transaction created with PENDING status linked to the order
+    expect(mockTransactionCreate).toHaveBeenCalledTimes(1);
+    const txCall = (
+      mockTransactionCreate.mock.calls[0] as unknown as [
+        { data: { orderId: string; status: string; currency: string } },
+      ]
+    )[0];
+    expect(txCall.data.orderId).toBe(fakeOrder.id);
+    expect(txCall.data.status).toBe("PENDING");
+    expect(txCall.data.currency).toBe("TWD");
+  });
+});

--- a/apps/blog/src/app/api/checkout/route.ts
+++ b/apps/blog/src/app/api/checkout/route.ts
@@ -1,0 +1,133 @@
+import { type NextRequest, NextResponse } from "next/server";
+import {
+  DEFAULT_SHIPPING_COST,
+  DEFAULT_TAX_RATE,
+} from "@/app/(blog)/tools/checkout/constants";
+import { checkoutSchema } from "@/app/(blog)/tools/checkout/schema";
+import { requireSessionForRoute } from "@/lib/auth";
+import { RequestApiReturnCode, requestApi } from "@/services/line-pay";
+import prisma from "@/services/prisma";
+
+export const runtime = "nodejs";
+
+// ---------------------------------------------------------------------------
+// POST /api/checkout — create order + PENDING transaction, then initiate LINE Pay
+// ---------------------------------------------------------------------------
+
+export async function POST(request: NextRequest) {
+  try {
+    const authResult = await requireSessionForRoute();
+    if (!authResult.ok) {
+      return authResult.response;
+    }
+
+    const rawBody = await request.json();
+    const parsed = checkoutSchema.safeParse(rawBody);
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: parsed.error.issues[0]?.message ?? "Invalid request body",
+        },
+        { status: 400 }
+      );
+    }
+
+    const { name, items } = parsed.data;
+    const sessionEmail = authResult.session.user.email;
+
+    // Fetch server-side prices — never trust client-submitted amounts.
+    const productIds = items.map((i) => i.id);
+    const products = await prisma.commerceProduct.findMany({
+      where: { id: { in: productIds } },
+      select: { id: true, title: true, price: true },
+    });
+
+    if (products.length !== items.length) {
+      return NextResponse.json(
+        { success: false, message: "One or more products not found" },
+        { status: 400 }
+      );
+    }
+
+    const priceMap = new Map(products.map((p) => [p.id, p.price.toNumber()]));
+
+    const subTotal = items.reduce(
+      (sum, item) => sum + (priceMap.get(item.id) ?? 0) * item.quantity,
+      0
+    );
+    const totalPrice =
+      subTotal + DEFAULT_SHIPPING_COST + subTotal * DEFAULT_TAX_RATE;
+
+    // Atomically persist order + PENDING transaction BEFORE any network call.
+    // This ensures the order record exists even if LINE Pay is unreachable.
+    const order = await prisma.$transaction(async (tx) => {
+      const created = await tx.commerceOrder.create({
+        data: {
+          email: sessionEmail,
+          name,
+          status: "PENDING",
+          totalPrice,
+          products: {
+            create: items.map((item) => ({
+              productId: item.id,
+              quantity: item.quantity,
+            })),
+          },
+        },
+      });
+
+      await tx.commerceTransaction.create({
+        data: {
+          orderId: created.id,
+          amount: totalPrice,
+          currency: "TWD",
+          status: "PENDING",
+        },
+      });
+
+      return created;
+    });
+
+    // Derive absolute redirect URLs from the inbound request origin.
+    const origin = new URL(request.url).origin;
+
+    const linePayResponse = await requestApi({
+      amount: Math.round(totalPrice),
+      currency: "TWD",
+      orderId: order.id,
+      packages: [
+        {
+          id: order.id,
+          amount: Math.round(totalPrice),
+          products: items.map((item) => ({
+            name: products.find((p) => p.id === item.id)?.title ?? item.id,
+            quantity: item.quantity,
+            price: Math.round(priceMap.get(item.id) ?? 0),
+          })),
+        },
+      ],
+      redirectUrls: {
+        confirmUrl: `${origin}/api/checkout/confirm?orderId=${order.id}`,
+        cancelUrl: `${origin}/tools/checkout`,
+      },
+    });
+
+    if (linePayResponse.returnCode === RequestApiReturnCode.Success) {
+      return NextResponse.json({
+        success: true,
+        data: linePayResponse.info.paymentUrl.web,
+      });
+    }
+
+    // Non-success LINE Pay return codes: T3b will refine this into 502 +
+    // mark the transaction FAILED. For T3a, surface as a 500.
+    throw new Error(
+      `LINE Pay error ${linePayResponse.returnCode}: ${linePayResponse.returnMessage}`
+    );
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Internal server error";
+    return NextResponse.json({ success: false, message }, { status: 500 });
+  }
+}

--- a/apps/blog/src/app/api/checkout/route.ts
+++ b/apps/blog/src/app/api/checkout/route.ts
@@ -60,8 +60,8 @@ export async function POST(request: NextRequest) {
       subTotal + DEFAULT_SHIPPING_COST + subTotal * DEFAULT_TAX_RATE;
 
     // Atomically persist order + PENDING transaction BEFORE any network call.
-    // This ensures the order record exists even if LINE Pay is unreachable.
-    const order = await prisma.$transaction(async (tx) => {
+    // Returns transactionId so we can mark it FAILED if LINE Pay rejects.
+    const { order, transactionId } = await prisma.$transaction(async (tx) => {
       const created = await tx.commerceOrder.create({
         data: {
           email: sessionEmail,
@@ -77,7 +77,7 @@ export async function POST(request: NextRequest) {
         },
       });
 
-      await tx.commerceTransaction.create({
+      const transaction = await tx.commerceTransaction.create({
         data: {
           orderId: created.id,
           amount: totalPrice,
@@ -86,45 +86,66 @@ export async function POST(request: NextRequest) {
         },
       });
 
-      return created;
+      return { order: created, transactionId: transaction.id };
     });
 
     // Derive absolute redirect URLs from the inbound request origin.
     const origin = new URL(request.url).origin;
 
-    const linePayResponse = await requestApi({
-      amount: Math.round(totalPrice),
-      currency: "TWD",
-      orderId: order.id,
-      packages: [
-        {
-          id: order.id,
-          amount: Math.round(totalPrice),
-          products: items.map((item) => ({
-            name: products.find((p) => p.id === item.id)?.title ?? item.id,
-            quantity: item.quantity,
-            price: Math.round(priceMap.get(item.id) ?? 0),
-          })),
+    // Wrap LINE Pay call so both returnCode failures and fetch throws
+    // (AbortError, HTTP 4xx/5xx via T2 hardening) produce 502 + FAILED update.
+    try {
+      const linePayResponse = await requestApi({
+        amount: Math.round(totalPrice),
+        currency: "TWD",
+        orderId: order.id,
+        packages: [
+          {
+            id: order.id,
+            amount: Math.round(totalPrice),
+            products: items.map((item) => ({
+              name: products.find((p) => p.id === item.id)?.title ?? item.id,
+              quantity: item.quantity,
+              price: Math.round(priceMap.get(item.id) ?? 0),
+            })),
+          },
+        ],
+        redirectUrls: {
+          confirmUrl: `${origin}/api/checkout/confirm?orderId=${order.id}`,
+          cancelUrl: `${origin}/tools/checkout`,
         },
-      ],
-      redirectUrls: {
-        confirmUrl: `${origin}/api/checkout/confirm?orderId=${order.id}`,
-        cancelUrl: `${origin}/tools/checkout`,
-      },
-    });
-
-    if (linePayResponse.returnCode === RequestApiReturnCode.Success) {
-      return NextResponse.json({
-        success: true,
-        data: linePayResponse.info.paymentUrl.web,
       });
-    }
 
-    // Non-success LINE Pay return codes: T3b will refine this into 502 +
-    // mark the transaction FAILED. For T3a, surface as a 500.
-    throw new Error(
-      `LINE Pay error ${linePayResponse.returnCode}: ${linePayResponse.returnMessage}`
-    );
+      if (linePayResponse.returnCode === RequestApiReturnCode.Success) {
+        return NextResponse.json({
+          success: true,
+          data: linePayResponse.info.paymentUrl.web,
+        });
+      }
+
+      // Non-success returnCode from LINE Pay
+      const message = `LINE Pay error ${linePayResponse.returnCode}: ${linePayResponse.returnMessage}`;
+      console.error(
+        `LINE Pay failed: ${linePayResponse.returnCode} ${linePayResponse.returnMessage}`
+      );
+      await prisma.commerceTransaction.update({
+        where: { id: transactionId },
+        data: { status: "FAILED" },
+      });
+      return NextResponse.json({ success: false, message }, { status: 502 });
+    } catch (linePayError) {
+      // fetch throw — AbortError (timeout), HTTP error from T2 hardening, etc.
+      const message =
+        linePayError instanceof Error
+          ? linePayError.message
+          : "LINE Pay request failed";
+      console.error(`LINE Pay failed: ${message}`);
+      await prisma.commerceTransaction.update({
+        where: { id: transactionId },
+        data: { status: "FAILED" },
+      });
+      return NextResponse.json({ success: false, message }, { status: 502 });
+    }
   } catch (error) {
     const message =
       error instanceof Error ? error.message : "Internal server error";

--- a/apps/blog/src/app/api/resume/__tests__/route.test.ts
+++ b/apps/blog/src/app/api/resume/__tests__/route.test.ts
@@ -1,0 +1,284 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import type { NextRequest } from "next/server";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const fakeSession = {
+  user: {
+    id: "user-1",
+    email: "owner@example.com",
+    name: "Owner User",
+    emailVerified: true,
+    createdAt: new Date("2024-01-01"),
+    updatedAt: new Date("2024-01-01"),
+  },
+  session: {
+    id: "sess-1",
+    userId: "user-1",
+    token: "tok-abc",
+    expiresAt: new Date("2099-01-01"),
+    createdAt: new Date("2024-01-01"),
+    updatedAt: new Date("2024-01-01"),
+  },
+};
+
+const fakeApplicant = {
+  id: "applicant-1",
+  email: "owner@example.com",
+  name: "Owner User",
+  address: "123 Test St",
+  phone: "0912345678",
+  github: "owneruser",
+  website: "https://owner.com",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const fakeProfile = {
+  id: "profile-1",
+  applicantId: "applicant-1",
+  company: "Test Corp",
+  position: "Engineer",
+  summary: "Test summary",
+  ordering: 0,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const fakeProfileWithApplicant = {
+  ...fakeProfile,
+  applicant: fakeApplicant,
+};
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+type SessionResult =
+  | { ok: true; session: typeof fakeSession }
+  | { ok: false; response: Response };
+
+const mockRequireSessionForRoute = mock(
+  (): Promise<SessionResult> =>
+    Promise.resolve({ ok: true as const, session: fakeSession })
+);
+
+mock.module("@/lib/auth", () => ({
+  requireSessionForRoute: mockRequireSessionForRoute,
+}));
+
+const mockUpsert = mock(() => Promise.resolve(fakeApplicant));
+const mockCreate = mock(() => Promise.resolve(fakeProfile));
+const mockFindUnique = mock<
+  () => Promise<typeof fakeProfileWithApplicant | null>
+>(() => Promise.resolve(fakeProfileWithApplicant));
+const mockUpdate = mock(() => Promise.resolve(fakeProfile));
+
+mock.module("@/services/prisma", () => ({
+  default: {
+    resumeApplicant: { upsert: mockUpsert },
+    resumeProfile: {
+      create: mockCreate,
+      findUnique: mockFindUnique,
+      update: mockUpdate,
+    },
+  },
+}));
+
+mock.module("next/server", () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), {
+        ...init,
+        headers: {
+          "content-type": "application/json",
+          ...(init?.headers ?? {}),
+        },
+      }),
+  },
+}));
+
+// Dynamic import AFTER mocks
+const { POST, PUT } = await import("../route");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const validBody = {
+  name: "Owner User",
+  address: "123 Test St",
+  phone: "0912345678",
+  email: "owner@example.com",
+  github: "owneruser",
+  website: "https://owner.com",
+  company: "Test Corp",
+  position: "Engineer",
+  summary: "Test summary",
+  experiences: [],
+  projects: [],
+  educations: [],
+  skills: [],
+  languages: [],
+};
+
+function makePostRequest(body: unknown): NextRequest {
+  return new Request("http://localhost:3000/api/resume", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }) as unknown as NextRequest;
+}
+
+function makePutRequest(body: unknown, profileId = "profile-1"): NextRequest {
+  return new Request(
+    `http://localhost:3000/api/resume?profileId=${profileId}`,
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  ) as unknown as NextRequest;
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/resume
+// ---------------------------------------------------------------------------
+
+describe("POST /api/resume", () => {
+  beforeEach(() => {
+    mockRequireSessionForRoute.mockClear();
+    mockUpsert.mockClear();
+    mockCreate.mockClear();
+    mockRequireSessionForRoute.mockImplementation(
+      (): Promise<SessionResult> =>
+        Promise.resolve({ ok: true as const, session: fakeSession })
+    );
+    mockUpsert.mockImplementation(() => Promise.resolve(fakeApplicant));
+    mockCreate.mockImplementation(() => Promise.resolve(fakeProfile));
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockRequireSessionForRoute.mockImplementationOnce(
+      (): Promise<SessionResult> =>
+        Promise.resolve({
+          ok: false as const,
+          response: new Response('{"message":"Unauthorized"}', {
+            status: 401,
+            headers: { "content-type": "application/json" },
+          }),
+        })
+    );
+
+    const res = await POST(makePostRequest(validBody));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for invalid body (missing required fields)", async () => {
+    const res = await POST(makePostRequest({ name: "Only Name" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(typeof body.message).toBe("string");
+  });
+
+  it("returns 400 for invalid email format", async () => {
+    const res = await POST(
+      makePostRequest({ ...validBody, email: "not-an-email" })
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+  });
+
+  it("returns 200 with profileId on valid POST", async () => {
+    const res = await POST(makePostRequest(validBody));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data).toBe("profile-1");
+  });
+
+  it("upserts applicant by session email and creates profile", async () => {
+    await POST(makePostRequest(validBody));
+    expect(mockUpsert).toHaveBeenCalledTimes(1);
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    // Applicant upsert must use session email as the lookup key
+    const upsertCall = (
+      mockUpsert.mock.calls[0] as unknown as [{ where: { email: string } }]
+    )[0];
+    expect(upsertCall.where.email).toBe("owner@example.com");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PUT /api/resume
+// ---------------------------------------------------------------------------
+
+describe("PUT /api/resume", () => {
+  beforeEach(() => {
+    mockRequireSessionForRoute.mockImplementation(
+      (): Promise<SessionResult> =>
+        Promise.resolve({ ok: true as const, session: fakeSession })
+    );
+    mockFindUnique.mockImplementation(() =>
+      Promise.resolve(fakeProfileWithApplicant)
+    );
+    mockUpdate.mockImplementation(() => Promise.resolve(fakeProfile));
+    mockUpsert.mockImplementation(() => Promise.resolve(fakeApplicant));
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockRequireSessionForRoute.mockImplementationOnce(
+      (): Promise<SessionResult> =>
+        Promise.resolve({
+          ok: false as const,
+          response: new Response('{"message":"Unauthorized"}', {
+            status: 401,
+            headers: { "content-type": "application/json" },
+          }),
+        })
+    );
+
+    const res = await PUT(makePutRequest(validBody));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when profileId does not exist", async () => {
+    mockFindUnique.mockImplementationOnce(() => Promise.resolve(null));
+    const res = await PUT(makePutRequest(validBody, "nonexistent-id"));
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+  });
+
+  it("returns 403 when session user does not own the profile", async () => {
+    mockFindUnique.mockImplementationOnce(() =>
+      Promise.resolve({
+        ...fakeProfileWithApplicant,
+        applicant: { ...fakeApplicant, email: "someone-else@example.com" },
+      })
+    );
+
+    const res = await PUT(makePutRequest(validBody));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+  });
+
+  it("returns 400 for invalid body", async () => {
+    const res = await PUT(makePutRequest({ name: "Only Name" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+  });
+
+  it("returns 200 on valid PUT by owner", async () => {
+    const res = await PUT(makePutRequest(validBody));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+  });
+});

--- a/apps/blog/src/app/api/resume/route.ts
+++ b/apps/blog/src/app/api/resume/route.ts
@@ -1,0 +1,298 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+import { resumeSchema } from "@/app/(blog)/profile/resume/schema";
+import { requireSessionForRoute } from "@/lib/auth";
+import prisma from "@/services/prisma";
+
+export const runtime = "nodejs";
+
+// ---------------------------------------------------------------------------
+// Helpers — map form schema fields to Prisma create inputs
+// ---------------------------------------------------------------------------
+
+function splitLines(value: string | undefined): string[] {
+  return value ? value.split("\n").filter(Boolean) : [];
+}
+
+function mapExperienceCreate(e: {
+  company: string;
+  companyUrl?: string;
+  companyDescription?: string;
+  location: string;
+  title: string;
+  size?: string;
+  startDate: string;
+  endDate?: string;
+  items?: string;
+  description?: string;
+}) {
+  return {
+    company: e.company,
+    location: e.location,
+    title: e.title,
+    startDate: new Date(e.startDate),
+    endDate: e.endDate ? new Date(e.endDate) : null,
+    responsibilities: splitLines(e.items),
+    companyUrl: e.companyUrl || null,
+    companyDescription: e.companyDescription || null,
+    size: e.size || null,
+    description: e.description || null,
+  };
+}
+
+function mapProjectCreate(p: {
+  title: string;
+  subtitle: string;
+  ordering?: number;
+  items?: string;
+  description?: string;
+}) {
+  return {
+    title: p.title,
+    subtitle: p.subtitle,
+    ordering: p.ordering ?? 0,
+    descriptions: splitLines(p.items),
+    description: p.description || null,
+  };
+}
+
+function mapEducationCreate(e: {
+  facility: string;
+  degree: string;
+  location: string;
+  startDate: string;
+  endDate: string;
+  items?: string;
+  description?: string;
+}) {
+  return {
+    facility: e.facility,
+    degree: e.degree,
+    location: e.location,
+    startDate: new Date(e.startDate),
+    endDate: new Date(e.endDate),
+    subjects: splitLines(e.items),
+    description: e.description || null,
+  };
+}
+
+function mapSkillCreate(s: {
+  title: string;
+  ordering?: number;
+  items?: string;
+}) {
+  return {
+    title: s.title,
+    ordering: s.ordering ?? 0,
+    items: splitLines(s.items),
+  };
+}
+
+function mapLanguageCreate(l: {
+  name: string;
+  proficiency: string;
+  ordering?: number;
+}) {
+  return {
+    name: l.name,
+    proficiency: l.proficiency,
+    ordering: l.ordering ?? 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/resume — create a new resume profile
+// ---------------------------------------------------------------------------
+
+export async function POST(request: NextRequest) {
+  try {
+    const authResult = await requireSessionForRoute();
+    if (!authResult.ok) {
+      return authResult.response;
+    }
+
+    const rawBody = await request.json();
+    const parsed = resumeSchema.safeParse(rawBody);
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: parsed.error.issues[0]?.message ?? "Invalid request body",
+        },
+        { status: 400 }
+      );
+    }
+
+    const {
+      name,
+      address,
+      phone,
+      email,
+      github,
+      website,
+      company,
+      position,
+      summary,
+      experiences,
+      projects,
+      educations,
+      skills,
+      languages,
+    } = parsed.data;
+
+    // Find-or-create the applicant by the authenticated user's email.
+    // The applicant record holds the personal info; profiles hold per-company data.
+    const applicant = await prisma.resumeApplicant.upsert({
+      where: { email: authResult.session.user.email },
+      update: { name, address, phone, email, github, website },
+      create: {
+        name,
+        address,
+        phone,
+        email: authResult.session.user.email,
+        github,
+        website,
+      },
+    });
+
+    const profile = await prisma.resumeProfile.create({
+      data: {
+        applicantId: applicant.id,
+        company,
+        position,
+        summary,
+        experiences: { create: experiences.map(mapExperienceCreate) },
+        projects: { create: projects.map(mapProjectCreate) },
+        educations: { create: educations.map(mapEducationCreate) },
+        skills: { create: skills.map(mapSkillCreate) },
+        languages: { create: languages.map(mapLanguageCreate) },
+      },
+    });
+
+    return NextResponse.json({ success: true, data: profile.id });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Internal server error";
+    return NextResponse.json({ success: false, message }, { status: 500 });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// PUT /api/resume?profileId=xxx — update an existing resume profile
+// ---------------------------------------------------------------------------
+
+export async function PUT(request: NextRequest) {
+  try {
+    const authResult = await requireSessionForRoute();
+    if (!authResult.ok) {
+      return authResult.response;
+    }
+
+    const { searchParams } = new URL(request.url);
+    const profileId = searchParams.get("profileId");
+
+    if (!profileId) {
+      return NextResponse.json(
+        { success: false, message: "Missing profileId parameter" },
+        { status: 400 }
+      );
+    }
+
+    const profile = await prisma.resumeProfile.findUnique({
+      where: { id: profileId },
+      include: { applicant: true },
+    });
+
+    if (!profile) {
+      return NextResponse.json(
+        { success: false, message: "Profile not found" },
+        { status: 404 }
+      );
+    }
+
+    if (profile.applicant.email !== authResult.session.user.email) {
+      return NextResponse.json(
+        { success: false, message: "Forbidden" },
+        { status: 403 }
+      );
+    }
+
+    const rawBody = await request.json();
+    const parsed = resumeSchema.safeParse(rawBody);
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: parsed.error.issues[0]?.message ?? "Invalid request body",
+        },
+        { status: 400 }
+      );
+    }
+
+    const {
+      name,
+      address,
+      phone,
+      email,
+      github,
+      website,
+      company,
+      position,
+      summary,
+      experiences,
+      projects,
+      educations,
+      skills,
+      languages,
+    } = parsed.data;
+
+    // Update applicant personal info alongside the profile.
+    await prisma.resumeApplicant.upsert({
+      where: { email: authResult.session.user.email },
+      update: { name, address, phone, email, github, website },
+      create: {
+        name,
+        address,
+        phone,
+        email: authResult.session.user.email,
+        github,
+        website,
+      },
+    });
+
+    await prisma.resumeProfile.update({
+      where: { id: profileId },
+      data: {
+        company,
+        position,
+        summary,
+        experiences: {
+          deleteMany: {},
+          create: experiences.map(mapExperienceCreate),
+        },
+        projects: {
+          deleteMany: {},
+          create: projects.map(mapProjectCreate),
+        },
+        educations: {
+          deleteMany: {},
+          create: educations.map(mapEducationCreate),
+        },
+        skills: {
+          deleteMany: {},
+          create: skills.map(mapSkillCreate),
+        },
+        languages: {
+          deleteMany: {},
+          create: languages.map(mapLanguageCreate),
+        },
+      },
+    });
+
+    return NextResponse.json({ success: true, data: profileId });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Internal server error";
+    return NextResponse.json({ success: false, message }, { status: 500 });
+  }
+}

--- a/apps/blog/src/lib/__tests__/auth.test.ts
+++ b/apps/blog/src/lib/__tests__/auth.test.ts
@@ -71,6 +71,14 @@ mock.module("next/headers", () => ({
 }));
 
 mock.module("next/navigation", () => ({
+  // useRouter is included so that test files mocking a client component that
+  // imports useRouter (e.g. ResumeEditor) do not race with this narrower mock
+  // and lose the named export. Bun 1.3.x shares mock.module state across files.
+  useRouter: () => ({
+    push: () => undefined,
+    replace: () => undefined,
+    back: () => undefined,
+  }),
   notFound: mock((): never => {
     throw Object.assign(new Error("NEXT_NOT_FOUND"), {
       digest: "NEXT_NOT_FOUND",

--- a/apps/blog/src/middleware.ts
+++ b/apps/blog/src/middleware.ts
@@ -12,6 +12,8 @@ const routePolicy: ReadonlyArray<{
   windowMs: number;
 }> = [
   { prefix: "/api/auth", limit: 10, windowMs: 60_000 },
+  { prefix: "/api/checkout", limit: 10, windowMs: 60_000 },
+  { prefix: "/api/resume", limit: 20, windowMs: 60_000 },
   { prefix: "/api/subscription", limit: 5, windowMs: 60_000 },
   { prefix: "/api/proxy", limit: 10, windowMs: 60_000 },
   { prefix: "/api/sudoku", limit: 20, windowMs: 60_000 },

--- a/apps/blog/src/services/__tests__/line-pay.test.ts
+++ b/apps/blog/src/services/__tests__/line-pay.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+
+// ---------------------------------------------------------------------------
+// Module mocks — must be registered before the dynamic import of line-pay.ts
+// ---------------------------------------------------------------------------
+
+mock.module("@/config/env.mjs", () => ({
+  env: {
+    LINE_PAY_API_URL: "https://sandbox-api-pay.line.me",
+    LINE_PAY_CHANNEL_ID: "test-channel-id",
+    LINE_PAY_CHANNEL_SECRET_KEY: "test-secret-key",
+  },
+}));
+
+// Avoid real HMAC computation: deterministic signature stub.
+mock.module("node:crypto", () => ({
+  createHmac: () => ({
+    update: () => ({
+      digest: () => "mock-signature-base64",
+    }),
+  }),
+  randomUUID: () => "test-nonce-uuid",
+}));
+
+// Dynamic import AFTER mocks are registered.
+const { requestApi, confirmApi } = await import("../line-pay");
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const minimalRequestParam = {
+  amount: 100,
+  currency: "TWD",
+  orderId: "order-001",
+  packages: [
+    {
+      id: "pkg-1",
+      amount: 100,
+      products: [{ name: "Test Product", quantity: 1, price: 100 }],
+    },
+  ],
+  redirectUrls: {
+    confirmUrl: "https://example.com/confirm",
+    cancelUrl: "https://example.com/cancel",
+  },
+};
+
+const minimalConfirmParam = { amount: 100, currency: "TWD" };
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("requestApi", () => {
+  beforeEach(() => {
+    // Reset to a default success response before each test.
+    global.fetch = mock(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            returnCode: "0000",
+            returnMessage: "Success",
+            info: {
+              transactionId: 12_345,
+              paymentAccessToken: "token-abc",
+              paymentUrl: {
+                app: "linepay://pay",
+                web: "https://sandbox-web-pay.line.me/pay/confirm?transactionId=12345",
+              },
+            },
+          }),
+          { status: 200 }
+        )
+      )
+    ) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    // Restore global fetch to avoid leaking across test files.
+    global.fetch = fetch;
+  });
+
+  it("returns parsed response body on HTTP 200", async () => {
+    const result = await requestApi(minimalRequestParam);
+    expect(result.returnCode).toBe("0000");
+    expect(result.info.transactionId).toBe(12_345);
+    expect(result.info.paymentUrl.web).toContain("sandbox-web-pay.line.me");
+  });
+
+  it("throws with HTTP status when upstream returns 5xx", async () => {
+    global.fetch = mock(() =>
+      Promise.resolve(
+        new Response("<html>Internal Server Error</html>", {
+          status: 500,
+          statusText: "Internal Server Error",
+        })
+      )
+    ) as unknown as typeof fetch;
+
+    await expect(requestApi(minimalRequestParam)).rejects.toThrow("HTTP 500");
+  });
+
+  it("throws with HTTP status when upstream returns 4xx", async () => {
+    global.fetch = mock(() =>
+      Promise.resolve(
+        new Response("<html>Bad Request</html>", {
+          status: 400,
+          statusText: "Bad Request",
+        })
+      )
+    ) as unknown as typeof fetch;
+
+    await expect(requestApi(minimalRequestParam)).rejects.toThrow("HTTP 400");
+  });
+
+  it("rejects with abort-derived error when fetch hangs (timeout)", async () => {
+    const abortError = Object.assign(new Error("The operation was aborted"), {
+      name: "AbortError",
+    });
+    global.fetch = mock(() =>
+      Promise.reject(abortError)
+    ) as unknown as typeof fetch;
+
+    await expect(requestApi(minimalRequestParam)).rejects.toThrow(
+      "The operation was aborted"
+    );
+  });
+
+  it("clears the timeout timer after a successful response", async () => {
+    const originalClearTimeout = globalThis.clearTimeout;
+    const clearTimeoutSpy = mock(
+      (id: ReturnType<typeof setTimeout> | undefined) => {
+        originalClearTimeout(id);
+      }
+    );
+    globalThis.clearTimeout = clearTimeoutSpy as unknown as typeof clearTimeout;
+
+    try {
+      await requestApi(minimalRequestParam);
+      expect(clearTimeoutSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      globalThis.clearTimeout = originalClearTimeout;
+    }
+  });
+});
+
+describe("confirmApi", () => {
+  beforeEach(() => {
+    global.fetch = mock(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            returnCode: "0000",
+            returnMessage: "Success",
+            info: {
+              orderId: "order-001",
+              transactionId: 12_345,
+            },
+          }),
+          { status: 200 }
+        )
+      )
+    ) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = fetch;
+  });
+
+  it("returns parsed response body on HTTP 200", async () => {
+    const result = await confirmApi("12345", minimalConfirmParam);
+    expect(result.returnCode).toBe("0000");
+    expect(result.info.orderId).toBe("order-001");
+  });
+
+  it("throws with HTTP status when upstream returns 5xx", async () => {
+    global.fetch = mock(() =>
+      Promise.resolve(
+        new Response("<html>Internal Server Error</html>", {
+          status: 500,
+          statusText: "Internal Server Error",
+        })
+      )
+    ) as unknown as typeof fetch;
+
+    await expect(confirmApi("12345", minimalConfirmParam)).rejects.toThrow(
+      "HTTP 500"
+    );
+  });
+
+  it("rejects with abort-derived error when fetch hangs (timeout)", async () => {
+    const abortError = Object.assign(new Error("The operation was aborted"), {
+      name: "AbortError",
+    });
+    global.fetch = mock(() =>
+      Promise.reject(abortError)
+    ) as unknown as typeof fetch;
+
+    await expect(confirmApi("12345", minimalConfirmParam)).rejects.toThrow(
+      "The operation was aborted"
+    );
+  });
+});

--- a/apps/blog/src/services/__tests__/line-pay.test.ts
+++ b/apps/blog/src/services/__tests__/line-pay.test.ts
@@ -23,7 +23,8 @@ mock.module("node:crypto", () => ({
 }));
 
 // Dynamic import AFTER mocks are registered.
-const { requestApi, confirmApi } = await import("../line-pay");
+const { requestApi, confirmApi, RequestApiReturnCode, ConfirmApiReturnCode } =
+  await import("../line-pay");
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -83,7 +84,7 @@ describe("requestApi", () => {
 
   it("returns parsed response body on HTTP 200", async () => {
     const result = await requestApi(minimalRequestParam);
-    expect(result.returnCode).toBe("0000");
+    expect(result.returnCode).toBe(RequestApiReturnCode.Success);
     expect(result.info.transactionId).toBe(12_345);
     expect(result.info.paymentUrl.web).toContain("sandbox-web-pay.line.me");
   });
@@ -170,7 +171,7 @@ describe("confirmApi", () => {
 
   it("returns parsed response body on HTTP 200", async () => {
     const result = await confirmApi("12345", minimalConfirmParam);
-    expect(result.returnCode).toBe("0000");
+    expect(result.returnCode).toBe(ConfirmApiReturnCode.Success);
     expect(result.info.orderId).toBe("order-001");
   });
 

--- a/apps/blog/src/services/line-pay.ts
+++ b/apps/blog/src/services/line-pay.ts
@@ -217,6 +217,22 @@ const getLinePayAuthorizationHeaders = (uri: string, body: string) => {
   } as const;
 };
 
+const FETCH_TIMEOUT_MS = 10_000;
+
+async function fetchLinePayJson<T>(url: string, init: RequestInit): Promise<T> {
+  const controller = new AbortController();
+  const timerId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { ...init, signal: controller.signal });
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status} ${res.statusText}`);
+    }
+    return res.json() as Promise<T>;
+  } finally {
+    clearTimeout(timerId);
+  }
+}
+
 export const requestApi = (
   param: RequestApiParam
 ): Promise<RequestApiResponse> => {
@@ -226,11 +242,17 @@ export const requestApi = (
 
   const body = JSON.stringify(param);
 
-  return fetch(env.LINE_PAY_API_URL + LinePayApiEndpoints.Request, {
-    method: "POST",
-    headers: getLinePayAuthorizationHeaders(LinePayApiEndpoints.Request, body),
-    body,
-  }).then((res) => res.json());
+  return fetchLinePayJson<RequestApiResponse>(
+    env.LINE_PAY_API_URL + LinePayApiEndpoints.Request,
+    {
+      method: "POST",
+      headers: getLinePayAuthorizationHeaders(
+        LinePayApiEndpoints.Request,
+        body
+      ),
+      body,
+    }
+  );
 };
 
 export const confirmApi = (
@@ -247,9 +269,9 @@ export const confirmApi = (
   );
   const body = JSON.stringify(param);
 
-  return fetch(env.LINE_PAY_API_URL + uri, {
+  return fetchLinePayJson<ConfirmApiResponse>(env.LINE_PAY_API_URL + uri, {
     method: "POST",
     headers: getLinePayAuthorizationHeaders(uri, body),
     body,
-  }).then((res) => res.json());
+  });
 };

--- a/apps/blog/test-preload.ts
+++ b/apps/blog/test-preload.ts
@@ -1,0 +1,35 @@
+import { mock } from "bun:test";
+
+// Mock next/navigation with all hooks before any test file registers a subset mock.
+// Without this, Bun's ESM/CJS interop analysis runs on whichever test file's mock
+// registers first (e.g. auth.test.ts only mocks notFound), locking the named-export
+// set to that subset. Any subsequent file that imports { useRouter } then fails with
+// "Export named 'useRouter' not found" even though its own mock.module provides it.
+// Preloading with the full export set ensures Bun's analysis cache is populated
+// correctly before parallel test files start overriding with narrower subsets.
+mock.module("next/navigation", () => ({
+  useRouter: () => ({
+    push: () => undefined,
+    replace: () => undefined,
+    back: () => undefined,
+    prefetch: () => undefined,
+  }),
+  usePathname: () => "/",
+  useSearchParams: () => new URLSearchParams(),
+  useParams: () => ({}),
+  notFound: (): never => {
+    throw Object.assign(new Error("NEXT_NOT_FOUND"), {
+      digest: "NEXT_NOT_FOUND",
+    });
+  },
+  redirect: (): never => {
+    throw Object.assign(new Error("NEXT_REDIRECT"), {
+      digest: "NEXT_REDIRECT",
+    });
+  },
+  permanentRedirect: (): never => {
+    throw Object.assign(new Error("NEXT_REDIRECT"), {
+      digest: "NEXT_REDIRECT",
+    });
+  },
+}));


### PR DESCRIPTION
## Summary

Restores LINE Pay checkout in production and hardens the blog checkout/payment flow end-to-end. Addresses the silent regression where `validateRedirectUrl` rejects every cross-origin URL (breaking the LINE Pay redirect), adds robust error handling to external API calls, surfaces real errors to users, creates missing API route handlers, and displays real order status.

- **LINE Pay redirect allow-list** — Fix `validateRedirectUrl` to allow trusted LINE Pay hosts (`web-pay.line.me`, `sandbox-web-pay.line.me`) via HTTPS while preserving open-redirect protection from #481 (#551)
- **Fetch hardening** — Add `AbortController` + 10s timeout + `response.ok` checks to LINE Pay and TDX outbound fetches (#479)
- **`/api/checkout` handler** — New App Router POST with auth guard, Zod validation, atomic `CommerceOrder` + `CommerceTransaction(PENDING)` creation before LINE Pay call, failure branching to 502 + `FAILED` status (#480)
- **`/api/resume` handler** — New App Router POST + PUT with auth guard, Zod validation, ownership enforcement via email JOIN (#480)
- **Error surfacing** — Replace silent `console.error` in `CheckoutForm` and `ResumeEditor` with `setError("root")` + `role="alert"` for all failure modes including redirect validation throws (#483)
- **Order status copy** — Replace hardcoded "has shipped" string with status-driven copy from `STATUS_COPY` map + `generateMetadata` (#544)
- **Test infrastructure** — Add `test-preload.ts` to fix Bun 1.3.x `mock.module` cache contamination across parallel test files

## Stats

- 21 files changed, +2070 / -70 lines
- 47 new tests (177 blog total, 210 monorepo total)
- 10 atomic commits

## Issues closed

Closes #551, closes #479, closes #480, closes #483, closes #544

## Known optional improvements (from review)

1. `DEFAULT_TAX_RATE` duplicated in `constants.tsx` and `CheckoutForm.tsx` — consolidate in follow-up
2. Outer catch in route handlers forwards raw `error.message` to client — swap to generic string + server-side log
3. `/api/resume` PUT applicant upsert + profile update not wrapped in `$transaction` — low risk (idempotent) but inconsistent

## Test plan

- [x] `bun run lint` — 0 errors across monorepo
- [x] `bun run type-check` — clean across all 6 packages
- [x] `bun run test` — 210/210 pass, 0 fail
- [ ] LINE Pay sandbox QA — requires sandbox credentials; manually verify checkout → redirect → payment page loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>