### PR TITLE
fix: filter entities in getVisibleArticles to drop archived articles (#759)

### DIFF
--- a/apps/blog/src/__tests__/articles/service.test.ts
+++ b/apps/blog/src/__tests__/articles/service.test.ts
@@ -91,6 +91,19 @@ describe("tag-aware service helpers", () => {
     }
   });
 
+  it("getVisibleArticles keeps ids and entities in sync (no archived leak)", async () => {
+    const visible = await getVisibleArticles();
+
+    expect(Object.keys(visible.entities).length).toBe(visible.ids.length);
+    for (const id of visible.ids) {
+      expect(visible.entities[id]).toBeDefined();
+    }
+    for (const key of Object.keys(visible.entities)) {
+      expect(visible.ids).toContain(key);
+      expect(visible.entities[key]?.meta.archived).not.toBe(true);
+    }
+  });
+
   it("getSlicedArticles keeps ids and entities in sync", async () => {
     const sliced = await getSlicedArticles(3);
     expect(sliced.ids.length).toBe(3);

--- a/apps/blog/src/app/(blog)/articles/service.ts
+++ b/apps/blog/src/app/(blog)/articles/service.ts
@@ -169,7 +169,11 @@ export const getVisibleArticles = cache(
   async (): Promise<Normalise<ArticleEntity>> => {
     const all = await getArticles();
     const ids = all.ids.filter((id) => !all.entities[id]?.meta.archived);
-    return { ids, entities: all.entities };
+    const entities: Record<string, ArticleEntity | undefined> = {};
+    for (const id of ids) {
+      entities[id] = all.entities[id];
+    }
+    return { ids, entities };
   }
 );
 


### PR DESCRIPTION
Fixes #759.

## Problem

`getVisibleArticles` filtered `ids` to drop archived articles but returned the **unfiltered** `entities` map (`return { ids, entities: all.entities }`). Helpers that look entities up by id (e.g. backlinks/related graph navigation) could therefore still surface archived articles, violating the `Normalise<ArticleEntity>` invariant that `ids` and `entities` stay in sync.

## Fix

`apps/blog/src/app/(blog)/articles/service.ts` — rebuild the `entities` map from the filtered `ids` so the returned view contains only visible (non-archived) articles.

## Tests

Added a regression test in `apps/blog/src/__tests__/articles/service.test.ts` asserting `ids`/`entities` stay in sync and that no archived article leaks through `entities`.

Verified in this session (`apps/blog`): `tsc --noEmit` exits clean; `bun test` reports 77 pass / 0 fail, including the new regression test.

Generated by Claude Code. Please review before merging.
