### PR TITLE
:recycle: refactor(blog): SunDisc as transparent wireframe globe

### DIFF
--- a/apps/blog/src/components/howardism/sun-disc.tsx
+++ b/apps/blog/src/components/howardism/sun-disc.tsx
@@ -1,5 +1,3 @@
-import { GRAIN_SVG } from "./grain";
-
 interface SunDiscProps {
   accent?: string;
   className?: string;
@@ -11,6 +9,15 @@ interface SunDiscProps {
 const LABEL_CLASS =
   "whitespace-nowrap font-mono text-[10px] text-foreground-subtle uppercase tracking-[0.18em]";
 
+const SPHERE_RADIUS = 99.2;
+const PARALLEL_OFFSET = 40;
+const PARALLEL_RADIUS = 91;
+const PARALLEL_DEPTH = 11;
+const EQUATOR_DEPTH = 12;
+const MERIDIAN_COUNT = 6;
+const ROTATION_DURATION_S = 30;
+const AXIAL_TILT_DEG = 23.5;
+
 export function SunDisc({
   size = 420,
   plate = "Plate I · Surface",
@@ -18,7 +25,7 @@ export function SunDisc({
   accent,
   className,
 }: SunDiscProps) {
-  const bgAccent = accent ?? "var(--brand)";
+  const stroke = accent ?? "var(--brand)";
   return (
     <div
       className={className}
@@ -30,18 +37,55 @@ export function SunDisc({
         aspectRatio: "1/1",
       }}
     >
-      <div
-        className="absolute inset-0 rounded-full"
-        style={{
-          background: `radial-gradient(circle at 35% 30%, oklch(from ${bgAccent} 0.82 0.09 h) 0%, oklch(from ${bgAccent} 0.56 0.15 h) 55%, oklch(from ${bgAccent} 0.38 0.1 h) 100%)`,
-          boxShadow: `0 40px 80px -30px oklch(from ${bgAccent} 0.4 0.14 h / 0.45), inset 0 -20px 60px oklch(from ${bgAccent} 0.3 0.1 h / 0.35)`,
-        }}
-      />
-      <div
+      <svg
         aria-hidden="true"
-        className="absolute inset-0 rounded-full opacity-60 mix-blend-overlay"
-        style={{ backgroundImage: GRAIN_SVG }}
-      />
+        className="absolute inset-0 h-full w-full"
+        style={{
+          transform: `rotate(-${AXIAL_TILT_DEG}deg)`,
+          transformOrigin: "center",
+        }}
+        viewBox="-100 -100 200 200"
+      >
+        <title>Wireframe globe</title>
+        <g fill="none" stroke={stroke} strokeLinecap="round">
+          <circle
+            cx={0}
+            cy={0}
+            opacity={0.7}
+            r={SPHERE_RADIUS}
+            strokeWidth={1}
+          />
+          <g opacity={0.5} strokeWidth={0.8}>
+            <ellipse cx={0} cy={0} rx={SPHERE_RADIUS} ry={EQUATOR_DEPTH} />
+            <ellipse
+              cx={0}
+              cy={-PARALLEL_OFFSET}
+              rx={PARALLEL_RADIUS}
+              ry={PARALLEL_DEPTH}
+            />
+            <ellipse
+              cx={0}
+              cy={PARALLEL_OFFSET}
+              rx={PARALLEL_RADIUS}
+              ry={PARALLEL_DEPTH}
+            />
+            {Array.from({ length: MERIDIAN_COUNT }).map((_, i) => (
+              <ellipse
+                className="hw-disc-meridian"
+                cx={0}
+                cy={0}
+                // biome-ignore lint/suspicious/noArrayIndexKey: stable static count
+                key={i}
+                rx={SPHERE_RADIUS}
+                ry={SPHERE_RADIUS}
+                style={{
+                  animationDelay: `-${(i * ROTATION_DURATION_S) / MERIDIAN_COUNT}s`,
+                }}
+              />
+            ))}
+          </g>
+        </g>
+      </svg>
       {number && (
         <div className="absolute -top-3 -left-3">
           <span className={LABEL_CLASS}>{number}</span>

--- a/apps/blog/src/styles/howardism.css
+++ b/apps/blog/src/styles/howardism.css
@@ -89,6 +89,11 @@ html.dark .hw-grain::after {
   .hw-page-enter {
     animation: hw-page-in 0.45s cubic-bezier(0.2, 0.7, 0.2, 1);
   }
+  .hw-disc-meridian {
+    transform-origin: center;
+    transform-box: fill-box;
+    animation: hw-disc-meridian-spin 30s linear infinite;
+  }
 }
 
 @keyframes hw-page-in {
@@ -99,5 +104,17 @@ html.dark .hw-grain::after {
   to {
     opacity: 1;
     transform: none;
+  }
+}
+
+@keyframes hw-disc-meridian-spin {
+  0%,
+  50%,
+  100% {
+    transform: scaleX(1);
+  }
+  25%,
+  75% {
+    transform: scaleX(0);
   }
 }


### PR DESCRIPTION
## Summary
- Replaces the radial-gradient sun motif with an SVG wireframe globe: outer rim, equator + two tropics, and six meridian ellipses animated via CSS keyframes to read as Earth-like rotation.
- Tilted 23.5° on the axis, ~30s per revolution; animation gated on `prefers-reduced-motion: no-preference` so reduced-motion users see a static wireframe.
- No JS — pure SVG + CSS. Grain overlay and drop shadow dropped (nothing to render against with no fill); number/plate labels preserved.

Split into two atomic commits: keyframes first (additive), then the component rewrite that consumes them.

## Test plan
- [ ] `cd apps/blog && bun run dev` and open `/` — confirm the hero shows a tilted, slowly rotating wireframe in terracotta with parallels visibly static and meridians sweeping.
- [ ] Toggle OS-level reduced motion → meridians stop animating, wireframe still renders.
- [ ] `bun run type-check` and `bun run test` pass (verified locally: 79/79).
- [ ] Quick check in dark mode — stroke color (`var(--brand)`) still legible against the dark background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)