### PR TITLE
:bug: fix(ui): scan @howardism/ui sources so Badge chip styles compile

### DIFF
--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -2,6 +2,16 @@
 @plugin "@tailwindcss/typography";
 
 /*
+ * Tailwind v4 doesn't follow workspace imports when auto-detecting sources,
+ * so consumers of this stylesheet would otherwise miss any utility used only
+ * inside @howardism/ui components (e.g. Badge's chip variant `bg-card/60`,
+ * `before:*` dot, `rounded-4xl`, `ring-ring/50`, `has-data-[icon=*]`). The
+ * paths are relative to this file and travel with the package.
+ */
+@source "../components/**/*.{ts,tsx}";
+@source "../lib/**/*.{ts,tsx}";
+
+/*
  * Map CSS custom properties to Tailwind v4 theme tokens.
  * Required so utilities like bg-primary, text-foreground, etc. generate styles.
  */


### PR DESCRIPTION
## Summary

The Menu badge in `Header` and the nav chips in `Footer` were rendering unstyled (no pill background, no terracotta dot). Root cause is a **Tailwind v4 source-scanning gap**, not classic CSS specificity pollution.

Tailwind v4 auto-detects sources only within the consuming app — it does NOT follow workspace imports. Since the blog has no `@source` directive and no `tailwind.config.*`, any utility used exclusively inside `@howardism/ui/src/components/*.tsx` was silently dropped from the compiled CSS.

Verified against the previous build's `apps/blog/.next/static/chunks/*.css`: the Badge `chip` variant was missing all of `bg-card/60`, `before:size-1.5`, `before:shrink-0`, `before:rounded-full`, `before:bg-brand`, `before:content-['']`, plus base CVA classes `rounded-4xl`, `w-fit`, `h-5`, `ring-ring/50`, `group/badge`, `has-data-[icon=*]:pr-1.5`, `aria-invalid:border-destructive`. Only classes that happened to also be used in `apps/blog/src/**` (e.g. `font-mono`, `text-muted-foreground`, `uppercase`) survived — which is why the chip looked like bare uppercase text.

The same bug silently affects every other `@howardism/ui` component used in the blog (Sheet's animation classes, Button variants, etc.); Badge was just the most visible victim because its chip variant depends on `::before` for the dot.

## Fix

Add `@source` directives to `packages/ui/src/styles/globals.css`. Paths are relative to the CSS file, so they travel with the package — every consumer that imports `@howardism/ui/styles/globals.css` automatically gets correct scanning.

```css
@source "../components/**/*.{ts,tsx}";
@source "../lib/**/*.{ts,tsx}";
```

After rebuild, all the previously-missing classes now appear in the compiled CSS (spot-checked `bg-card/60`, `before:size-1.5`, `before:bg-brand`, `before:content-['']`, `ring-ring/50`, `has-data-[icon=inline-end]:pr-1.5`).

## Test plan

- [x] `bun run build` succeeds for the blog app
- [x] `bun run lint` clean
- [x] `bun test` passes (155 tests, 0 fail — run via pre-commit hook)
- [x] Verified compiled CSS contains the previously-missing Badge utility rules
- [ ] Visual check: Menu badge in Header and nav chips in Footer render with the terracotta-dot pill in both light and dark modes

---
_Generated by [Claude Code](https://claude.ai/code/session_015gh6jZtveTQ8drRH6DYKhL)_