### PR TITLE
fix: emit robots noindex for archived articles (#763)

### DIFF
--- a/apps/blog/src/app/(blog)/articles/[slug]/page.tsx
+++ b/apps/blog/src/app/(blog)/articles/[slug]/page.tsx
@@ -44,6 +44,9 @@ export async function generateMetadata({
     title: mod.meta.title,
     description: mod.meta.description,
     alternates: { canonical: url },
+    ...(mod.meta.archived === true && {
+      robots: { index: false, follow: false },
+    }),
     openGraph: {
       type: "article",
       url,


### PR DESCRIPTION
Fixes #763.

## Problem

Articles with `archived: true` in frontmatter keep live static pages at `/articles/[slug]` (they stay in `generateStaticParams` via `getArticles()`), but are excluded from the sitemap, articles index, and RSS feed (which use `getVisibleArticles()`). Because `generateMetadata` never inspected `meta.archived`, no `noindex` directive was emitted, so search engines that reach an archived URL via an inbound link would crawl and index de-listed content.

## Fix

`apps/blog/src/app/(blog)/articles/[slug]/page.tsx` — `generateMetadata` now spreads `robots: { index: false, follow: false }` into the returned `Metadata` when `mod.meta.archived === true`. URLs stay live (no 404), but archived pages signal de-listing to crawlers. This matches the issue's recommended fix; non-archived articles are unchanged.

## Tests

No automated regression test added: `generateMetadata` dynamically imports article modules via a runtime template path (`@/content/articles/${slug}.mdx`), which the bun/happy-dom test environment cannot load and which is impractical to mock without disproportionate scaffolding for a three-line conditional. There are also no archived articles in `src/content` to exercise it. The change is a guarded metadata addition with no effect on the non-archived path.

Verified in this session by running, from `apps/blog`:
- `bun run type-check` (`tsc --noEmit`) -> exit 0
- `bun run test` (`bun test`) -> "76 pass / 0 fail, 290 expect() calls, Ran 76 tests across 10 files" (unchanged from baseline; the existing suite does not cover page-level metadata).

Generated by Claude Code. Please review before merging.
