### PR TITLE
:bug: fix(minecraft): treat cube faceIndex 0 as a valid click target (#529)

### DIFF
--- a/apps/minecraft/src/components/Cube.tsx
+++ b/apps/minecraft/src/components/Cube.tsx
@@ -7,6 +7,8 @@ import { type ReactNode, useState } from "react";
 import type { BufferGeometry, Mesh } from "three";
 import { create } from "zustand";
 
+import { resolveAdjacentCell, resolveHoverSlot } from "./faceAdjacency";
+
 interface CubeStore {
   addCube: (x: number, y: number, z: number) => void;
   cubes: ReactNode[];
@@ -37,8 +39,9 @@ export default function Cube({ position }: CubeProps) {
 
   const handlePointerMove = (event: ThreeEvent<PointerEvent>) => {
     event.stopPropagation();
-    if (event.faceIndex) {
-      setHover(Math.floor(event.faceIndex / 2));
+    const slot = resolveHoverSlot(event.faceIndex);
+    if (slot !== null) {
+      setHover(slot);
     }
   };
 
@@ -49,37 +52,18 @@ export default function Cube({ position }: CubeProps) {
   const handleOnClick = (event: ThreeEvent<MouseEvent>) => {
     event.stopPropagation();
 
-    if (!(event.faceIndex && ref.current)) {
+    if (!ref.current) {
       return;
     }
 
-    const faceIndex = Math.floor(event.faceIndex / 2);
     const { x, y, z } = ref.current.position;
-
-    switch (faceIndex) {
-      case 4:
-        addCube(x, y, z + 1);
-        return;
-
-      case 2:
-        addCube(x, y + 1, z);
-        return;
-
-      case 1:
-        addCube(x - 1, y, z);
-        return;
-
-      case 5:
-        addCube(x, y, z - 1);
-        return;
-
-      case 3:
-        addCube(x, y - 1, z);
-        return;
-
-      default:
-        addCube(x + 1, y, z);
+    const cell = resolveAdjacentCell(event.faceIndex, [x, y, z]);
+    if (cell === null) {
+      return;
     }
+
+    const [nx, ny, nz] = cell;
+    addCube(nx, ny, nz);
   };
 
   return (

--- a/apps/minecraft/src/components/faceAdjacency.test.ts
+++ b/apps/minecraft/src/components/faceAdjacency.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "bun:test";
+
+import { resolveAdjacentCell, resolveHoverSlot } from "./faceAdjacency";
+
+describe("resolveAdjacentCell", () => {
+  it("returns null when faceIndex is null", () => {
+    expect(resolveAdjacentCell(null, [0, 0, 0])).toBeNull();
+  });
+
+  it("returns null when faceIndex is undefined", () => {
+    expect(resolveAdjacentCell(undefined, [0, 0, 0])).toBeNull();
+  });
+
+  // Regression for #529 — truthy check treated 0 as missing.
+  it("treats faceIndex 0 as a valid click on the +x face", () => {
+    expect(resolveAdjacentCell(0, [0, 0, 0])).toEqual([1, 0, 0]);
+  });
+
+  it("maps faceIndex 1 (triangle 2 of +x face) to +x as well", () => {
+    // Math.floor(1 / 2) === 0 → default case → +x
+    expect(resolveAdjacentCell(1, [0, 0, 0])).toEqual([1, 0, 0]);
+  });
+
+  it("maps faceIndex 2 (first triangle of -x face) to -x", () => {
+    expect(resolveAdjacentCell(2, [5, 0, 0])).toEqual([4, 0, 0]);
+  });
+
+  it("maps faceIndex 4 (+y face) to +y", () => {
+    expect(resolveAdjacentCell(4, [0, 1, 0])).toEqual([0, 2, 0]);
+  });
+
+  it("maps faceIndex 6 (-y face) to -y", () => {
+    expect(resolveAdjacentCell(6, [0, 1, 0])).toEqual([0, 0, 0]);
+  });
+
+  it("maps faceIndex 8 (+z face) to +z", () => {
+    expect(resolveAdjacentCell(8, [0, 0, 2])).toEqual([0, 0, 3]);
+  });
+
+  it("maps faceIndex 10 (-z face) to -z", () => {
+    expect(resolveAdjacentCell(10, [0, 0, 2])).toEqual([0, 0, 1]);
+  });
+});
+
+describe("resolveHoverSlot", () => {
+  it("returns null for null/undefined faceIndex", () => {
+    expect(resolveHoverSlot(null)).toBeNull();
+    expect(resolveHoverSlot(undefined)).toBeNull();
+  });
+
+  // Regression for #529 — hover also dropped face-0.
+  it("returns 0 for faceIndex 0 (does not treat it as missing)", () => {
+    expect(resolveHoverSlot(0)).toBe(0);
+  });
+
+  it("returns the floored slot for non-zero indices", () => {
+    expect(resolveHoverSlot(3)).toBe(1);
+    expect(resolveHoverSlot(10)).toBe(5);
+  });
+});

--- a/apps/minecraft/src/components/faceAdjacency.ts
+++ b/apps/minecraft/src/components/faceAdjacency.ts
@@ -1,0 +1,51 @@
+import type { Triplet } from "@react-three/cannon";
+
+/**
+ * Given a Three.js triangle `faceIndex` from a BoxGeometry and a cube's
+ * current grid position, return the grid coordinates of the neighbouring
+ * cell that a click/tap on that face should spawn a new cube into.
+ *
+ * BoxGeometry has 12 triangles (6 quads × 2). Dividing by 2 maps to 6 face
+ * slots 0..5 — one per orthogonal axis.
+ *
+ * Returns `null` only when `faceIndex` is `null`/`undefined` — NEVER when
+ * it's `0`, which is a legitimate index for the +x face. The previous
+ * `if (event.faceIndex)` truthiness check silently dropped face-0 clicks.
+ */
+export function resolveAdjacentCell(
+  faceIndex: number | null | undefined,
+  [x, y, z]: Triplet
+): Triplet | null {
+  if (faceIndex === null || faceIndex === undefined) {
+    return null;
+  }
+  const slot = Math.floor(faceIndex / 2);
+  switch (slot) {
+    case 4:
+      return [x, y, z + 1];
+    case 2:
+      return [x, y + 1, z];
+    case 1:
+      return [x - 1, y, z];
+    case 5:
+      return [x, y, z - 1];
+    case 3:
+      return [x, y - 1, z];
+    default:
+      return [x + 1, y, z];
+  }
+}
+
+/**
+ * Face slot (0..5) for the hovered face, or `null` if the pointer event
+ * carried no `faceIndex`. Guards against `0`-falsy drops the same way
+ * `resolveAdjacentCell` does.
+ */
+export function resolveHoverSlot(
+  faceIndex: number | null | undefined
+): number | null {
+  if (faceIndex === null || faceIndex === undefined) {
+    return null;
+  }
+  return Math.floor(faceIndex / 2);
+}

--- a/openspec/changes/fix-minecraft-cube-face-click/.openspec.yaml
+++ b/openspec/changes/fix-minecraft-cube-face-click/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-17

--- a/openspec/changes/fix-minecraft-cube-face-click/proposal.md
+++ b/openspec/changes/fix-minecraft-cube-face-click/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+`apps/minecraft/src/components/Cube.tsx` guards face-click + hover handlers with truthy checks (`if (event.faceIndex)` and `if (!(event.faceIndex && ref.current))`). Three.js `BoxGeometry` emits `faceIndex` values `0..11`, where `0` is the first triangle of the `+x` face — a legitimate click target. The truthy check silently drops every interaction on face 0, so users cannot spawn a cube adjacent to the `+x` face or hover-highlight it. The inline `switch (faceIndex) { … default: addCube(x+1, y, z) }` masks the hover bug's impact on click because `case 0` falls through to `default`, but that's accidental — the early return on face 0 means the click never reaches the switch at all.
+
+## What Changes
+
+- Extract the face-index → adjacent-grid-cell math into a pure module `apps/minecraft/src/components/faceAdjacency.ts` exporting `resolveAdjacentCell(faceIndex, [x, y, z])` and `resolveHoverSlot(faceIndex)`, each explicitly checking `faceIndex === null || faceIndex === undefined` instead of truthy so `0` passes through.
+- Replace the inline truthy guards and `switch` in `Cube.tsx` with calls to these functions, preserving the existing behaviour for faces 1..5 and restoring it for face 0.
+- Add `apps/minecraft/src/components/faceAdjacency.test.ts` — `bun:test` unit tests including regression coverage for `faceIndex === 0` on both functions.
+
+## Capabilities
+
+### New Capabilities
+
+- `minecraft-cube-interactions`: Pointer-move hover highlighting and click-to-spawn behaviour for the 3D cube grid, driven by Three.js `BoxGeometry` `faceIndex` values. Face 0 MUST be treated as a valid interaction, not as "no face".
+
+### Modified Capabilities
+
+_(none — no existing `openspec/specs/` capability covers the minecraft app yet.)_
+
+## Impact
+
+- **Code**:
+  - `apps/minecraft/src/components/Cube.tsx` (edit)
+  - `apps/minecraft/src/components/faceAdjacency.ts` (new)
+  - `apps/minecraft/src/components/faceAdjacency.test.ts` (new)
+- **APIs**: none (app-internal module).
+- **Dependencies**: none added.
+- **Data model**: n/a.
+- **GitHub issues closed**: #529.
+- **Not closed**: #538 (cube store uses `ReactNode[]` for game state — out of scope; would change the store contract).

--- a/openspec/changes/fix-minecraft-cube-face-click/specs/minecraft-cube-interactions/spec.md
+++ b/openspec/changes/fix-minecraft-cube-face-click/specs/minecraft-cube-interactions/spec.md
@@ -1,0 +1,77 @@
+## ADDED Requirements
+
+### Requirement: Face 0 clicks spawn an adjacent cube
+
+The system SHALL, when a `ThreeEvent<MouseEvent>` with `faceIndex === 0` reaches `Cube`'s click handler, spawn a new cube at the `+x` grid neighbour of the clicked cube's current position.
+
+#### Scenario: Click face 0 of a cube at origin
+
+- **WHEN** `resolveAdjacentCell(0, [0, 0, 0])` is called
+- **THEN** the function returns `[1, 0, 0]`
+
+#### Scenario: Click face 1 (second triangle of the +x quad)
+
+- **WHEN** `resolveAdjacentCell(1, [0, 0, 0])` is called
+- **THEN** the function returns `[1, 0, 0]` — both triangles of a quad map to the same face
+
+### Requirement: Face-slot axis mapping is preserved
+
+The system SHALL map `Math.floor(faceIndex / 2)` to grid deltas as follows: slot `0` → `+x`, slot `1` → `-x`, slot `2` → `+y`, slot `3` → `-y`, slot `4` → `+z`, slot `5` → `-z`.
+
+#### Scenario: -x face
+
+- **WHEN** `resolveAdjacentCell(2, [5, 0, 0])` is called
+- **THEN** the function returns `[4, 0, 0]`
+
+#### Scenario: +y face
+
+- **WHEN** `resolveAdjacentCell(4, [0, 1, 0])` is called
+- **THEN** the function returns `[0, 2, 0]`
+
+#### Scenario: -y face
+
+- **WHEN** `resolveAdjacentCell(6, [0, 1, 0])` is called
+- **THEN** the function returns `[0, 0, 0]`
+
+#### Scenario: +z face
+
+- **WHEN** `resolveAdjacentCell(8, [0, 0, 2])` is called
+- **THEN** the function returns `[0, 0, 3]`
+
+#### Scenario: -z face
+
+- **WHEN** `resolveAdjacentCell(10, [0, 0, 2])` is called
+- **THEN** the function returns `[0, 0, 1]`
+
+### Requirement: Missing faceIndex is rejected
+
+The system SHALL return `null` from `resolveAdjacentCell` and `resolveHoverSlot` if and only if `faceIndex` is `null` or `undefined`. Numeric `0` MUST NOT be treated as missing.
+
+#### Scenario: null faceIndex on resolveAdjacentCell
+
+- **WHEN** `resolveAdjacentCell(null, [0, 0, 0])` is called
+- **THEN** the function returns `null`
+
+#### Scenario: undefined faceIndex on resolveAdjacentCell
+
+- **WHEN** `resolveAdjacentCell(undefined, [0, 0, 0])` is called
+- **THEN** the function returns `null`
+
+#### Scenario: null faceIndex on resolveHoverSlot
+
+- **WHEN** `resolveHoverSlot(null)` is called
+- **THEN** the function returns `null`
+
+#### Scenario: faceIndex 0 on resolveHoverSlot
+
+- **WHEN** `resolveHoverSlot(0)` is called
+- **THEN** the function returns `0` — NOT `null`
+
+### Requirement: Hover slot mirrors click logic
+
+The system SHALL return `Math.floor(faceIndex / 2)` from `resolveHoverSlot` for any non-nullish `faceIndex`, matching the slot index used by `resolveAdjacentCell` so hover highlight and click spawn axis-align.
+
+#### Scenario: Non-zero faceIndex
+
+- **WHEN** `resolveHoverSlot(3)` is called
+- **THEN** the function returns `1`

--- a/openspec/changes/fix-minecraft-cube-face-click/tasks.md
+++ b/openspec/changes/fix-minecraft-cube-face-click/tasks.md
@@ -1,0 +1,23 @@
+## 1. Pure function extraction
+
+- [x] 1.1 Create `apps/minecraft/src/components/faceAdjacency.ts` exporting `resolveAdjacentCell(faceIndex, [x, y, z])` and `resolveHoverSlot(faceIndex)`, each returning `null` only when `faceIndex` is `null` or `undefined` (never for `0`).
+- [x] 1.2 Port the six-case `switch` from `Cube.tsx` into `resolveAdjacentCell`, keeping the existing axis mapping (slot `4` → `+z`, `2` → `+y`, `1` → `-x`, `5` → `-z`, `3` → `-y`, default → `+x`).
+
+## 2. Consume from `Cube.tsx`
+
+- [x] 2.1 Import `resolveAdjacentCell` + `resolveHoverSlot` in `Cube.tsx`.
+- [x] 2.2 Rewrite `handlePointerMove` to call `resolveHoverSlot(event.faceIndex)` and guard with `!== null` (so face 0 registers).
+- [x] 2.3 Rewrite `handleOnClick` to call `resolveAdjacentCell(event.faceIndex, [x, y, z])` after the `ref.current` null-check; spread the returned triplet into `addCube`.
+- [x] 2.4 Delete the now-dead inline `switch` block.
+
+## 3. Regression tests
+
+- [x] 3.1 Add `apps/minecraft/src/components/faceAdjacency.test.ts` with explicit `faceIndex === 0` cases for both functions (the regression for #529).
+- [x] 3.2 Cover each face slot (`0`, `2`, `4`, `6`, `8`, `10`) with an expected grid delta.
+- [x] 3.3 Cover `null` + `undefined` returning `null` on both functions.
+
+## 4. Verification
+
+- [x] 4.1 `bun test apps/minecraft/src/components/faceAdjacency.test.ts` — all pass.
+- [x] 4.2 `bun run type-check` inside `apps/minecraft` — clean.
+- [ ] 4.3 Manual smoke: `bun run dev` in `apps/minecraft`, click top face of the default cube (which is face 0 via `+x` orientation depending on camera), verify a new cube spawns adjacent.


### PR DESCRIPTION
## Summary

- Extract face-index → adjacent-cell math out of `Cube.tsx` into a pure `faceAdjacency` module with explicit `=== null || === undefined` guards so `faceIndex === 0` (first triangle of the `+x` face) is no longer silently dropped.
- Add `faceAdjacency.test.ts` — `bun:test` coverage for all six face slots plus regressions for `faceIndex === 0` on both `resolveAdjacentCell` and `resolveHoverSlot`.
- New OpenSpec change `fix-minecraft-cube-face-click` capturing the `minecraft-cube-interactions` capability.

Closes #529.

## Why

`BoxGeometry` emits `faceIndex` values `0..11`. The previous `if (event.faceIndex)` / `if (!(event.faceIndex && ref.current))` guards treated `0` as falsy, so every click or hover on the `+x` face was dropped before it ever reached the switch. The `case 0` arm in the old inline switch was effectively unreachable — removing it uncovers the latent bug.

## Test plan

- [x] `bun test apps/minecraft/src/components/faceAdjacency.test.ts` — 12 pass
- [x] `bun run type-check` in `apps/minecraft` — clean
- [x] `bunx openspec validate fix-minecraft-cube-face-click` — valid
- [ ] Manual smoke: `bun run dev`, click each face of the default cube, verify an adjacent cube spawns on all six faces (previously face 0 was dead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)