### PR TITLE
:wrench: chore(turbo): drop ^build from test task (#535)

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -14,7 +14,8 @@
       "dependsOn": ["^type-check"]
     },
     "test": {
-      "dependsOn": ["^build"]
+      "dependsOn": [],
+      "outputs": []
     },
     "clean": {
       "cache": false


### PR DESCRIPTION
Tests import workspace source directly; no upstream build artifacts needed. Empty outputs since test run produces no cacheable files.