### PR TITLE
fix: strip markdown link syntax from getHeadings slugs (#773)

### DIFF
--- a/apps/blog/src/__tests__/articles/service.test.ts
+++ b/apps/blog/src/__tests__/articles/service.test.ts
@@ -3,6 +3,7 @@ import {
   type ArticleTag,
   getArticlesByTag,
   getBacklinks,
+  getHeadings,
   getOutgoing,
   getRelated,
   getSlicedArticles,
@@ -122,6 +123,32 @@ describe("tag-aware service helpers", () => {
       const tagged: ArticleTag = tag;
       const articles = await getArticlesByTag(tagged);
       expect(counts[tagged]).toBe(articles.length);
+    }
+  });
+});
+
+describe("getHeadings markdown-link handling", () => {
+  it("strips inline link syntax so ids match rehype-slug (incl. multiple links)", async () => {
+    // deliberative-alignment.mdx has `## How it compares to [AFT](...) and [MSM](...)`
+    const headings = await getHeadings("deliberative-alignment");
+    const compareHeading = headings.find((h) =>
+      h.text.startsWith("How it compares to")
+    );
+
+    expect(compareHeading).toBeDefined();
+    expect(compareHeading?.text).toBe("How it compares to AFT and MSM");
+    expect(compareHeading?.id).toBe("how-it-compares-to-aft-and-msm");
+  });
+
+  it("never leaks link syntax or URL paths into any heading text or id", async () => {
+    for (const slug of ["deliberative-alignment", "cot-monitorability"]) {
+      const headings = await getHeadings(slug);
+      expect(headings.length).toBeGreaterThan(0);
+      for (const heading of headings) {
+        expect(heading.text).not.toContain("](");
+        expect(heading.id).not.toContain("/");
+        expect(heading.id).not.toContain("articles");
+      }
     }
   });
 });

--- a/apps/blog/src/app/(blog)/articles/service.ts
+++ b/apps/blog/src/app/(blog)/articles/service.ts
@@ -248,6 +248,9 @@ const FRONTMATTER_FENCE = /^---\r?\n[\s\S]*?\r?\n---\r?\n/;
 const CODE_FENCE = /^(?:```|~~~)/;
 const HEADING_RE = /^(#{2,3})\s+(.+?)\s*$/;
 const TRAILING_AUTOLINK_HASH = /\s*#\s*$/;
+// `[visible text](url)` → `visible text`. rehype-slug only sees the rendered
+// link text, so slug the visible text too or the ids diverge from the DOM.
+const MD_LINK_RE = /\[([^\]]+)\]\([^)]*\)/g;
 const LINE_SPLIT = /\r?\n/;
 
 /**
@@ -284,7 +287,10 @@ export const getHeadings = cache(
         continue;
       }
       const depth = match[1].length as 2 | 3;
-      const text = match[2].replace(TRAILING_AUTOLINK_HASH, "").trim();
+      const text = match[2]
+        .replace(MD_LINK_RE, "$1")
+        .replace(TRAILING_AUTOLINK_HASH, "")
+        .trim();
       if (!text) {
         continue;
       }


### PR DESCRIPTION
Fixes #773.

## Problem

`getHeadings` slugged the **raw** MDX heading text. For a heading like `## How it compares to [AFT](/articles/alignment-fine-tuning) and [MSM](/articles/model-spec-midtraining)`, it produced an id containing the URL characters, while `rehype-slug` (running on the rendered hast tree) only sees the link's *visible* text and writes a different DOM id. The two diverged across 7 articles, so TOC anchor `href`s pointed at non-existent ids and `useScrollSpy`'s `document.getElementById` returned `null` — the affected headings were untracked and un-navigable.

## Fix

`apps/blog/src/app/(blog)/articles/service.ts` — strip inline markdown link syntax (`[visible text](url)` → `visible text`) from the captured heading text before slugging, via a top-level global regex (handles multiple links in one heading, e.g. `[AFT](...) and [MSM](...)`). This makes `getHeadings` produce the same slug as `rehype-slug`, and as a bonus the displayed TOC `text` no longer shows raw markdown link syntax.

Scope: this strips only link syntax. Backtick/inline-code syntax in heading `text` is a separate concern tracked by its own issue, so it's left untouched here.

## Tests

Added regression tests to `apps/blog/src/__tests__/articles/service.test.ts` (`getHeadings` reads raw MDX from disk, so it's testable against the real affected content):
- the two-link heading in `deliberative-alignment.mdx` resolves to text `"How it compares to AFT and MSM"` and id `"how-it-compares-to-aft-and-msm"`;
- across `deliberative-alignment` and `cot-monitorability`, no heading `text` contains `](` and no `id` contains `/` or `articles` (URL-leak artifacts).

Both tests fail against the pre-fix code (the raw ids contained the URL paths).

Verified in this session, from `apps/blog`:
- `bun run type-check` (`tsc --noEmit`) -> exit 0
- `bun x ultracite check` on both changed files -> "Checked 2 files. No fixes applied."
- `bun test src/__tests__/articles/service.test.ts` -> 10 pass / 0 fail
- `bun run test` (full blog suite) -> "78 pass / 0 fail, 349 expect() calls, Ran 78 tests across 10 files" (up from the 76/290 baseline by the two new tests; the second iterates over each heading).

Generated by Claude Code. Please review before merging.
