### PR TITLE
fix: close useScrollSpy TOC dead zone at tall viewports (#772)

### DIFF
--- a/apps/blog/src/hooks/use-scroll-spy.ts
+++ b/apps/blog/src/hooks/use-scroll-spy.ts
@@ -17,10 +17,12 @@ const DEFAULT_FALLBACK_OFFSET_PX = 96;
  * this keeps the highlight on the section the reader is currently inside,
  * rather than snapping back to the first when scrolling past a long block.
  *
- * Caller is responsible for the rootMargin via mutating the observer or
- * accepting the default band. The current band ("-12% 0px -65% 0px") is
- * intentional: highlights what's near the top of the viewport, not what's
- * about to leave from the bottom.
+ * The observer's top margin is tied to `fallbackOffsetPx` (default 96px) so
+ * the intersection band and the fallback anchor share a single threshold —
+ * otherwise a viewport-relative top margin and a fixed-pixel fallback drift
+ * apart and open a dead zone where neither strategy fires. The bottom margin
+ * (-65%) highlights what's near the top of the viewport, not what's about to
+ * leave from the bottom.
  */
 export default function useScrollSpy({
   defaultSectionId = null,
@@ -68,7 +70,7 @@ export default function useScrollSpy({
         }
         recompute();
       },
-      { rootMargin: "-12% 0px -65% 0px", threshold: 0 }
+      { rootMargin: `-${fallbackOffsetPx}px 0px -65% 0px`, threshold: 0 }
     );
 
     for (const el of elements) {


### PR DESCRIPTION
Fixes #772.

## Problem

`useScrollSpy` used two detection strategies with mismatched units: the `IntersectionObserver` top cut-off was `-12%` (of viewport height) while the fallback anchor (`findLastAboveAnchorId`) used a fixed `fallbackOffsetPx = 96`. The two thresholds are equal only at `vh = 800px`. At taller viewports a dead zone opens between them (24px at 1000px, ~77px at 1440px); a heading parked in that zone is neither "intersecting" nor "above the fallback anchor", so `recompute` falls through to `elements[0].id` and the TOC highlights the first heading instead of the current section. (Shorter viewports invert the gap.)

## Fix

`apps/blog/src/hooks/use-scroll-spy.ts` — tie the observer's top `rootMargin` to the same `fallbackOffsetPx` the fallback uses:

```
rootMargin: `-${fallbackOffsetPx}px 0px -65% 0px`
```

Now both strategies share a single threshold value, so they can never drift — the dead zone is closed at every viewport height, and it stays closed after a window resize (the observer recomputes its margins against the live viewport, and the fallback uses the identical pixel value). The bottom margin (`-65%`) is unchanged.

## Why this over the issue's primary proposal

The issue's primary suggestion was to compute `fallbackPx = window.innerHeight * 0.12` inside the effect. That fixes the dead zone at mount, but the effect's deps are `[sectionIds, fallbackOffsetPx]`, so `fallbackPx` is **not** recomputed on resize — the observer's percentage margin would then drift from the stale fallback px and reopen the gap (the issue flags a `resize` listener as a separate "adds complexity" alternative). The chosen approach (the issue's "alternative 1") needs no resize listener and makes the two thresholds the *same value* rather than two values kept in sync. Trade-off: the top band is now a fixed 96px rather than 12% of vh — a fixed highlight offset is arguably more predictable, and the "highlight near the top" intent is preserved.

## Tests

No regression test added: the hook's behaviour depends on a functional `IntersectionObserver` firing against real layout geometry, but the happy-dom test environment provides only a non-functional `IntersectionObserver` stub and `getBoundingClientRect()` returns zeros (no layout). A behavioural dead-zone test isn't achievable here, and asserting the `rootMargin` string would be brittle implementation-detail testing. The fix is a threshold-unification with no new branches.

Verified in this session, from `apps/blog`:
- `bun run type-check` (`tsc --noEmit`) -> exit 0
- `bun x ultracite check apps/blog/src/hooks/use-scroll-spy.ts` -> "Checked 1 file. No fixes applied."
- `bun run test` (full blog suite) -> "76 pass / 0 fail, 290 expect() calls, Ran 76 tests across 10 files" (unchanged from baseline; this change adds no test).

Generated by Claude Code. Please review before merging.
