### PR TITLE
:bug: fix(blog): collapse empty ArticleRail aside (#780)

### DIFF
--- a/apps/blog/src/__tests__/articles/article-rail.test.tsx
+++ b/apps/blog/src/__tests__/articles/article-rail.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "bun:test";
+
+import { ArticleRail } from "@/app/(blog)/articles/[slug]/article-rail";
+import type { ArticleHeading } from "@/app/(blog)/articles/service";
+
+// A slug absent from the article graph: getBacklinks and getRelated both
+// resolve to empty arrays, so `headings` is the rail's only content source.
+const SLUG_WITHOUT_LINKS = "slug-absent-from-article-graph";
+
+const HEADING: ArticleHeading = { depth: 2, id: "intro", text: "Intro" };
+
+describe("ArticleRail empty guard (#780)", () => {
+  it("returns null when TOC, related, and backlinks are all empty", async () => {
+    const result = await ArticleRail({
+      headings: [],
+      slug: SLUG_WITHOUT_LINKS,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("renders the rail when at least one heading is present", async () => {
+    const result = await ArticleRail({
+      headings: [HEADING],
+      slug: SLUG_WITHOUT_LINKS,
+    });
+
+    expect(result).not.toBeNull();
+  });
+});

--- a/apps/blog/src/app/(blog)/articles/[slug]/article-rail.tsx
+++ b/apps/blog/src/app/(blog)/articles/[slug]/article-rail.tsx
@@ -19,6 +19,12 @@ export async function ArticleRail({ headings, slug }: ArticleRailProps) {
     getRelated(slug),
   ]);
 
+  const isEmpty =
+    headings.length === 0 && related.length === 0 && backlinks.length === 0;
+  if (isEmpty) {
+    return null;
+  }
+
   return (
     <aside aria-label="Article navigation rail" className="rail:block hidden">
       <div className="sticky top-8 flex max-h-[calc(100vh-4rem)] flex-col gap-8 overflow-y-auto pr-2 pb-4">


### PR DESCRIPTION
Fixes #780.

## Problem

`ArticleRail` (`apps/blog/src/app/(blog)/articles/[slug]/article-rail.tsx`) always rendered its `<aside>` wrapper. When an article has no headings, no related articles, and no backlinks, all three children (`ArticleToc` + two `RailSection`s) return `null`, but the `<aside>` still occupied the 320 px rail grid column.

## Fix

Return `null` when the rail has nothing to show — i.e. `headings.length === 0 && related.length === 0 && backlinks.length === 0`. The condition mirrors each child's own empty guard (`ArticleToc` returns null at `headings.length === 0`; `RailSection` returns null at `links.length === 0`).

## Tests

Added `apps/blog/src/__tests__/articles/article-rail.test.tsx`:
- returns `null` when TOC, related, and backlinks are all empty (fails against pre-fix code)
- renders the rail when at least one heading is present

Verified this session from `apps/blog`:
- `bun run test` (full blog suite) → **78 pass / 0 fail**, 292 expect() calls across 11 files (76 baseline + 2 new)
- `bun run type-check` (`tsc --noEmit`) → exit 0
- `bun x ultracite check` on both changed files → "Checked 2 files. No fixes applied."

Generated by Claude Code. Please review before merging.