### PR TITLE
fix: skip emitting archived wiki articles (#765)

### DIFF
--- a/apps/cli/src/import-wiki/index.ts
+++ b/apps/cli/src/import-wiki/index.ts
@@ -105,7 +105,14 @@ async function main(): Promise<void> {
   const ctx = await buildImportContext(opts);
   const summary = createSummary();
 
-  await runWithConcurrency(ctx.parsedAll, IMAGE_CONCURRENCY, (parsed) =>
+  // Archived articles are excluded from the link graph; drop them from the MDX
+  // emission pipeline too so an author's `archived: true` keeps the entry off
+  // the public blog. Mirrors the graph builder's predicate in emitGraph.
+  const toEmit = ctx.parsedAll.filter(
+    (parsed) => parsed.frontmatter.archived !== true
+  );
+
+  await runWithConcurrency(toEmit, IMAGE_CONCURRENCY, (parsed) =>
     processArticle(parsed, ctx, opts, summary)
   );
 


### PR DESCRIPTION
Fixes #765.

## Problem

The `import-wiki` pipeline read `archived: true` from a wiki article's frontmatter and excluded it from the link graph, but **never excluded it from MDX emission** and **never wrote `archived: true` into the generated frontmatter**. Every archived wiki article therefore shipped to the blog as a fully visible, non-archived post — appearing in the articles index, sitemap, and RSS feed (since `getVisibleArticles` filters on a `meta.archived` field that was absent).

## Fix (Option A)

`apps/cli/src/import-wiki/index.ts` — filter out `archived: true` articles before the emission pass (`runWithConcurrency` → `processArticle`), using the same predicate the graph builder already applies in `emitGraph`. Archived entries are now dropped from emission, so they never reach the public blog.

## Why Option A over Option B

The issue offered two options: (A) skip emission entirely, or (B) emit with `archived: true` frontmatter and keep the page live-but-hidden (which would pair with the `robots: noindex` work in #763). I chose A because:

- The author's documented intent in `parse.ts` states archived articles are "dropped from the link graph and (eventually) the **MDX emission pipeline**" — i.e. excluded from emission, which is exactly Option A.
- It is the privacy-safest reading of "archived = not ready for public": the article is not published at all, rather than published-but-accessible-by-URL.
- The issue itself notes A "is simpler and matches the behaviour users expect."

If you'd rather keep archived articles live at their URL but hidden from navigation (Option B), that's the alternative — it would lean on the #763 noindex guard. Flagging the choice since A and B have different public-exposure semantics.

## Tests

No regression test added: the emission filter lives inside the unexported `main()` orchestrator (filesystem writes + image generation), which has no test harness; exercising it would require disproportionate fs/image mocking or an export-for-testing refactor beyond the minimum change. The predicate is identical to the graph builder's `isArchived`, whose exclusion behaviour is already covered by `graph.test.ts` ("excludes archived nodes entirely...").

Verified in this session by running, from `apps/cli`:
- `bun run type-check` (`tsc --noEmit`) -> exit 0
- `bun x ultracite check apps/cli/src/import-wiki/index.ts` -> "Checked 1 file. No fixes applied."
- `bun run test` (`bun test`) -> "76 pass / 0 fail, 130 expect() calls, Ran 76 tests across 4 files" (the cli suite: transform/parse/graph/codex).

Generated by Claude Code. Please review before merging.
