### PR TITLE
fix: set canonical URL on /articles/tag index pages (#766)

### DIFF
--- a/apps/blog/src/app/(blog)/articles/tag/[tag]/page.tsx
+++ b/apps/blog/src/app/(blog)/articles/tag/[tag]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
 import { DiscPageHeader } from "@/components/howardism/disc-page-header";
+import { env } from "@/config/env";
 import { formatDateShort } from "@/utils/time";
 
 import { ArticlesTable } from "../../articles-table";
@@ -34,9 +35,12 @@ export async function generateMetadata({
   if (!section) {
     return { title: "Not found — Howardism" };
   }
+  const url = `${env.NEXT_PUBLIC_DOMAIN_NAME}/articles/tag/${section.slug}`;
   return {
     title: `${section.title} articles — Howardism`,
     description: section.metaDescription,
+    alternates: { canonical: url },
+    openGraph: { url },
   };
 }
 


### PR DESCRIPTION
Fixes #766.

## Problem

The four `/articles/tag/[tag]` pages (`concept`, `entity`, `essay`, `index`) set no `alternates.canonical` in `generateMetadata`. Next.js shallow-merges nested `alternates` from the root `(blog)/layout.tsx`, whose `alternates.canonical` is the homepage URL — so every tag index page declared `https://www.howardism.dev/` as its canonical URL, risking de-duplication/demotion by search engines.

## Fix

`apps/blog/src/app/(blog)/articles/tag/[tag]/page.tsx` — `generateMetadata` now sets `alternates.canonical` and `openGraph.url` to the page's own URL (`${NEXT_PUBLIC_DOMAIN_NAME}/articles/tag/${section.slug}`), mirroring the existing pattern in `articles/page.tsx`.

## Scope note

This issue's proposed fix also suggested adding the tag pages to `sitemap.ts`. That sitemap omission is the subject of a **separate** open issue, **#769**, so I intentionally left it out here to avoid a double-fix / merge conflict between the two PRs. This PR is the canonical fix only — which the issue itself flags as the higher-priority item.

## Tests

No regression test added: the blog has no page-`generateMetadata` tests by convention (importing a page module pulls in its full component + data-service graph), and this is a declarative metadata addition identical to the established `articles/page.tsx` pattern. Same rationale as #763.

Verified in this session by running, from `apps/blog`:
- `bun run type-check` (`tsc --noEmit`) -> exit 0
- `bun x ultracite check` on the changed file -> "Checked 1 file. No fixes applied."
- `bun run test` (`bun test`) -> "76 pass / 0 fail, 290 expect() calls, Ran 76 tests across 10 files" — unchanged from the origin/main baseline, since this change adds no test.

Generated by Claude Code. Please review before merging.
