### PR TITLE
fix(ResumeDocument): replace hardcoded 'Luke Skywalker' PDF metadata with dynamic values

### DIFF
--- a/apps/blog/src/app/(blog)/profile/resume/ResumeDocument.tsx
+++ b/apps/blog/src/app/(blog)/profile/resume/ResumeDocument.tsx
@@ -175,9 +175,9 @@ export default function ResumeDocument({
     >
       <Document
         author={name}
-        keywords="awesome, resume, start wars"
-        subject="The resume of Luke Skywalker"
-        title="Resume"
+        keywords={`${name}, resume`}
+        subject={`Resume of ${name}`}
+        title={`${name} — Resume`}
       >
         <Page size="A4" style={styles.page} wrap>
           <View wrap={false}>


### PR DESCRIPTION
## Summary

Per #675, the rendered resume PDF shipped with template placeholders in its Document Properties:

- \`subject=\"The resume of Luke Skywalker\"\`
- \`keywords=\"awesome, resume, start wars\"\` (also misspelled \"Star Wars\")
- \`title=\"Resume\"\`

PDF viewers (Adobe Reader, Preview, Chrome) surface these fields, and search engines may index them — so end-users' generated resumes exposed \"Luke Skywalker\" and \"start wars\" in their document properties.

Swapped to dynamic values built from the existing \`name\` prop:

\`\`\`tsx
<Document
  author={name}
  keywords={\`\${name}, resume\`}
  subject={\`Resume of \${name}\`}
  title={\`\${name} — Resume\`}
>
\`\`\`

Did **not** introduce a new \`position\` prop (not threaded through this component); happy to follow up if maintainers want to include it.

Closes #675

## Testing

Single-block props update; existing \`name\` prop is already in scope. No imports changed.