### PR TITLE
fix: stop bleeding link className into InternalLink hover card (#768)

### DIFF
--- a/apps/blog/src/components/internal-link.tsx
+++ b/apps/blog/src/components/internal-link.tsx
@@ -5,7 +5,6 @@ import {
   HoverCardContent,
   HoverCardTrigger,
 } from "@howardism/ui/components/hover-card";
-import { cn } from "@howardism/ui/lib/utils";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import type { ComponentProps } from "react";
@@ -72,7 +71,7 @@ export function InternalLink({
       </HoverCardTrigger>
       <HoverCardContent
         align="start"
-        className={cn("max-w-[320px] bg-background/90 p-3.5", className)}
+        className="max-w-[320px] bg-background/90 p-3.5"
         id={describedById}
         role="dialog"
         side="top"


### PR DESCRIPTION
Fixes #768.

## Problem

`InternalLink` applied the caller's `className` to both the `<Link>` trigger **and** the `<HoverCardContent>` popup (`cn("max-w-[320px] bg-background/90 p-3.5", className)`). Link-only utilities like `hover:text-brand`, `font-display`, `font-medium`, and `text-[0.95rem]` therefore landed on the card container. Once the cursor entered the popup, `hover:text-brand` fired on the container and forced every descendant to the brand colour, collapsing the card's `text-muted-foreground` / `text-brand` hierarchy; the font utilities overrode the card's own typography.

## Fix

`apps/blog/src/components/internal-link.tsx` — `HoverCardContent` now uses only its own fixed design tokens (`"max-w-[320px] bg-background/90 p-3.5"`). The caller's `className` continues to flow to the `<Link>` trigger (both the plain and hover-card branches), which is correct. Removed the now-unused `cn` import.

## Tests

No regression test added: the component's own comment notes that "Radix's portal + open-state behaviour doesn't unwrap cleanly under happy-dom" — which is exactly why the existing tests render `InternalLinkPreviewBody` in isolation. Asserting on the open `HoverCardContent`'s resolved className is therefore not feasible in this test environment. The change is the removal of a className pass-through with no behavioural branch.

Verified in this session by running, from `apps/blog`:
- `bun run type-check` (`tsc --noEmit`) -> exit 0
- `bun x ultracite check apps/blog/src/components/internal-link.tsx` -> "Checked 1 file. No fixes applied."
- `bun test src/__tests__/components/internal-link.test.tsx src/__tests__/articles/backlinks-disclosure.test.tsx` -> 16 pass / 0 fail
- `bun run test` (full blog suite) -> "76 pass / 0 fail, 290 expect() calls, Ran 76 tests across 10 files"

Generated by Claude Code. Please review before merging.
