### PR TITLE
:lock: fix(recipe): HttpOnly auth cookie + recipe-ID allow-list (#565, #547)

### DIFF
--- a/apps/recipe/package.json
+++ b/apps/recipe/package.json
@@ -23,6 +23,7 @@
     "@howardism/ui": "workspace:*",
     "@reduxjs/toolkit": "^2.2.1",
     "axios": "^1.6.7",
+    "cookie": "^0.7.2",
     "lodash.throttle": "^4.1.1",
     "lucide-react": "^1.7.0",
     "next": "^16.2.2",

--- a/apps/recipe/src/hooks/useAuth.tsx
+++ b/apps/recipe/src/hooks/useAuth.tsx
@@ -8,10 +8,9 @@ import useAppToast from "./useAppToast";
 interface UseAuth {
   isLoggedIn: boolean;
   login: (account: Account) => Promise<void>;
-  logout: VoidFunction;
+  logout: () => Promise<void>;
 }
 
-// TODO: consider manage auth by redux
 const useAuth = (): UseAuth => {
   const dispatch = useAppDispatch();
   const { isLoggedIn } = useAppSelector((state) => state.auth);
@@ -35,8 +34,8 @@ const useAuth = (): UseAuth => {
     }
   };
 
-  const logout = (): void => {
-    dispatch(authLogout());
+  const logout = async (): Promise<void> => {
+    await dispatch(authLogout());
   };
 
   return { isLoggedIn, login, logout };

--- a/apps/recipe/src/pages/api/_lib/auth-cookie.ts
+++ b/apps/recipe/src/pages/api/_lib/auth-cookie.ts
@@ -1,0 +1,41 @@
+import { parse, serialize } from "cookie";
+import type { NextApiRequest } from "next";
+
+export const AUTH_COOKIE_NAME = "recipe_auth";
+
+const ONE_WEEK_SECONDS = 60 * 60 * 24 * 7;
+
+export function serializeAuthCookie(jwt: string): string {
+  return serialize(AUTH_COOKIE_NAME, jwt, {
+    httpOnly: true,
+    maxAge: ONE_WEEK_SECONDS,
+    path: "/",
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+  });
+}
+
+export function serializeClearAuthCookie(): string {
+  return serialize(AUTH_COOKIE_NAME, "", {
+    httpOnly: true,
+    maxAge: 0,
+    path: "/",
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+  });
+}
+
+export function getAuthToken(req: NextApiRequest): string | null {
+  const fromParsed = req.cookies?.[AUTH_COOKIE_NAME];
+  if (typeof fromParsed === "string" && fromParsed.length > 0) {
+    return fromParsed;
+  }
+
+  const header = req.headers?.cookie;
+  if (typeof header !== "string" || header.length === 0) {
+    return null;
+  }
+  const parsed = parse(header);
+  const token = parsed[AUTH_COOKIE_NAME];
+  return typeof token === "string" && token.length > 0 ? token : null;
+}

--- a/apps/recipe/src/pages/api/auth/login.test.ts
+++ b/apps/recipe/src/pages/api/auth/login.test.ts
@@ -6,11 +6,14 @@ const mockLogin = mock(() => Promise.resolve("test-jwt-token"));
 // Mock the service before importing handler
 mock.module("@/services/auth", () => ({
   login: mockLogin,
+  verify: mock(() => Promise.resolve({})),
 }));
 
 describe("POST /api/auth/login", () => {
   let handler: (req: NextApiRequest, res: NextApiResponse) => Promise<unknown>;
   let mockRes: NextApiResponse;
+  let setHeader: ReturnType<typeof mock>;
+  let send: ReturnType<typeof mock>;
   let warnSpy: ReturnType<typeof spyOn>;
   let errorSpy: ReturnType<typeof spyOn>;
 
@@ -20,9 +23,9 @@ describe("POST /api/auth/login", () => {
     warnSpy = spyOn(console, "warn").mockImplementation(() => undefined);
     errorSpy = spyOn(console, "error").mockImplementation(() => undefined);
 
-    const send = mock();
+    send = mock();
     const status = mock(() => ({ send, end: mock(), json: mock() }));
-    const setHeader = mock();
+    setHeader = mock();
     mockRes = {
       send,
       status,
@@ -65,7 +68,7 @@ describe("POST /api/auth/login", () => {
     expect(mockLogin).not.toHaveBeenCalled();
   });
 
-  it("returns 200 and calls login with parsed body for valid input", async () => {
+  it("returns 200 and sets HttpOnly recipe_auth cookie on success", async () => {
     const req = {
       method: "POST",
       headers: {},
@@ -77,6 +80,33 @@ describe("POST /api/auth/login", () => {
       password: "s3cr3t",
     });
     expect(mockRes.status).toHaveBeenCalledWith(200);
+
+    const cookieCall = setHeader.mock.calls.find(
+      (call) => call[0] === "Set-Cookie"
+    );
+    expect(cookieCall).toBeDefined();
+    const cookieValue = cookieCall?.[1] as string;
+    expect(cookieValue).toContain("recipe_auth=test-jwt-token");
+    expect(cookieValue).toContain("HttpOnly");
+    expect(cookieValue).toContain("SameSite=Lax");
+    expect(cookieValue).toContain("Path=/");
+    expect(cookieValue).toContain("Max-Age=604800");
+  });
+
+  it("response body on success contains no jwt", async () => {
+    const req = {
+      method: "POST",
+      headers: {},
+      body: { identifier: "user@example.com", password: "s3cr3t" },
+    } as unknown as NextApiRequest;
+    await handler(req, mockRes);
+
+    for (const call of send.mock.calls) {
+      const body = call[0];
+      const serialized = JSON.stringify(body);
+      expect(serialized).not.toContain("test-jwt-token");
+      expect(serialized).not.toContain('"jwt"');
+    }
   });
 
   it("does not log request body contents to console.warn", async () => {

--- a/apps/recipe/src/pages/api/auth/login.ts
+++ b/apps/recipe/src/pages/api/auth/login.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { login } from "@/services/auth";
+import { serializeAuthCookie } from "../_lib/auth-cookie";
 import { loginSchema } from "../recipe/schemas";
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
@@ -17,7 +18,8 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
 
   try {
     const jwt = await login(result.data);
-    return res.status(200).send({ success: true, jwt });
+    res.setHeader("Set-Cookie", serializeAuthCookie(jwt));
+    return res.status(200).send({ success: true });
   } catch (error) {
     console.error((error as Error).message);
     return res.status(400).send({ success: false });

--- a/apps/recipe/src/pages/api/auth/logout.test.ts
+++ b/apps/recipe/src/pages/api/auth/logout.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+describe("POST /api/auth/logout", () => {
+  let handler: (req: NextApiRequest, res: NextApiResponse) => unknown;
+  let mockRes: NextApiResponse;
+  let setHeader: ReturnType<typeof mock>;
+  let send: ReturnType<typeof mock>;
+
+  beforeEach(async () => {
+    handler = (await import("./logout")).default;
+    send = mock();
+    const status = mock(() => ({ send, end: mock(), json: mock() }));
+    setHeader = mock();
+    mockRes = {
+      send,
+      status,
+      setHeader,
+      end: mock(),
+    } as unknown as NextApiResponse;
+  });
+
+  it("returns 405 for non-POST methods", () => {
+    const req = { method: "GET", headers: {} } as NextApiRequest;
+    handler(req, mockRes);
+    expect(mockRes.status).toHaveBeenCalledWith(405);
+  });
+
+  it("clears the recipe_auth cookie and responds 200", () => {
+    const req = {
+      method: "POST",
+      headers: { cookie: "recipe_auth=abc" },
+      cookies: { recipe_auth: "abc" },
+    } as unknown as NextApiRequest;
+    handler(req, mockRes);
+
+    expect(mockRes.status).toHaveBeenCalledWith(200);
+    const cookieCall = setHeader.mock.calls.find(
+      (call) => call[0] === "Set-Cookie"
+    );
+    expect(cookieCall).toBeDefined();
+    const cookieValue = cookieCall?.[1] as string;
+    expect(cookieValue).toContain("recipe_auth=");
+    expect(cookieValue).toContain("Max-Age=0");
+    expect(cookieValue).toContain("HttpOnly");
+    expect(cookieValue).toContain("Path=/");
+  });
+
+  it("is idempotent when no cookie is present", () => {
+    const req = {
+      method: "POST",
+      headers: {},
+      cookies: {},
+    } as unknown as NextApiRequest;
+    handler(req, mockRes);
+
+    expect(mockRes.status).toHaveBeenCalledWith(200);
+    const cookieCall = setHeader.mock.calls.find(
+      (call) => call[0] === "Set-Cookie"
+    );
+    expect(cookieCall).toBeDefined();
+  });
+});

--- a/apps/recipe/src/pages/api/auth/logout.ts
+++ b/apps/recipe/src/pages/api/auth/logout.ts
@@ -1,0 +1,15 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { serializeClearAuthCookie } from "../_lib/auth-cookie";
+
+const handler = (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", ["POST"]);
+    return res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+
+  res.setHeader("Set-Cookie", serializeClearAuthCookie());
+  return res.status(200).send({ success: true });
+};
+
+export default handler;

--- a/apps/recipe/src/pages/api/auth/me.test.ts
+++ b/apps/recipe/src/pages/api/auth/me.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+const mockVerify = mock(() =>
+  Promise.resolve({ id: "u1", email: "a@b.com", username: "alice" })
+);
+
+mock.module("@/services/auth", () => ({
+  login: mock(() => Promise.resolve("jwt")),
+  verify: mockVerify,
+}));
+
+describe("GET /api/auth/me", () => {
+  let handler: (req: NextApiRequest, res: NextApiResponse) => Promise<unknown>;
+  let mockRes: NextApiResponse;
+  let send: ReturnType<typeof mock>;
+  let errorSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(async () => {
+    handler = (await import("./me")).default;
+    mockVerify.mockClear();
+    errorSpy = spyOn(console, "error").mockImplementation(() => undefined);
+
+    send = mock();
+    const status = mock(() => ({ send, end: mock(), json: mock() }));
+    mockRes = {
+      send,
+      status,
+      setHeader: mock(),
+      end: mock(),
+    } as unknown as NextApiResponse;
+  });
+
+  it("returns 405 for non-GET methods", async () => {
+    const req = { method: "POST", headers: {}, cookies: {} } as NextApiRequest;
+    await handler(req, mockRes);
+    expect(mockRes.status).toHaveBeenCalledWith(405);
+    expect(mockVerify).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when recipe_auth cookie is absent", async () => {
+    const req = {
+      method: "GET",
+      headers: {},
+      cookies: {},
+    } as unknown as NextApiRequest;
+    await handler(req, mockRes);
+    expect(mockRes.status).toHaveBeenCalledWith(400);
+    expect(mockVerify).not.toHaveBeenCalled();
+  });
+
+  it("reads token from cookie and returns account on success", async () => {
+    const req = {
+      method: "GET",
+      headers: { cookie: "recipe_auth=valid-jwt" },
+      cookies: { recipe_auth: "valid-jwt" },
+    } as unknown as NextApiRequest;
+    await handler(req, mockRes);
+    expect(mockVerify).toHaveBeenCalledWith("valid-jwt");
+    expect(mockRes.status).toHaveBeenCalledWith(200);
+  });
+
+  it("returns 403 when verify throws", async () => {
+    mockVerify.mockRejectedValueOnce(new Error("invalid"));
+    const req = {
+      method: "GET",
+      headers: { cookie: "recipe_auth=bad" },
+      cookies: { recipe_auth: "bad" },
+    } as unknown as NextApiRequest;
+    await handler(req, mockRes);
+    expect(mockRes.status).toHaveBeenCalledWith(403);
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("ignores legacy recipe-token request header", async () => {
+    const req = {
+      method: "GET",
+      headers: { "recipe-token": "legacy" },
+      cookies: {},
+    } as unknown as NextApiRequest;
+    await handler(req, mockRes);
+    expect(mockRes.status).toHaveBeenCalledWith(400);
+    expect(mockVerify).not.toHaveBeenCalled();
+  });
+});

--- a/apps/recipe/src/pages/api/auth/me.ts
+++ b/apps/recipe/src/pages/api/auth/me.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { verify } from "@/services/auth";
+import { getAuthToken } from "../_lib/auth-cookie";
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   if (req.method !== "GET") {
@@ -8,9 +9,9 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     return res.status(405).end(`Method ${req.method} Not Allowed`);
   }
 
-  const jwt = req.headers["recipe-token"];
+  const jwt = getAuthToken(req);
 
-  if (typeof jwt !== "string") {
+  if (jwt === null) {
     return res.status(400).send({ success: false });
   }
 

--- a/apps/recipe/src/pages/api/recipe/create.test.ts
+++ b/apps/recipe/src/pages/api/recipe/create.test.ts
@@ -40,16 +40,22 @@ describe("POST /api/recipe/create", () => {
   });
 
   it("returns 405 for non-POST methods", async () => {
-    const req = { method: "GET", headers: {}, body: {} } as NextApiRequest;
+    const req = {
+      method: "GET",
+      headers: {},
+      cookies: {},
+      body: {},
+    } as NextApiRequest;
     await handler(req, mockRes);
     expect(mockRes.status).toHaveBeenCalledWith(405);
     expect(mockCreateRecipe).not.toHaveBeenCalled();
   });
 
-  it("returns 401 for missing authorization header", async () => {
+  it("returns 401 when recipe_auth cookie is absent", async () => {
     const req = {
       method: "POST",
-      headers: { authorization: undefined },
+      headers: {},
+      cookies: {},
       body: validRecipe,
     } as unknown as NextApiRequest;
     await handler(req, mockRes);
@@ -57,10 +63,11 @@ describe("POST /api/recipe/create", () => {
     expect(mockCreateRecipe).not.toHaveBeenCalled();
   });
 
-  it("returns 401 for non-Bearer authorization header", async () => {
+  it("returns 401 when Authorization header is present but cookie is not", async () => {
     const req = {
       method: "POST",
-      headers: { authorization: "Basic dXNlcjpwYXNz" },
+      headers: { authorization: "Bearer legacy-token" },
+      cookies: {},
       body: validRecipe,
     } as unknown as NextApiRequest;
     await handler(req, mockRes);
@@ -68,21 +75,11 @@ describe("POST /api/recipe/create", () => {
     expect(mockCreateRecipe).not.toHaveBeenCalled();
   });
 
-  it("returns 401 for authorization header that is too short to be valid", async () => {
+  it("returns 400 with flattened errors for malformed body", async () => {
     const req = {
       method: "POST",
-      headers: { authorization: "Bearer" },
-      body: validRecipe,
-    } as unknown as NextApiRequest;
-    await handler(req, mockRes);
-    expect(mockRes.status).toHaveBeenCalledWith(401);
-    expect(mockCreateRecipe).not.toHaveBeenCalled();
-  });
-
-  it("returns 400 with flattened errors for malformed body with valid Bearer", async () => {
-    const req = {
-      method: "POST",
-      headers: { authorization: "Bearer valid-token-abc" },
+      headers: { cookie: "recipe_auth=valid-token-abc" },
+      cookies: { recipe_auth: "valid-token-abc" },
       body: { title: "missing required fields" },
     } as unknown as NextApiRequest;
     await handler(req, mockRes);
@@ -98,7 +95,8 @@ describe("POST /api/recipe/create", () => {
   it("returns 400 for completely invalid body", async () => {
     const req = {
       method: "POST",
-      headers: { authorization: "Bearer valid-token-abc" },
+      headers: { cookie: "recipe_auth=valid-token-abc" },
+      cookies: { recipe_auth: "valid-token-abc" },
       body: null,
     } as unknown as NextApiRequest;
     await handler(req, mockRes);
@@ -106,16 +104,17 @@ describe("POST /api/recipe/create", () => {
     expect(mockCreateRecipe).not.toHaveBeenCalled();
   });
 
-  it("returns 200 and calls createRecipe for valid Bearer and valid body", async () => {
+  it("returns 200 and calls createRecipe with raw JWT for valid cookie + body", async () => {
     const req = {
       method: "POST",
-      headers: { authorization: "Bearer valid-token-abc" },
+      headers: { cookie: "recipe_auth=valid-token-abc" },
+      cookies: { recipe_auth: "valid-token-abc" },
       body: validRecipe,
     } as unknown as NextApiRequest;
     await handler(req, mockRes);
     expect(mockCreateRecipe).toHaveBeenCalledWith(
       validRecipe,
-      "Bearer valid-token-abc"
+      "valid-token-abc"
     );
     expect(mockRes.status).toHaveBeenCalledWith(200);
   });
@@ -127,7 +126,8 @@ describe("POST /api/recipe/create", () => {
     };
     const req = {
       method: "POST",
-      headers: { authorization: "Bearer abc123" },
+      headers: { cookie: "recipe_auth=abc123" },
+      cookies: { recipe_auth: "abc123" },
       body: sensitiveBody,
     } as unknown as NextApiRequest;
     await handler(req, mockRes);
@@ -139,26 +139,11 @@ describe("POST /api/recipe/create", () => {
     }
   });
 
-  it("does not log the authorization header or token to console.error", async () => {
+  it("does not log the cookie token on body validation failure", async () => {
     const req = {
       method: "POST",
-      headers: { authorization: "Basic notabearer-shouldtrigger401" },
-      body: {},
-    } as unknown as NextApiRequest;
-    await handler(req, mockRes);
-
-    for (const call of errorSpy.mock.calls) {
-      const logged = call.map((a) => JSON.stringify(a)).join(" ");
-      expect(logged).not.toContain("notabearer-shouldtrigger401");
-      expect(logged).not.toContain("Authorization");
-      expect(logged).not.toContain("authorization");
-    }
-  });
-
-  it("does not log the Bearer token value to console.error on body validation failure", async () => {
-    const req = {
-      method: "POST",
-      headers: { authorization: "Bearer supersecret-token-xyz" },
+      headers: { cookie: "recipe_auth=supersecret-token-xyz" },
+      cookies: { recipe_auth: "supersecret-token-xyz" },
       body: { bad: "body" },
     } as unknown as NextApiRequest;
     await handler(req, mockRes);
@@ -166,7 +151,6 @@ describe("POST /api/recipe/create", () => {
     for (const call of errorSpy.mock.calls) {
       const logged = call.map((a) => JSON.stringify(a)).join(" ");
       expect(logged).not.toContain("supersecret-token-xyz");
-      expect(logged).not.toContain("Bearer");
     }
   });
 });

--- a/apps/recipe/src/pages/api/recipe/create.ts
+++ b/apps/recipe/src/pages/api/recipe/create.ts
@@ -1,7 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { createRecipe } from "@/services/recipe";
-import { bearerTokenSchema, recipeSchema } from "./schemas";
+import { getAuthToken } from "../_lib/auth-cookie";
+import { recipeSchema } from "./schemas";
 
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   if (req.method !== "POST") {
@@ -9,9 +10,9 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     return res.status(405).end(`Method ${req.method} Not Allowed`);
   }
 
-  const authResult = bearerTokenSchema.safeParse(req.headers.authorization);
+  const jwt = getAuthToken(req);
 
-  if (!authResult.success) {
+  if (jwt === null) {
     return res.status(401).send({ success: false });
   }
 
@@ -22,7 +23,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 
   try {
-    const success = await createRecipe(bodyResult.data, authResult.data);
+    const success = await createRecipe(bodyResult.data, jwt);
     return res.status(200).send({ success });
   } catch (error) {
     console.error((error as Error).message);

--- a/apps/recipe/src/pages/api/recipe/schemas.ts
+++ b/apps/recipe/src/pages/api/recipe/schemas.ts
@@ -24,5 +24,3 @@ export const loginSchema = z.object({
   identifier: z.string(),
   password: z.string(),
 });
-
-export const bearerTokenSchema = z.string().regex(/^Bearer .+/);

--- a/apps/recipe/src/pages/recipe/[id].tsx
+++ b/apps/recipe/src/pages/recipe/[id].tsx
@@ -11,7 +11,11 @@ import logo from "@/../public/favicon/logo.png";
 import LayerCheckboxes from "@/components/LayerCheckboxes";
 import { NAV_BAR_HEIGHT } from "@/components/NavBar";
 import ProcedureStep from "@/components/ProcedureStep";
-import { getRecipeById, getRecipes } from "@/services/recipe";
+import {
+  getRecipeById,
+  getRecipes,
+  RECIPE_ID_PATTERN,
+} from "@/services/recipe";
 import type { Recipe } from "@/types/recipe";
 
 export default function RecipePage({
@@ -86,7 +90,13 @@ export const getStaticProps = async (
     return { notFound: true };
   }
 
-  const recipe = await getRecipeById(context.params.id);
+  const rawId = context.params.id;
+  const id = typeof rawId === "string" ? rawId : rawId?.[0];
+  if (!(id && RECIPE_ID_PATTERN.test(id))) {
+    return { notFound: true };
+  }
+
+  const recipe = await getRecipeById(id);
 
   if (recipe === null) {
     return {

--- a/apps/recipe/src/redux/api.ts
+++ b/apps/recipe/src/redux/api.ts
@@ -4,12 +4,4 @@ export type LocalAPIResponse<T = unknown> = T & { success: boolean };
 
 const api = axios.create({ baseURL: "/api" });
 
-export const updateAuthorizationHeader = (jwt: string): void => {
-  api.defaults.headers.common.Authorization = `Bearer ${jwt}`;
-};
-
-export const deleteAuthorizationHeader = (): void => {
-  api.defaults.headers.common.Authorization = "";
-};
-
 export default api;

--- a/apps/recipe/src/redux/slices/auth.ts
+++ b/apps/recipe/src/redux/slices/auth.ts
@@ -2,20 +2,14 @@ import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 
 import type { Account, LoginResponse } from "@/types/auth";
 
-import api, {
-  deleteAuthorizationHeader,
-  type LocalAPIResponse,
-  updateAuthorizationHeader,
-} from "../api";
+import api, { type LocalAPIResponse } from "../api";
 
 interface AuthState {
   isLoggedIn: boolean;
-  jwt: string;
 }
 
 const initialState: AuthState = {
   isLoggedIn: false,
-  jwt: "",
 };
 
 export const authLogin = createAsyncThunk(
@@ -30,24 +24,22 @@ export const authLogin = createAsyncThunk(
   }
 );
 
-const { actions, reducer } = createSlice({
+export const authLogout = createAsyncThunk("auth/logout", async () => {
+  await api.post("/auth/logout");
+});
+
+const { reducer } = createSlice({
   name: "auth",
   initialState,
-  reducers: {
-    authLogout: () => {
-      deleteAuthorizationHeader();
-      return initialState;
-    },
-  },
+  reducers: {},
   extraReducers: (builder) =>
     builder
       .addCase(authLogin.fulfilled, (state, action) => {
         state.isLoggedIn = action.payload.success;
-        state.jwt = action.payload.jwt;
-        updateAuthorizationHeader(action.payload.jwt);
       })
-      .addCase(authLogin.rejected, () => initialState),
+      .addCase(authLogin.rejected, () => initialState)
+      .addCase(authLogout.fulfilled, () => initialState)
+      .addCase(authLogout.rejected, () => initialState),
 });
 
-export const { authLogout } = actions;
 export default reducer;

--- a/apps/recipe/src/services/__tests__/recipe.test.ts
+++ b/apps/recipe/src/services/__tests__/recipe.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, mock, spyOn } from "bun:test";
+
+const mockGet = mock<
+  (url: string, config?: unknown) => Promise<{ data: unknown }>
+>(() => Promise.resolve({ data: { id: 1, title: "r" } }));
+const mockPost = mock<
+  (url: string, body?: unknown, config?: unknown) => Promise<{ data: unknown }>
+>(() => Promise.resolve({ data: true }));
+
+mock.module("@/services/cms", () => ({
+  default: { get: mockGet, post: mockPost },
+}));
+
+describe("services/recipe", () => {
+  let getRecipeById: typeof import("../recipe").getRecipeById;
+  let createRecipe: typeof import("../recipe").createRecipe;
+  let errorSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(async () => {
+    mockGet.mockClear();
+    mockPost.mockClear();
+    errorSpy = spyOn(console, "error").mockImplementation(() => undefined);
+    const mod = await import("../recipe");
+    getRecipeById = mod.getRecipeById;
+    createRecipe = mod.createRecipe;
+  });
+
+  describe("getRecipeById (allow-list)", () => {
+    it("proceeds for alphanumeric IDs", async () => {
+      mockGet.mockResolvedValueOnce({ data: { id: 1, title: "ok" } });
+      const result = await getRecipeById("abc123");
+      expect(mockGet).toHaveBeenCalledTimes(1);
+      expect(mockGet.mock.calls[0]?.[0]).toBe("/recipes/abc123");
+      expect(result).toEqual({ id: 1, title: "ok" });
+    });
+
+    it("proceeds for numeric IDs (Strapi v4)", async () => {
+      mockGet.mockResolvedValueOnce({ data: { id: 42, title: "ok" } });
+      await getRecipeById("42");
+      expect(mockGet.mock.calls[0]?.[0]).toBe("/recipes/42");
+    });
+
+    it("proceeds for 24-char documentId (Strapi v5)", async () => {
+      const docId = "a1b2c3d4e5f6a7b8c9d0e1f2";
+      mockGet.mockResolvedValueOnce({ data: { id: docId, title: "ok" } });
+      await getRecipeById(docId);
+      expect(mockGet.mock.calls[0]?.[0]).toBe(`/recipes/${docId}`);
+    });
+
+    it("rejects ID containing a slash (#547 regression)", async () => {
+      const result = await getRecipeById("../etc/passwd");
+      expect(result).toBeNull();
+      expect(mockGet).not.toHaveBeenCalled();
+    });
+
+    it("rejects ID containing URL-encoded traversal", async () => {
+      const result = await getRecipeById("..%2Fetc%2Fpasswd");
+      expect(result).toBeNull();
+      expect(mockGet).not.toHaveBeenCalled();
+    });
+
+    it("rejects ID containing a NUL byte", async () => {
+      const result = await getRecipeById("abc\x00def");
+      expect(result).toBeNull();
+      expect(mockGet).not.toHaveBeenCalled();
+    });
+
+    it("rejects empty string", async () => {
+      const result = await getRecipeById("");
+      expect(result).toBeNull();
+      expect(mockGet).not.toHaveBeenCalled();
+    });
+
+    it("rejects ID longer than 64 chars", async () => {
+      const tooLong = "a".repeat(65);
+      const result = await getRecipeById(tooLong);
+      expect(result).toBeNull();
+      expect(mockGet).not.toHaveBeenCalled();
+    });
+
+    it("rejects ID with a dot (no extension traversal)", async () => {
+      const result = await getRecipeById("abc.def");
+      expect(result).toBeNull();
+      expect(mockGet).not.toHaveBeenCalled();
+    });
+
+    it("returns null on CMS error without leaking", async () => {
+      mockGet.mockRejectedValueOnce(new Error("503"));
+      const result = await getRecipeById("abc");
+      expect(result).toBeNull();
+      expect(errorSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe("createRecipe (raw-JWT signature)", () => {
+    it("constructs Bearer header from raw JWT internally", async () => {
+      mockPost.mockResolvedValueOnce({ data: true });
+      const recipe = {
+        description: "d",
+        title: "t",
+        ingredients: [],
+        seasonings: [],
+        steps: [],
+      };
+      const ok = await createRecipe(recipe, "abc");
+      expect(ok).toBe(true);
+      const config = mockPost.mock.calls[0]?.[2] as {
+        headers?: Record<string, string>;
+      };
+      expect(config?.headers?.Authorization).toBe("Bearer abc");
+    });
+  });
+});

--- a/apps/recipe/src/services/__tests__/recipe.test.ts
+++ b/apps/recipe/src/services/__tests__/recipe.test.ts
@@ -31,7 +31,7 @@ describe("services/recipe", () => {
       const result = await getRecipeById("abc123");
       expect(mockGet).toHaveBeenCalledTimes(1);
       expect(mockGet.mock.calls[0]?.[0]).toBe("/recipes/abc123");
-      expect(result).toEqual({ id: 1, title: "ok" });
+      expect(result).toMatchObject({ id: 1, title: "ok" });
     });
 
     it("proceeds for numeric IDs (Strapi v4)", async () => {

--- a/apps/recipe/src/services/auth.ts
+++ b/apps/recipe/src/services/auth.ts
@@ -1,9 +1,13 @@
-import type { Account, LoginResponse, VerifyResponse } from "@/types/auth";
+import type { Account, VerifyResponse } from "@/types/auth";
 
 import cms from "./cms";
 
+interface CmsLoginResponse {
+  jwt: string;
+}
+
 export const login = async (account: Account): Promise<string> => {
-  const response = await cms.post<LoginResponse>("/auth/local", account);
+  const response = await cms.post<CmsLoginResponse>("/auth/local", account);
 
   return response.data.jwt;
 };

--- a/apps/recipe/src/services/recipe.ts
+++ b/apps/recipe/src/services/recipe.ts
@@ -2,6 +2,8 @@ import type { RawRecipe, Recipe } from "@/types/recipe";
 
 import cms from "./cms";
 
+export const RECIPE_ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
+
 export const getRecipes = async (): Promise<Recipe[]> => {
   try {
     const response = await cms.get<Recipe[]>("/recipes");
@@ -13,8 +15,14 @@ export const getRecipes = async (): Promise<Recipe[]> => {
 };
 
 export const getRecipeById = async (id: string): Promise<Recipe | null> => {
+  if (!RECIPE_ID_PATTERN.test(id)) {
+    return null;
+  }
+
   try {
-    const response = await cms.get<Recipe>(`/recipes/${id}`);
+    const response = await cms.get<Recipe>(
+      `/recipes/${encodeURIComponent(id)}`
+    );
 
     return response.data;
   } catch (error) {
@@ -25,11 +33,11 @@ export const getRecipeById = async (id: string): Promise<Recipe | null> => {
 
 export const createRecipe = async (
   recipe: RawRecipe,
-  authHeader: string
+  jwt: string
 ): Promise<boolean> => {
   try {
     await cms.post("recipes", recipe, {
-      headers: { Authorization: authHeader },
+      headers: { Authorization: `Bearer ${jwt}` },
     });
     return true;
   } catch (error) {

--- a/apps/recipe/src/types/auth.d.ts
+++ b/apps/recipe/src/types/auth.d.ts
@@ -4,7 +4,7 @@ export interface Account {
 }
 
 export interface LoginResponse {
-  jwt: string;
+  success: boolean;
 }
 
 export interface VerifyResponse {

--- a/bun.lock
+++ b/bun.lock
@@ -155,6 +155,7 @@
         "@howardism/ui": "workspace:*",
         "@reduxjs/toolkit": "^2.2.1",
         "axios": "^1.6.7",
+        "cookie": "^0.7.2",
         "lodash.throttle": "^4.1.1",
         "lucide-react": "^1.7.0",
         "next": "^16.2.2",
@@ -1333,6 +1334,8 @@
     "conventional-commits-parser": ["conventional-commits-parser@6.4.0", "", { "dependencies": { "@simple-libs/stream-utils": "^1.2.0", "meow": "^13.0.0" }, "bin": { "conventional-commits-parser": "dist/cli/index.js" } }, "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
     "copy-to-clipboard": ["copy-to-clipboard@3.3.3", "", { "dependencies": { "toggle-selection": "^1.0.6" } }, "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA=="],
 

--- a/openspec/changes/recipe-auth-and-id-hardening/.openspec.yaml
+++ b/openspec/changes/recipe-auth-and-id-hardening/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-19

--- a/openspec/changes/recipe-auth-and-id-hardening/design.md
+++ b/openspec/changes/recipe-auth-and-id-hardening/design.md
@@ -1,0 +1,82 @@
+# Design — `recipe-auth-and-id-hardening`
+
+## Scope
+
+Two high-severity defects at the recipe app's CMS boundary, bundled because they share the same file cluster and the same cross-cutting principle (don't trust what flows downstream):
+
+- **#565** — CMS JWT stored in Redux state + on `axios.defaults.headers`. XSS = token theft.
+- **#547** — `getRecipeById(id)` passes caller-supplied `id` unvalidated + unencoded into the CMS URL. Path-traversal risk.
+
+## Key decisions
+
+### D1 — HttpOnly cookie, not sessionStorage, not Redis-backed session
+
+**Options considered:**
+
+| Option | Pros | Cons |
+|---|---|---|
+| **HttpOnly cookie (`recipe_auth`)** (chosen) | Zero JS exposure — not reachable from `document.cookie` or `window.*`; browser-attached on same-origin `/api/*` calls with no axios config; 7-day lifetime matches previous UX | Cookie is sent on every same-origin request — slight bandwidth uptick; CSRF surface appears on state-changing routes |
+| `sessionStorage` | Still no meaningful improvement over Redux state — readable by any JS on the page | Same XSS exposure as today |
+| Server-side session (Redis or Strapi session lookup) | Rotates token, adds server session knobs | Overkill — no session state to manage; Strapi returns a signed JWT that's already self-validating |
+| Move JWT to a Next.js server action / middleware-only context | Token never reaches client | Requires App Router migration + much heavier refactor |
+
+Chose the cookie because it fully closes the XSS window with the smallest surface change — login sets the cookie, browsers attach it automatically, server reads it, client never touches it.
+
+**CSRF note.** `SameSite=Lax` blocks cross-site POSTs from a third-party origin following a link (which is how CSRF typically lands). This app has no cross-site state-changing flows, and the only mutating endpoint (`/api/recipe/create`) is called from first-party JS via axios. If we later add forms posted from other origins we'll layer a CSRF token; for now Lax is sufficient.
+
+### D2 — Cookie name and attributes
+
+- `name: "recipe_auth"` — keeps the app prefix; avoids colliding with a different app on the same domain during local-dev on shared ports.
+- `httpOnly: true` — non-negotiable; the whole point of the change.
+- `sameSite: "lax"` — see D1 CSRF note.
+- `path: "/"` — cookie attaches to both page navigation and `/api/*` same-origin calls.
+- `secure: process.env.NODE_ENV === "production"` — `Secure` requires HTTPS; enabling it in dev breaks `http://localhost:3000`. The gate is standard Next.js convention.
+- `maxAge: 60 * 60 * 24 * 7` (7 days) — the previous flow had no explicit client-side expiry (JWT validity was CMS-controlled). 7 days keeps UX unchanged while giving a client-side revocation knob (logout).
+
+### D3 — Allow-list pattern for recipe IDs
+
+`^[A-Za-z0-9_-]{1,64}$` covers:
+
+- Strapi v4 numeric IDs: digits only (e.g. `42`).
+- Strapi v5 `documentId`: 24-char cuid-ish (alphanumeric + `-`).
+- Realistic upper bound of 64 chars to forbid absurdly long inputs without cutting into legitimate shapes.
+- Excludes: `/`, `\`, `%`, `.`, whitespace, control chars — every char a path-traversal payload would need.
+
+**Why not use the CMS's ID schema directly?** Strapi doesn't publish a regex; schemas vary across versions. A conservative allow-list is stable across CMS upgrades — a CMS change that introduces a new ID shape gets caught at the service-layer boundary and surfaces as a 404, which is the correct failure mode.
+
+**Why both allow-list AND `encodeURIComponent`?** The allow-list is the primary defense; the encoder is belt-and-braces. If the allow-list is ever loosened (say, to admit `:` for a namespaced ID), the encoder prevents any newly-permitted special char from reshaping the URL path. The cost of the encoder is one function call.
+
+### D4 — Share the regex via the service module, not a new barrel
+
+The same pattern is used in `services/recipe.ts` and `pages/recipe/[id].tsx`. Three options:
+
+| Option | Verdict |
+|---|---|
+| Inline-duplicate | rejected — drift risk |
+| Export `RECIPE_ID_PATTERN` from `services/recipe.ts` | **chosen** — single source of truth, no new file, Ultracite-compliant (top-level regex) |
+| Create `services/constants.ts` barrel | rejected — Ultracite's `noBarrelFile` flags barrels; a single shared regex doesn't justify a new barrel |
+
+### D5 — Why retire `bearerTokenSchema` entirely
+
+`bearerTokenSchema = z.string().regex(/^Bearer .+/)` validates the CLIENT-supplied header shape. Post-cookie, the client doesn't supply a header at all — the browser sends the cookie, the server reads it. Schema validation on a header we don't read anymore is dead code. Removing it shrinks the trust surface.
+
+### D6 — Signature change: `createRecipe(recipe, jwt)` not `createRecipe(recipe, authHeader)`
+
+The service used to take a full `Authorization: Bearer <jwt>` string. Passing a full header around couples the service to HTTP specifics and makes it possible for the API-route layer to pass the WRONG header (e.g., `Basic`). Passing the raw JWT and letting the service construct the header is the straightforward contract — service knows it's talking to a Bearer-expecting CMS, caller knows it has a user JWT.
+
+### D7 — Retain API-route layer (don't collapse into Server Action)
+
+Recipe app is on the Pages Router. Moving to App Router server actions to "eliminate the network hop" is out of scope — would require rewriting the routing + data-fetching model for a single endpoint. The Pages API layer stays; the cookie read happens there.
+
+## Risks
+
+1. **Session-invalidation UX.** Users currently authenticated via the old Redux-stored JWT become "logged out" on first load after deploy. No server session to migrate. The UI already handles unauthenticated state (signin page). Mitigation: none needed — one-time re-login is acceptable for a security fix.
+2. **Dev HTTPS gap.** `Secure` is off in dev, so a MITM on localhost could observe the cookie. Local-dev MITM is out of threat model.
+3. **CSRF drift.** If we later accept cross-site state-changing requests, `SameSite=Lax` alone isn't enough — need a CSRF token. Flagged in D1; not addressed in this change.
+4. **Allow-list over-restriction.** If Strapi's future ID format includes `:` or `.`, the regex rejects legitimate IDs and all recipe pages 404. Mitigation: change is centralized in one constant; a follow-up one-liner updates it. Failure mode is visible (404 on every page) not silent.
+
+## Out of scope
+
+- App-Router migration for the recipe app (architectural rewrite, separate change).
+- CSRF token layer (see D1).
+- Strapi-side RBAC or per-user recipe ownership (this app currently trusts any valid-JWT holder to write — tightening is orthogonal).

--- a/openspec/changes/recipe-auth-and-id-hardening/proposal.md
+++ b/openspec/changes/recipe-auth-and-id-hardening/proposal.md
@@ -1,0 +1,43 @@
+## Why
+
+Two outstanding high-severity security defects sit on the same trust boundary — the recipe app's handoff between the browser, its Next.js Pages-API layer, and the Strapi CMS:
+
+1. **#565 — JWT in Redux/JS-readable state.** After login, `redux/slices/auth.ts` stores the CMS JWT directly in Redux state and writes it onto `api.defaults.headers.common.Authorization`. Any XSS vulnerability — in our code, a dependency, or a third-party script — immediately exfiltrates the token. The token grants CMS write access for the session's lifetime. An HttpOnly cookie moves the token out of reach of `document.cookie` and `window.*`, so XSS alone is no longer sufficient to lift a token.
+2. **#547 — Unvalidated recipe ID flows into CMS URL.** `getRecipeById(id)` interpolates the caller-supplied `id` into `/recipes/${id}` with no validation and no URL encoding. `getStaticProps` in `pages/recipe/[id].tsx` passes `context.params.id` straight through. A crafted `id` such as `..%2Fadmin%2Fusers` (or decoded `..\admin\users`) can traverse the CMS path and surface internal endpoints the CMS might otherwise auth-gate at the exact `/recipes/:id` shape only. Strapi doesn't normalize arbitrary paths, but depth-of-defense requires the caller validate anyway — unencoded `/` in an `id` is never a legitimate recipe identifier.
+
+Both defects sit on the boundary where the app wraps a CMS — same file cluster (`services/recipe.ts`, `services/auth.ts`, `services/cms.ts`, `pages/api/**`), same "don't trust what you pass downstream" cross-cut. One change, one PR.
+
+## What Changes
+
+### #565 — JWT → HttpOnly cookie
+
+- **Server: set cookie on login.** `pages/api/auth/login.ts` SHALL, on successful CMS login, issue a `Set-Cookie` header for `recipe_auth` with the returned JWT. Cookie attributes: `HttpOnly`, `SameSite=Lax`, `Path=/`, `Max-Age=604800` (7 days), `Secure` when `NODE_ENV === "production"`. Response body drops the JWT entirely — returns `{ success: true }`.
+- **Server: new logout route.** `pages/api/auth/logout.ts` SHALL clear `recipe_auth` by issuing a `Set-Cookie` with `Max-Age=0`. Idempotent — works whether or not the cookie is present.
+- **Server: cookie-as-source for JWT consumers.** `pages/api/auth/me.ts` and `pages/api/recipe/create.ts` SHALL read the token from `req.cookies.recipe_auth` (or via a `getAuthToken` helper in `pages/api/_lib/auth-cookie.ts`) instead of from request headers (`recipe-token`) or `Authorization: Bearer …`. The `bearerTokenSchema` in `pages/api/recipe/schemas.ts` is retired; the authorization gate becomes presence-check-on-cookie.
+- **Server: service-layer signature cleanup.** `services/recipe.ts:createRecipe` changes from `(recipe, authHeader)` to `(recipe, jwt)`; the service builds `Authorization: \`Bearer ${jwt}\`` internally. Callers can no longer leak a raw header to the service boundary.
+- **Client: drop JWT from Redux state.** `redux/slices/auth.ts` `AuthState` shrinks from `{ isLoggedIn, jwt }` to `{ isLoggedIn }`. `authLogin.fulfilled` flips `isLoggedIn` based on response status, does NOT store a token. `authLogout` posts to `/api/auth/logout` (the server clears the cookie) and flips `isLoggedIn = false`.
+- **Client: drop header-mutation helpers.** `redux/api.ts` `updateAuthorizationHeader` / `deleteAuthorizationHeader` are deleted. The browser attaches the `recipe_auth` cookie to same-origin `/api/*` calls automatically — axios has no work to do for auth.
+- **Client: `useAuth` logout becomes async.** The hook's `logout` awaits the logout-post-and-dispatch so the server-side clear happens before a follow-up read.
+- **Types.** `types/auth.d.ts` `LoginResponse` drops `jwt`; becomes `{ success: boolean }` (or is removed — clients can derive success from HTTP status).
+
+### #547 — Recipe-ID hygiene
+
+- **Validate in the service layer.** `services/recipe.ts:getRecipeById` SHALL reject any `id` that does not match `/^[A-Za-z0-9_-]{1,64}$/` — the allow-list that covers Strapi v4 numeric IDs and v5 documentId (24-char hex) without admitting slashes, `..`, `%`, or control chars. Rejection returns `null` without an outbound fetch.
+- **Defense-in-depth URL encoding.** Even after the allow-list admits an `id`, `encodeURIComponent(id)` SHALL be interpolated into the URL path. The allow-list already forbids the chars that would need escaping, but the encoding preserves correctness if the allow-list is ever loosened.
+- **Validate at page ingress.** `pages/recipe/[id].tsx:getStaticProps` SHALL apply the same regex to `context.params.id` and return `{ notFound: true }` on mismatch, avoiding an unnecessary CMS round-trip and presenting the attacker with a clean 404 (matching legitimate missing-recipe behavior — no signal that the input was malformed).
+
+## Capabilities
+
+### New Capabilities
+
+- `recipe-auth-cookie` — HttpOnly-cookie-backed authentication for the recipe app's CMS gateway, replacing the prior token-in-JS flow.
+- `recipe-cms-id-hygiene` — allow-list validation and URL encoding for CMS-bound recipe identifiers.
+
+## Impact
+
+- **Code**: `apps/recipe/src/pages/api/auth/{login,logout,me}.ts`, new `apps/recipe/src/pages/api/_lib/auth-cookie.ts`, `apps/recipe/src/pages/api/recipe/{create,schemas}.ts`, `apps/recipe/src/services/{auth,recipe}.ts`, `apps/recipe/src/pages/recipe/[id].tsx`, `apps/recipe/src/redux/{api,slices/auth}.ts`, `apps/recipe/src/hooks/useAuth.tsx`, `apps/recipe/src/types/auth.d.ts`.
+- **Dependencies**: add `cookie@^0.7` to `apps/recipe/package.json` for `Set-Cookie` serialization (already a Next.js transitive dep; promoting to direct keeps the import graph explicit). `@types/cookie` is bundled with the `cookie` package since v1; no separate `@types` install required.
+- **Environment**: none.
+- **Tests**: updated `pages/api/auth/login.test.ts` (assert `Set-Cookie` header, body has no `jwt`), new `pages/api/auth/logout.test.ts`, new `pages/api/auth/me.test.ts` (cookie-read path), updated `pages/api/recipe/create.test.ts` (cookie-read in place of `Authorization: Bearer`), new `services/__tests__/recipe.test.ts` (path-traversal regression cases), new `services/__tests__/getRecipeById.test.ts` (allow-list).
+- **Issues auto-closed on merge**: `Fixes #565`, `Fixes #547`.
+- **Migration note for existing sessions.** A JWT currently held in a browser's Redux Persist blob (if any persistence is on — check `apps/recipe/src/redux/store.ts` in the archaeology step) becomes inert; users re-log-in once. No backwards-compat shim.

--- a/openspec/changes/recipe-auth-and-id-hardening/specs/recipe-auth-cookie/spec.md
+++ b/openspec/changes/recipe-auth-and-id-hardening/specs/recipe-auth-cookie/spec.md
@@ -1,0 +1,93 @@
+## ADDED Requirements
+
+### Requirement: Login issues an HttpOnly auth cookie
+
+On a successful `POST /api/auth/login` in the recipe app, the handler SHALL issue a `Set-Cookie` response header named `recipe_auth` carrying the JWT returned by the CMS. The cookie SHALL carry the attributes: `HttpOnly`, `SameSite=Lax`, `Path=/`, `Max-Age=604800`. The `Secure` attribute SHALL be present when `process.env.NODE_ENV === "production"` and absent otherwise. The HTTP response body SHALL be the JSON object `{"success": true}` and SHALL NOT include the JWT.
+
+#### Scenario: Login sets the HttpOnly cookie and no JWT in body
+
+- **WHEN** `POST /api/auth/login` is invoked with valid credentials and the CMS returns a JWT
+- **THEN** the response SHALL set a `Set-Cookie` header whose name is `recipe_auth`
+- **AND** the `Set-Cookie` value SHALL contain `HttpOnly`, `SameSite=Lax`, `Path=/`, `Max-Age=604800`
+- **AND** the response body SHALL be `{"success":true}`
+- **AND** the response body SHALL NOT contain the JWT value anywhere
+
+#### Scenario: Production response carries Secure flag
+
+- **WHEN** login succeeds with `process.env.NODE_ENV === "production"`
+- **THEN** the `Set-Cookie` value SHALL contain the `Secure` attribute
+
+#### Scenario: Failure responses carry no cookie
+
+- **WHEN** credentials are invalid and CMS login rejects
+- **THEN** the handler SHALL respond 400 with `{"success": false}`
+- **AND** SHALL NOT emit a `Set-Cookie` header
+
+### Requirement: Logout clears the auth cookie
+
+A `POST /api/auth/logout` handler SHALL, regardless of whether a valid `recipe_auth` cookie was presented, issue a `Set-Cookie` header that clears `recipe_auth` (`Max-Age=0`) and respond 200 with `{"success": true}`. The operation SHALL be idempotent.
+
+#### Scenario: Logout clears cookie when present
+
+- **WHEN** `POST /api/auth/logout` is invoked with a `recipe_auth` cookie attached
+- **THEN** the response SHALL set a `Set-Cookie` header whose value clears `recipe_auth` with `Max-Age=0`
+- **AND** the response status SHALL be 200
+
+#### Scenario: Logout is idempotent
+
+- **WHEN** `POST /api/auth/logout` is invoked without any `recipe_auth` cookie
+- **THEN** the response SHALL still set the clearing `Set-Cookie` header and respond 200
+
+#### Scenario: Logout rejects non-POST methods
+
+- **WHEN** a non-POST request arrives at `/api/auth/logout`
+- **THEN** the response SHALL be 405 with an `Allow: POST` header
+
+### Requirement: Protected routes read JWT from cookie, not header
+
+`GET /api/auth/me` and `POST /api/recipe/create` SHALL read the bearer token from the `recipe_auth` request cookie and SHALL NOT accept a `recipe-token` request header or an `Authorization: Bearer …` header. When the cookie is absent or empty, these handlers SHALL respond 401 for `create` and 400 for `me` without calling any CMS service.
+
+#### Scenario: Create route reads JWT from cookie
+
+- **WHEN** `POST /api/recipe/create` is invoked with `req.cookies.recipe_auth = "valid-jwt"` and a valid body
+- **THEN** the downstream `createRecipe(body, jwt)` SHALL be called with the raw JWT string `"valid-jwt"` (NOT `"Bearer valid-jwt"`)
+- **AND** the response status SHALL be 200
+
+#### Scenario: Create route rejects missing cookie
+
+- **WHEN** `POST /api/recipe/create` is invoked with `req.cookies.recipe_auth` absent
+- **THEN** the response status SHALL be 401
+- **AND** no CMS-facing `createRecipe` call SHALL be made
+
+#### Scenario: Create route ignores Authorization header
+
+- **WHEN** `POST /api/recipe/create` is invoked with `Authorization: Bearer abc` in headers but no `recipe_auth` cookie
+- **THEN** the response status SHALL be 401 (the header SHALL NOT be honored)
+
+#### Scenario: Me route reads JWT from cookie
+
+- **WHEN** `GET /api/auth/me` is invoked with `req.cookies.recipe_auth = "valid-jwt"` and CMS verify succeeds
+- **THEN** the response status SHALL be 200 with `{success, account: { id, email, username }}`
+
+### Requirement: Client state MUST NOT persist JWT
+
+The recipe app's Redux `AuthState` SHALL consist of `{ isLoggedIn: boolean }` only. No code in `apps/recipe/src/` SHALL read `state.auth.jwt` or write the JWT to `axios.defaults.headers`, `localStorage`, `sessionStorage`, or any other JS-reachable storage.
+
+#### Scenario: AuthState shape
+
+- **WHEN** the auth slice's `initialState` is inspected
+- **THEN** its shape SHALL be `{ isLoggedIn: false }` with no `jwt` key
+
+#### Scenario: No Authorization-header mutation helpers remain
+
+- **WHEN** the source tree is searched for exports named `updateAuthorizationHeader` or `deleteAuthorizationHeader`
+- **THEN** no such export SHALL be found in `apps/recipe/src/redux/`
+
+### Requirement: Service-layer accepts raw JWT, constructs Authorization header internally
+
+`createRecipe(recipe, jwt)` in `apps/recipe/src/services/recipe.ts` SHALL accept the raw JWT string as its second argument and SHALL construct the `Authorization: Bearer <jwt>` header inside the service before calling the CMS. Callers at the API-route layer SHALL NOT construct Bearer strings themselves.
+
+#### Scenario: Service builds the Authorization header
+
+- **WHEN** `createRecipe(validRecipe, "abc")` is invoked
+- **THEN** the CMS call SHALL carry `Authorization: Bearer abc`

--- a/openspec/changes/recipe-auth-and-id-hardening/specs/recipe-cms-id-hygiene/spec.md
+++ b/openspec/changes/recipe-auth-and-id-hardening/specs/recipe-cms-id-hygiene/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: Recipe-ID allow-list at the service layer
+
+`getRecipeById(id)` in `apps/recipe/src/services/recipe.ts` SHALL validate its `id` argument against the pattern `/^[A-Za-z0-9_-]{1,64}$/` before any outbound fetch. When the pattern does not match, the function SHALL return `null` without calling the CMS.
+
+The allow-list pattern SHALL be declared at module top-level (Ultracite `useTopLevelRegex`), exported from `services/recipe.ts` as `RECIPE_ID_PATTERN`, and reused by `pages/recipe/[id].tsx`.
+
+#### Scenario: Allow-listed ID proceeds to CMS
+
+- **WHEN** `getRecipeById("abc123")` is invoked
+- **THEN** `cms.get` SHALL be called with URL path `/recipes/abc123`
+
+#### Scenario: ID with slash is rejected (regression for #547)
+
+- **WHEN** `getRecipeById("../etc/passwd")` is invoked
+- **THEN** the function SHALL return `null`
+- **AND** `cms.get` SHALL NOT be called
+
+#### Scenario: URL-encoded traversal is rejected
+
+- **WHEN** `getRecipeById("..%2Fetc%2Fpasswd")` is invoked
+- **THEN** the function SHALL return `null`
+- **AND** `cms.get` SHALL NOT be called
+
+#### Scenario: Control-character ID is rejected
+
+- **WHEN** `getRecipeById("abc\x00def")` is invoked
+- **THEN** the function SHALL return `null`
+
+#### Scenario: Empty ID is rejected
+
+- **WHEN** `getRecipeById("")` is invoked
+- **THEN** the function SHALL return `null`
+
+#### Scenario: Oversized ID is rejected
+
+- **WHEN** `getRecipeById(<65-char-string>)` is invoked
+- **THEN** the function SHALL return `null`
+
+### Requirement: Defense-in-depth URL encoding
+
+`getRecipeById` SHALL wrap the validated `id` in `encodeURIComponent` before interpolating it into the CMS URL, even though the allow-list already forbids the characters that would need escaping. The encoding SHALL survive any future loosening of the allow-list.
+
+#### Scenario: CMS URL uses encoded ID
+
+- **WHEN** `getRecipeById("abc_123")` is invoked
+- **THEN** the CMS call URL path SHALL be `/recipes/abc_123` (encoding is a no-op for this input, but the `encodeURIComponent` call SHALL be present in the source)
+
+### Requirement: Page-layer ID validation
+
+`getStaticProps` in `apps/recipe/src/pages/recipe/[id].tsx` SHALL apply the same `RECIPE_ID_PATTERN` to `context.params?.id` before calling `getRecipeById`. A mismatch SHALL return `{ notFound: true }` and SHALL NOT trigger a CMS round-trip.
+
+#### Scenario: Page rejects traversal ID with notFound
+
+- **WHEN** `getStaticProps` is invoked with `context.params = { id: "../etc/passwd" }`
+- **THEN** the result SHALL equal `{ notFound: true }`
+- **AND** `getRecipeById` SHALL NOT be called
+
+#### Scenario: Page accepts valid ID and delegates to service
+
+- **WHEN** `getStaticProps` is invoked with `context.params = { id: "42" }`
+- **THEN** `getRecipeById("42")` SHALL be invoked
+- **AND** its return value SHALL determine the page outcome (`props` on success, `notFound: true` on null)

--- a/openspec/changes/recipe-auth-and-id-hardening/tasks.md
+++ b/openspec/changes/recipe-auth-and-id-hardening/tasks.md
@@ -1,0 +1,93 @@
+## 0. Code archaeology (must precede plan)
+
+- [x] 0.1 Confirm the recipe app has no `redux-persist` or equivalent client-side storage of Redux state (grep `persistReducer`, `redux-persist`, `localStorage` under `apps/recipe/src/redux`) — needed to rule out a migration for stored JWTs.
+- [x] 0.2 Enumerate consumers of `state.auth.jwt` (expect two: `redux/slices/auth.ts`, any component destructuring `jwt`). Confirm only `isLoggedIn` is read outside the slice itself (`hooks/useAuth.tsx`).
+- [x] 0.3 Enumerate callers of `api.defaults.headers.common.Authorization` / `updateAuthorizationHeader` / `deleteAuthorizationHeader` — should be contained to `redux/api.ts` + `redux/slices/auth.ts`.
+- [x] 0.4 Confirm `cms.post("recipes", …)` at `services/recipe.ts:31` is the only caller of the header-injected CMS write path; `getRecipes()` + `getRecipeById()` do NOT attach auth (read endpoints on Strapi are public in this app).
+- [x] 0.5 Confirm `cookie@^0.7` is resolvable in the workspace (it's already a Next.js transitive dep); plan to add it as a direct dependency of `apps/recipe` so the import graph is explicit.
+- [x] 0.6 Confirm the page caller `pages/recipe/[id].tsx:89` is the only caller of `getRecipeById`; tests in `src/pages/api/` don't exercise this path so no mock updates needed there.
+
+## 1. Recipe-ID allow-list + encoding (R1 — issue #547)
+
+- [ ] 1.1 Add failing tests in `apps/recipe/src/services/__tests__/recipe.test.ts` for `getRecipeById`:
+  - (a) allow-listed ID `"abc123"` → proceeds (mock cms.get, assert URL path is `/recipes/abc123`)
+  - (b) numeric ID `"42"` → proceeds
+  - (c) 24-char hex ID (Strapi v5 documentId shape) → proceeds
+  - (d) regression: ID containing `/` (`"../etc/passwd"`) → returns `null` without calling `cms.get`
+  - (e) regression: ID containing `%` (`"..%2Fetc%2Fpasswd"`) → returns `null`
+  - (f) regression: ID containing control chars (`"abc\x00def"`) → returns `null`
+  - (g) empty string → returns `null`
+  - (h) oversized ID (>64 chars) → returns `null`
+- [ ] 1.2 Define a top-level `RECIPE_ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/` in `apps/recipe/src/services/recipe.ts` (top-level per Ultracite `useTopLevelRegex`).
+- [ ] 1.3 Rewrite `getRecipeById(id)` in `apps/recipe/src/services/recipe.ts` to: `if (!RECIPE_ID_PATTERN.test(id)) return null;` then `cms.get<Recipe>(\`/recipes/${encodeURIComponent(id)}\`)` — both the allow-list and the encoding land, belt-and-braces.
+- [ ] 1.4 Add matching validation in `apps/recipe/src/pages/recipe/[id].tsx:getStaticProps`: if `context.params.id` fails the same regex, return `{ notFound: true }`. Share the pattern via export from `services/recipe.ts` (NOT via a new barrel).
+- [ ] 1.5 `cd apps/recipe && bun test src/services/__tests__/recipe.test.ts` → all green.
+
+## 2. Cookie helper + login handler (R2 — issue #565)
+
+- [ ] 2.1 Create `apps/recipe/src/pages/api/_lib/auth-cookie.ts` exporting `AUTH_COOKIE_NAME = "recipe_auth" as const`, `serializeAuthCookie(jwt: string): string`, `serializeClearAuthCookie(): string`, and `getAuthToken(req: NextApiRequest): string | null`. `serializeAuthCookie` uses `cookie.serialize` with `httpOnly: true, sameSite: "lax", path: "/", maxAge: 60 * 60 * 24 * 7, secure: process.env.NODE_ENV === "production"`. `serializeClearAuthCookie` emits the same cookie name with `maxAge: 0`.
+- [ ] 2.2 Add `cookie@^0.7.2` to `apps/recipe/package.json` dependencies; run `bun install`.
+- [ ] 2.3 Update `apps/recipe/src/pages/api/auth/login.test.ts`:
+  - Assert `res.setHeader` called with `"Set-Cookie"` and a value containing `"recipe_auth="`, `"HttpOnly"`, `"SameSite=Lax"`, `"Path=/"`, `"Max-Age=604800"`.
+  - Assert the response body passed to `send` is `{ success: true }` (NO `jwt` key).
+- [ ] 2.4 Rewrite `apps/recipe/src/pages/api/auth/login.ts`:
+  - On success, `res.setHeader("Set-Cookie", serializeAuthCookie(jwt))`.
+  - Respond `{ success: true }` — no JWT in body.
+- [ ] 2.5 `bun test src/pages/api/auth/login.test.ts` → all green.
+
+## 3. Logout handler (R2 — issue #565)
+
+- [ ] 3.1 Add new `apps/recipe/src/pages/api/auth/logout.test.ts` covering: POST returns 200 and sets a `Set-Cookie` header that clears `recipe_auth` (`Max-Age=0`); non-POST returns 405.
+- [ ] 3.2 Create `apps/recipe/src/pages/api/auth/logout.ts` — `POST` only; sets the clear cookie; responds `{ success: true }`.
+- [ ] 3.3 `bun test src/pages/api/auth/logout.test.ts` → green.
+
+## 4. Cookie-as-source for protected handlers (R2 — issue #565)
+
+- [ ] 4.1 Add new `apps/recipe/src/pages/api/auth/me.test.ts`:
+  - 400 when `req.cookies.recipe_auth` is absent
+  - 200 with account info when present and verify() succeeds
+  - 403 when verify() throws (invalid/expired token)
+  - 405 on non-GET
+- [ ] 4.2 Rewrite `apps/recipe/src/pages/api/auth/me.ts` to use `getAuthToken(req)` instead of `req.headers["recipe-token"]`. Drop the `recipe-token` header contract entirely.
+- [ ] 4.3 Update `apps/recipe/src/pages/api/recipe/create.test.ts`:
+  - Remove the `bearerTokenSchema`-based cases (missing/non-Bearer/short).
+  - Add a "missing cookie" case → 401, no `createRecipe` call.
+  - Happy path: `req.cookies = { recipe_auth: "valid-token-abc" }` → `createRecipe` called with `(validRecipe, "valid-token-abc")` (raw JWT, NOT `"Bearer valid-token-abc"`).
+- [ ] 4.4 Rewrite `apps/recipe/src/pages/api/recipe/create.ts`:
+  - Replace `bearerTokenSchema.safeParse(req.headers.authorization)` with `const jwt = getAuthToken(req); if (jwt === null) return res.status(401).send({ success: false });`.
+  - Pass raw `jwt` to `createRecipe`.
+- [ ] 4.5 Delete `bearerTokenSchema` from `apps/recipe/src/pages/api/recipe/schemas.ts` — no callers remain.
+- [ ] 4.6 `bun test src/pages/api/auth src/pages/api/recipe` → all green.
+
+## 5. Service-layer signature cleanup (R2 — issue #565)
+
+- [ ] 5.1 Change `createRecipe` in `apps/recipe/src/services/recipe.ts` from `(recipe, authHeader)` to `(recipe, jwt)`. Inside the function, construct `Authorization: \`Bearer ${jwt}\``. Callers pass only the raw JWT.
+- [ ] 5.2 `bun run type-check` at root → green (catches any stale caller).
+
+## 6. Client-side Redux simplification (R2 — issue #565)
+
+- [ ] 6.1 Delete `updateAuthorizationHeader` and `deleteAuthorizationHeader` from `apps/recipe/src/redux/api.ts`. The file becomes the axios-instance-only module.
+- [ ] 6.2 In `apps/recipe/src/redux/slices/auth.ts`:
+  - Shrink `AuthState` to `{ isLoggedIn: boolean }`.
+  - `authLogin.fulfilled`: `state.isLoggedIn = action.payload.success` only; drop JWT writes and `updateAuthorizationHeader` call.
+  - `authLogout`: becomes an async thunk that POSTs `/api/auth/logout` and returns the response. Reducer on `authLogout.fulfilled` resets to `initialState`. Delete the `deleteAuthorizationHeader` call.
+- [ ] 6.3 Update `apps/recipe/src/hooks/useAuth.tsx` `logout` to `async (): Promise<void>`; `await dispatch(authLogout())`.
+- [ ] 6.4 Update `apps/recipe/src/types/auth.d.ts` — drop `jwt` from `LoginResponse` (becomes `{ success: boolean }`); retain `Account` and `VerifyResponse` unchanged.
+- [ ] 6.5 `bun run type-check` at root → green.
+
+## 7. Verification
+
+- [ ] 7.1 `cd apps/recipe && bun test` → all green (expect new tests to dominate the delta).
+- [ ] 7.2 `bun run type-check` at root → green.
+- [ ] 7.3 `bun run lint` at root → green (no `useTopLevelRegex`, no `noBarrelFile` violations; the shared pattern export lives in `services/recipe.ts`, not a barrel).
+- [ ] 7.4 Manual smoke: `cd apps/recipe && bun run dev`, sign in, open devtools → Application → Cookies: `recipe_auth` visible, `HttpOnly` + `SameSite=Lax` attributes checked, no JS-visible cookie (`document.cookie` in console returns empty string for the recipe cookie). Create a recipe via `/create`. Visit `/recipe/42` (valid) → renders. Visit `/recipe/..%2Fetc%2Fpasswd` → 404, no CMS round-trip in Network tab. Log out, confirm the cookie is cleared.
+
+## 8. OpenSpec bookkeeping
+
+- [x] 8.1 `openspec/changes/recipe-auth-and-id-hardening/.openspec.yaml`
+- [x] 8.2 `openspec/changes/recipe-auth-and-id-hardening/proposal.md`
+- [x] 8.3 `openspec/changes/recipe-auth-and-id-hardening/tasks.md` (this file)
+- [ ] 8.4 `openspec/changes/recipe-auth-and-id-hardening/design.md` — cookie attribute rationale, allow-list rationale, why one PR for two issues
+- [ ] 8.5 `openspec/changes/recipe-auth-and-id-hardening/specs/recipe-auth-cookie/spec.md` — ADDED requirements for cookie issue, clear, consumption
+- [ ] 8.6 `openspec/changes/recipe-auth-and-id-hardening/specs/recipe-cms-id-hygiene/spec.md` — ADDED requirements for allow-list + encoding
+- [ ] 8.7 `bunx openspec validate recipe-auth-and-id-hardening` → clean.


### PR DESCRIPTION
## Summary

Closes two high-severity defects at the recipe app's browser → Next.js API → Strapi CMS boundary:

- **Fixes #565** — CMS JWT moved out of Redux state and off `axios.defaults.headers.common.Authorization` onto an `HttpOnly` `recipe_auth` cookie (`SameSite=Lax`, `Path=/`, `Max-Age=604800`, `Secure` in production). An XSS payload on a logged-in page can no longer read the token from JS. New `/api/auth/logout` route clears the cookie; protected routes (`/api/auth/me`, `/api/recipe/create`) read the token via a new `getAuthToken` helper and no longer accept `recipe-token` or `Authorization: Bearer` headers. Service signature `createRecipe(recipe, jwt)` takes the raw JWT — Bearer prefix is constructed inside the service, eliminating a leaky abstraction.
- **Fixes #547** — `getRecipeById(id)` now validates against `/^[A-Za-z0-9_-]{1,64}$/` before issuing the CMS fetch, and wraps the validated ID in `encodeURIComponent` as defense-in-depth. The same pattern guards `getStaticProps` in `pages/recipe/[id].tsx` so a traversal payload becomes a clean 404 with zero CMS round-trip. `RECIPE_ID_PATTERN` is exported from `services/recipe.ts` as the single source of truth.

## Atomic commits

- `48e13aa` :lock: recipe-ID allow-list + `encodeURIComponent` + OpenSpec scaffold (#547)
- `186f283` :lock: server-side cookie plumbing — login/logout/me/create handlers, `auth-cookie.ts` helper, service signature cleanup, retire `bearerTokenSchema` (#565 server half)
- `19a3d75` :lock: client-side cleanup — drop `jwt` from Redux `AuthState`, delete `updateAuthorizationHeader`/`deleteAuthorizationHeader`, `authLogout` async thunk, `useAuth.logout` async (#565 client half)

## OpenSpec

Change `recipe-auth-and-id-hardening` with two new capabilities:

- `recipe-auth-cookie` — cookie issuance, clearing, cookie-as-source for protected routes, client state shape (no JWT), service signature contract.
- `recipe-cms-id-hygiene` — allow-list pattern, URL encoding, page-layer validation.

`bunx openspec validate recipe-auth-and-id-hardening` → clean.

## Deployment notes

- **No env vars added.**
- **No back-compat migration.** No `redux-persist` in the app, so no stored JWTs to invalidate. Users currently authenticated via the old flow will re-log-in once on first visit after deploy — acceptable for a security fix.
- **CSRF.** `SameSite=Lax` is sufficient given the app has no cross-site state-changing flows today. Design doc flags the follow-up if that assumption ever changes.

## Test plan

- [x] `cd apps/recipe && bun test` — 35 pass, 0 fail (up from 12)
- [x] `bun run type-check` at root — green
- [x] `bun run lint` at root — green
- [x] New unit tests: `services/__tests__/recipe.test.ts` (11 cases — allow-list + encoding + raw-JWT signature), `pages/api/auth/logout.test.ts`, `pages/api/auth/me.test.ts`
- [x] Updated: `pages/api/auth/login.test.ts` (asserts `Set-Cookie` shape + no JWT in body), `pages/api/recipe/create.test.ts` (cookie-based auth, raw JWT passed to service)
- [ ] Manual smoke (deferred — requires CMS + dev server): sign in → devtools shows `recipe_auth` with `HttpOnly` + `SameSite=Lax`; `document.cookie` empty of `recipe_auth`; create a recipe; visit `/recipe/42` (valid) → renders; visit `/recipe/..%2Fetc%2Fpasswd` → 404, no CMS hit in Network tab; log out → cookie cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
