### PR TITLE
:construction_worker: ci(repo): run build on pull requests to catch breakage (#777)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,5 +55,4 @@ jobs:
         run: bunx turbo run test
 
       - name: Build
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: bunx turbo run build


### PR DESCRIPTION
## Summary

The `Build` step in `.github/workflows/test.yml` was gated to `if: github.event_name == 'push' && github.ref == 'refs/heads/main'`, so it only ran *after* a change landed on `main`. PR checks ran lint, type-check, and test — but **not** build. A change that compiles fine under `tsc` but breaks `next build` (e.g. a server/client boundary violation, an invalid `next.config` option, an MDX build failure) could pass all PR checks and merge undetected, only turning `main` red afterwards.

## Change

Drop the `if:` gate so `turbo run build` runs on every `push` and `pull_request`, alongside the other verification steps.

```diff
       - name: Build
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: bunx turbo run build
```

Turbo's remote/local cache keeps the added PR cost low when inputs are unchanged.

Fixes #777