### PR TITLE
fix: strip upgrade-insecure-requests from any CSP under insecureTransport (#764)

### DIFF
--- a/apps/blog/src/config/security-headers.ts
+++ b/apps/blog/src/config/security-headers.ts
@@ -54,9 +54,9 @@ export interface SecurityHeaderOptions {
    * and the `upgrade-insecure-requests` CSP directive. The dev server is plain
    * HTTP and Safari honours HSTS (and request upgrades) on `localhost`, so
    * leaving these on makes Safari refuse to connect over HTTP with a TLS
-   * handshake error. Only strips `upgrade-insecure-requests` from the default
-   * directives; an explicitly passed `contentSecurityPolicy` is left untouched.
-   * Defaults to `false`.
+   * handshake error. Strips `upgrade-insecure-requests` from the effective
+   * directives — whether the default policy or an explicitly passed
+   * `contentSecurityPolicy`. Defaults to `false`.
    */
   insecureTransport?: boolean;
 }
@@ -136,10 +136,10 @@ export function getSecurityHeaders({
     return headers;
   }
 
-  let directives = contentSecurityPolicy ?? DEFAULT_CSP_DIRECTIVES;
-  if (insecureTransport && directives === DEFAULT_CSP_DIRECTIVES) {
-    const { "upgrade-insecure-requests": _omit, ...rest } =
-      DEFAULT_CSP_DIRECTIVES;
+  let directives: CspDirectives =
+    contentSecurityPolicy ?? DEFAULT_CSP_DIRECTIVES;
+  if (insecureTransport) {
+    const { "upgrade-insecure-requests": _omit, ...rest } = directives;
     directives = rest;
   }
   const cspValue = serializeCsp(directives);

--- a/apps/blog/test/config/security-headers.test.ts
+++ b/apps/blog/test/config/security-headers.test.ts
@@ -68,14 +68,21 @@ describe("getSecurityHeaders", () => {
     expect(csp?.value).toContain("default-src 'self'");
   });
 
-  it("leaves an explicit CSP untouched when insecureTransport is true", () => {
+  it("strips upgrade-insecure-requests from a custom CSP when insecureTransport is true", () => {
+    // Mirrors next.config.ts, which passes a spread copy of the defaults. The
+    // old identity check only stripped the exact DEFAULT_CSP_DIRECTIVES
+    // reference, so the directive leaked into dev-server headers.
     const headers = getSecurityHeaders({
       geolocation: "()",
       insecureTransport: true,
-      contentSecurityPolicy: { "upgrade-insecure-requests": true },
+      contentSecurityPolicy: {
+        ...DEFAULT_CSP_DIRECTIVES,
+        "script-src": ["'self'", "'unsafe-inline'"],
+      },
     });
     const csp = headers.find((h) => h.key === "Content-Security-Policy");
-    expect(csp?.value).toBe("upgrade-insecure-requests");
+    expect(csp?.value).not.toContain("upgrade-insecure-requests");
+    expect(csp?.value).toContain("default-src 'self'");
   });
 
   it("suppresses the CSP header entirely when contentSecurityPolicy is false", () => {


### PR DESCRIPTION
Fixes #764.

## Problem

`getSecurityHeaders` decided whether to strip the `upgrade-insecure-requests` CSP directive (when `insecureTransport: true`) using a **reference-identity** check: `directives === DEFAULT_CSP_DIRECTIVES`. `next.config.ts` — the only consumer — passes a **spread copy** (`{ ...DEFAULT_CSP_DIRECTIVES, "script-src": [...], "connect-src": [...] }`), a new object, so the check was always `false` and the directive was emitted verbatim in every dev-server response. That contradicts `next.config.ts`'s own intent (`insecureTransport: process.env.NODE_ENV !== "production"`) and its comment about Safari refusing plain-HTTP `localhost` connections when HTTPS-forcing directives are present.

## Fix

`apps/blog/src/config/security-headers.ts` — strip `upgrade-insecure-requests` from the effective directives (default **or** an explicitly passed policy) whenever `insecureTransport` is set, instead of only when the exact default reference is passed.

## Behavior change (please review)

This **reverses** the previous "an explicitly passed `contentSecurityPolicy` is left untouched" contract for the `upgrade-insecure-requests` directive — previously documented in the `insecureTransport` JSDoc and locked in by the test "leaves an explicit CSP untouched when insecureTransport is true".

I judged this safe because `security-headers.ts` is app-local with a **single consumer** (`next.config.ts`), which demonstrably *intends* the dev-time strip. No other code relies on the old carve-out. The alternative (fix the caller in `next.config.ts` instead) is also viable but more awkward and leaves the same trap for future consumers. Flagging the contract change explicitly so you can veto if you'd rather keep the library contract and fix the caller.

Updated the JSDoc to match, and replaced the now-incorrect test with one that mirrors `next.config.ts`'s spread-copy scenario (the actual regression).

## Tests

Verified in this session by running, from `apps/blog`:
- `bun run type-check` (`tsc --noEmit`) -> exit 0
- `bun x ultracite check` on the two changed files -> "Checked 2 files. No fixes applied."
- `bun test test/config/security-headers.test.ts` -> 15 pass / 0 fail
- `bun run test` (full blog suite) -> "76 pass / 0 fail, 291 expect() calls, Ran 76 tests across 10 files"

Generated by Claude Code. Please review before merging.
