### PR TITLE
fix: escape < unconditionally in wiki prose to prevent MDX build failure (#762)

### DIFF
--- a/apps/cli/src/__tests__/transform.test.ts
+++ b/apps/cli/src/__tests__/transform.test.ts
@@ -203,9 +203,17 @@ describe("escapeMdxBody", () => {
     expect(lines[4]).toBe("after \\{y\\}");
   });
 
-  it("leaves < before a letter alone (it might be valid JSX)", () => {
+  it("escapes < before a letter so generic types in prose don't break MDX", () => {
+    const input =
+      "Returns a Promise<T> that resolves to a Map<string, number>.";
+    expect(escapeMdxBody(input)).toBe(
+      "Returns a Promise&lt;T> that resolves to a Map&lt;string, number>."
+    );
+  });
+
+  it("escapes < in raw JSX/HTML prose so it renders as literal text", () => {
     const input = '<Image alt="x" />';
-    expect(escapeMdxBody(input)).toBe(input);
+    expect(escapeMdxBody(input)).toBe('&lt;Image alt="x" />');
   });
 
   it("preserves inline code spans", () => {

--- a/apps/cli/src/import-wiki/transform.ts
+++ b/apps/cli/src/import-wiki/transform.ts
@@ -9,7 +9,6 @@ export interface SourceRef {
 // Obsidian convention for embedding pipes inside markdown tables.
 const WIKI_LINK_RE = /\[\[([^\]|\\]+)(?:\\?\|([^\]]+))?\]\]/g;
 const FENCE_RE = /^(\s*)(```+|~~~+)/;
-const HTML_TAG_HINT_RE = /^[A-Za-z!/]/;
 const WORD_RE = /\b\w+\b/g;
 const LEADING_H1_RE = /^#\s+.+\n+/;
 const TRAILING_PUNCT_RE = /[.\s]+$/;
@@ -297,8 +296,7 @@ function escapeProseChar(line: string, i: number): string {
     return `\\${ch}`;
   }
   if (ch === "<") {
-    const next = line[i + 1] ?? "";
-    return HTML_TAG_HINT_RE.test(next) ? ch : "&lt;";
+    return "&lt;";
   }
   return ch;
 }


### PR DESCRIPTION
Fixes #762.

## Problem

`escapeProseChar` (in `apps/cli/src/import-wiki/transform.ts`) left `<` **unescaped** when the next character matched `/^[A-Za-z!/]/`, a heuristic meant to let raw HTML/JSX tags through. The same heuristic silently passes generic-type notation in prose — `Promise<T>`, `Map<string, number>`, `List<E>` — which the MDX compiler then parses as a JSX element opener, aborting `next build`. The corrupted `.mdx` is committed without the importer detecting it.

## Fix

Escape `<` unconditionally to `&lt;` in prose. Inline code (backtick spans) and fenced code blocks are still preserved verbatim by `escapeLine`/`escapeMdxBody`, so legitimate `<` inside code is unaffected. Removed the now-unused `HTML_TAG_HINT_RE`.

This matches the issue's recommended fix.

## Behavior change (please review)

Raw HTML/JSX tags written directly in wiki **prose** (e.g. `<Image alt="x" />`) now render as **literal text** (`&lt;Image alt="x" />`) instead of being passed through as JSX. This reverses the prior intent encoded by the test "leaves `<` before a letter alone (it might be valid JSX)". Authors needing literal HTML/JSX should use backtick spans or fenced code blocks. This is the safe trade the issue calls for, but flagging it explicitly since it changes an intentional prior behavior.

## Tests

Updated `apps/cli/src/__tests__/transform.test.ts`: replaced the test asserting the old pass-through behavior with one asserting generic types in prose are escaped (`Promise<T>` -> `Promise&lt;T>`), plus one asserting raw JSX prose becomes literal text.

Verified in this session by running, from `apps/cli`:
- `bun run type-check` (`tsc --noEmit`) -> exit 0
- `bun x ultracite check` on the two changed files -> "Checked 2 files. No fixes applied."
- `bun run test` (`bun test`) -> "77 pass / 0 fail, 131 expect() calls, Ran 77 tests across 4 files" (the cli suite: transform/parse/graph/codex). Note the count coincidentally equals the apps/blog suite's; this is the apps/cli run, distinguishable by its 4 test files and 131 expect() calls.

Generated by Claude Code. Please review before merging.
