### PR TITLE
fix: advertise /articles/tag pages in sitemap (#769)

### DIFF
--- a/apps/blog/src/__tests__/sitemap.test.ts
+++ b/apps/blog/src/__tests__/sitemap.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "bun:test";
+
+import { TAG_SECTIONS } from "@/app/(blog)/articles/tag-sections";
+import sitemap from "@/app/sitemap";
+
+describe("sitemap", () => {
+  it("includes an entry for every /articles/tag section page", async () => {
+    const entries = await sitemap();
+    const urls = entries.map((entry) => entry.url);
+
+    for (const section of TAG_SECTIONS) {
+      expect(
+        urls.some((url) => url.endsWith(`/articles/tag/${section.slug}`))
+      ).toBe(true);
+    }
+  });
+
+  it("still includes the home and articles index entries", async () => {
+    const entries = await sitemap();
+    const urls = entries.map((entry) => entry.url);
+
+    expect(urls.some((url) => url.endsWith("/articles"))).toBe(true);
+    expect(urls.length).toBeGreaterThanOrEqual(2 + TAG_SECTIONS.length);
+  });
+});

--- a/apps/blog/src/app/sitemap.ts
+++ b/apps/blog/src/app/sitemap.ts
@@ -1,11 +1,19 @@
 import type { MetadataRoute } from "next";
 
 import { getVisibleArticles } from "@/app/(blog)/articles/service";
+import { TAG_SECTIONS } from "@/app/(blog)/articles/tag-sections";
 import { env } from "@/config/env";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const visible = await getVisibleArticles();
   const baseUrl = env.NEXT_PUBLIC_DOMAIN_NAME;
+
+  const tagEntries: MetadataRoute.Sitemap = TAG_SECTIONS.map((section) => ({
+    url: `${baseUrl}/articles/tag/${section.slug}`,
+    lastModified: new Date(),
+    changeFrequency: "weekly" as const,
+    priority: 0.85,
+  }));
 
   const articleEntries: MetadataRoute.Sitemap = visible.ids.flatMap((slug) => {
     const entity = visible.entities[slug];
@@ -35,6 +43,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: "weekly",
       priority: 0.9,
     },
+    ...tagEntries,
     ...articleEntries,
   ];
 }


### PR DESCRIPTION
Fixes #769.

## Problem

`apps/blog/src/app/sitemap.ts` emitted entries for the home page, the articles index, and individual articles, but omitted the four statically-generated `/articles/tag/[tag]` section pages (`concept`, `entity`, `essay`, `index`). They were discoverable only via crawl links, not advertised in `sitemap.xml`.

## Fix

Import the canonical `TAG_SECTIONS` list and append a sitemap entry per section, placed between the articles index and individual articles to reflect the site hierarchy (`weekly` change frequency, priority `0.85` — above individual articles at `0.8`, below `/articles` at `0.9`).

## Tests

Added `apps/blog/src/__tests__/sitemap.test.ts` asserting that `sitemap()` contains an entry for every `TAG_SECTIONS` slug, plus the home/articles-index entries. (The sitemap function is unit-testable: it calls `getVisibleArticles`, the same path exercised by the existing `service.test.ts`.)

Verified in this session by running, from `apps/blog`:
- `bun run type-check` (`tsc --noEmit`) -> exit 0
- `bun x ultracite check` on both changed files -> "No fixes applied."
- `bun test src/__tests__/sitemap.test.ts` -> 2 pass / 0 fail
- `bun run test` (full blog suite) -> "78 pass / 0 fail, 296 expect() calls, Ran 78 tests across 11 files" (up from the 76/10-files baseline by the two new sitemap tests).

## Note

This is the sitemap half I intentionally deferred from #766 (the canonical-URL fix for the same tag pages, PR #787). The two are complementary and touch different files.

Generated by Claude Code. Please review before merging.
