### PR TITLE
:wrench: fix(ci): mark @howardism/test-config private to unblock release

### DIFF
--- a/packages/test-config/package.json
+++ b/packages/test-config/package.json
@@ -1,9 +1,7 @@
 {
   "name": "@howardism/test-config",
   "version": "0.0.4",
-  "publishConfig": {
-    "access": "public"
-  },
+  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/Howard86/howardism",


### PR DESCRIPTION
## Summary

- Release workflow on `main` failed with `E404 Not Found - PUT https://registry.npmjs.org/@howardism%2ftest-config` ([run 25934368310](https://github.com/howard86/howardism/actions/runs/25934368310/job/76235905892)).
- `@howardism/test-config` is new on npm (404 on GET confirms it was never published) and the `NPM_TOKEN` lacks permission to create new packages in the `@howardism` scope.
- The package is internal tooling — its only consumer is `apps/blog/bunfig.toml` for Bun test preload. No external consumers.
- Marking it `private: true` matches `@howardism/ui` and tells changesets to skip it on publish. `@howardism/tsconfig` stays public (already on npm at 0.0.2; workflow already correctly skips it as "already published").

## Test plan

- [x] `bun install --frozen-lockfile` — no lockfile drift
- [x] `bun test` in `apps/blog` — 79/79 pass, preload still resolves via workspace
- [ ] After merge: confirm Release workflow on `main` no longer attempts to publish `@howardism/test-config`

🤖 Generated with [Claude Code](https://claude.com/claude-code)