### PR TITLE
:sparkles: feat(blog): surface real article tags as chips and tagged routes

### DIFF
--- a/apps/blog/src/app/(blog)/articles/[slug]/article-layout.tsx
+++ b/apps/blog/src/app/(blog)/articles/[slug]/article-layout.tsx
@@ -6,7 +6,7 @@ import type { CSSProperties, ReactNode } from "react";
 
 import { DataGrid } from "@/components/howardism/data-grid";
 import { HalfDisc } from "@/components/howardism/half-disc";
-import { TagChipList } from "@/components/howardism/tag-chip-list";
+import { SubjectChipList } from "@/components/howardism/subject-chip-list";
 import { TopicLabel } from "@/components/howardism/topic-label";
 import { formatDate } from "@/utils/time";
 
@@ -21,13 +21,15 @@ interface ArticleLayoutProps {
   heroImage?: StaticImageData;
   meta: ArticleMeta;
   /** Subject tags with their own page — used to decide which chips link. */
-  navigableTags?: readonly string[];
+  navigable?: ReadonlySet<string>;
   nextSlug?: string;
   nextTitle?: string;
   previousSlug?: string;
   previousTitle?: string;
   slug: string;
 }
+
+const NO_NAVIGABLE_TAGS: ReadonlySet<string> = new Set();
 
 const EYEBROW_CLASS =
   "font-mono text-[10.5px] text-foreground-subtle uppercase tracking-[0.22em]";
@@ -41,7 +43,7 @@ export function ArticleLayout({
   headings = [],
   heroImage,
   meta,
-  navigableTags = [],
+  navigable = NO_NAVIGABLE_TAGS,
   previousSlug,
   previousTitle,
   nextSlug,
@@ -56,11 +58,7 @@ export function ArticleLayout({
     meta.tags && meta.tags.length > 0
       ? [
           "Tags",
-          <TagChipList
-            key="tags"
-            navigable={new Set(navigableTags)}
-            tags={meta.tags}
-          />,
+          <SubjectChipList key="tags" navigable={navigable} tags={meta.tags} />,
         ]
       : null;
   const metaRows: [string, ReactNode][] = [

--- a/apps/blog/src/app/(blog)/articles/[slug]/article-layout.tsx
+++ b/apps/blog/src/app/(blog)/articles/[slug]/article-layout.tsx
@@ -6,6 +6,7 @@ import type { CSSProperties, ReactNode } from "react";
 
 import { DataGrid } from "@/components/howardism/data-grid";
 import { HalfDisc } from "@/components/howardism/half-disc";
+import { TagChipList } from "@/components/howardism/tag-chip-list";
 import { TopicLabel } from "@/components/howardism/topic-label";
 import { formatDate } from "@/utils/time";
 
@@ -19,6 +20,8 @@ interface ArticleLayoutProps {
   headings?: ArticleHeading[];
   heroImage?: StaticImageData;
   meta: ArticleMeta;
+  /** Subject tags with their own page — used to decide which chips link. */
+  navigableTags?: readonly string[];
   nextSlug?: string;
   nextTitle?: string;
   previousSlug?: string;
@@ -38,6 +41,7 @@ export function ArticleLayout({
   headings = [],
   heroImage,
   meta,
+  navigableTags = [],
   previousSlug,
   previousTitle,
   nextSlug,
@@ -48,10 +52,22 @@ export function ArticleLayout({
   const topicRow: [string, ReactNode] | null = meta.topic
     ? ["Topic", <TopicLabel key="topic" topic={meta.topic} />]
     : null;
+  const tagsRow: [string, ReactNode] | null =
+    meta.tags && meta.tags.length > 0
+      ? [
+          "Tags",
+          <TagChipList
+            key="tags"
+            navigable={new Set(navigableTags)}
+            tags={meta.tags}
+          />,
+        ]
+      : null;
   const metaRows: [string, ReactNode][] = [
     ["Published", formatDate(meta.date)],
     ["Filed", meta.tag],
     ...(topicRow ? [topicRow] : []),
+    ...(tagsRow ? [tagsRow] : []),
     ["Reading", `${meta.readingTime} min`],
     ["Source", "AI-synthesised"],
   ];

--- a/apps/blog/src/app/(blog)/articles/[slug]/page.tsx
+++ b/apps/blog/src/app/(blog)/articles/[slug]/page.tsx
@@ -8,6 +8,7 @@ import {
   type ArticleMeta,
   getArticles,
   getHeadings,
+  getNavigableTags,
   getSiblings,
 } from "../service";
 import { ArticleLayout } from "./article-layout";
@@ -66,18 +67,24 @@ export async function generateMetadata({
 
 export default async function ArticlePage({ params }: ArticlePageProps) {
   const { slug } = await params;
-  const [mod, { previousSlug, previousTitle, nextSlug, nextTitle }, headings] =
-    await Promise.all([
-      import(`@/content/articles/${slug}.mdx`) as Promise<ArticleModule>,
-      getSiblings(slug),
-      getHeadings(slug),
-    ]);
+  const [
+    mod,
+    { previousSlug, previousTitle, nextSlug, nextTitle },
+    headings,
+    navigableTags,
+  ] = await Promise.all([
+    import(`@/content/articles/${slug}.mdx`) as Promise<ArticleModule>,
+    getSiblings(slug),
+    getHeadings(slug),
+    getNavigableTags(),
+  ]);
 
   return (
     <ArticleLayout
       headings={headings}
       heroImage={mod.heroImage}
       meta={mod.meta}
+      navigableTags={navigableTags}
       nextSlug={nextSlug}
       nextTitle={nextTitle}
       previousSlug={previousSlug}

--- a/apps/blog/src/app/(blog)/articles/[slug]/page.tsx
+++ b/apps/blog/src/app/(blog)/articles/[slug]/page.tsx
@@ -8,7 +8,7 @@ import {
   type ArticleMeta,
   getArticles,
   getHeadings,
-  getNavigableTags,
+  getNavigableTagSet,
   getSiblings,
 } from "../service";
 import { ArticleLayout } from "./article-layout";
@@ -71,12 +71,12 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
     mod,
     { previousSlug, previousTitle, nextSlug, nextTitle },
     headings,
-    navigableTags,
+    navigable,
   ] = await Promise.all([
     import(`@/content/articles/${slug}.mdx`) as Promise<ArticleModule>,
     getSiblings(slug),
     getHeadings(slug),
-    getNavigableTags(),
+    getNavigableTagSet(),
   ]);
 
   return (
@@ -84,7 +84,7 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
       headings={headings}
       heroImage={mod.heroImage}
       meta={mod.meta}
-      navigableTags={navigableTags}
+      navigable={navigable}
       nextSlug={nextSlug}
       nextTitle={nextTitle}
       previousSlug={previousSlug}

--- a/apps/blog/src/app/(blog)/articles/kind-plate.tsx
+++ b/apps/blog/src/app/(blog)/articles/kind-plate.tsx
@@ -1,3 +1,4 @@
+import { TagChipList } from "@/components/howardism/tag-chip-list";
 import { TopicLabel } from "@/components/howardism/topic-label";
 import { InternalLink } from "@/components/internal-link";
 import { formatDateShort } from "@/utils/time";
@@ -21,6 +22,8 @@ const KIND_META: Record<TagSectionSlug, KindMeta> = {
 interface KindPlateProps {
   articles: ArticleEntity[];
   blurb: string;
+  /** Subject tags with their own page — used to decide which chips link. */
+  navigable: ReadonlySet<string>;
   /** 1-based plate position. */
   position: number;
   /** Section slug used for the anchor id + tag link + kind styling. */
@@ -35,6 +38,7 @@ export function KindPlate({
   articles,
   slug,
   blurb,
+  navigable,
   position,
   total,
   title,
@@ -125,6 +129,15 @@ export function KindPlate({
                     >
                       {article.meta.title}
                     </InternalLink>
+                    {article.meta.tags && article.meta.tags.length > 0 && (
+                      <div className="mt-1.5">
+                        <TagChipList
+                          limit={3}
+                          navigable={navigable}
+                          tags={article.meta.tags}
+                        />
+                      </div>
+                    )}
                   </td>
                   <td className="w-[150px] py-3.5 pr-6 align-baseline">
                     {article.meta.topic && (

--- a/apps/blog/src/app/(blog)/articles/kind-plate.tsx
+++ b/apps/blog/src/app/(blog)/articles/kind-plate.tsx
@@ -1,4 +1,4 @@
-import { TagChipList } from "@/components/howardism/tag-chip-list";
+import { SubjectChipList } from "@/components/howardism/subject-chip-list";
 import { TopicLabel } from "@/components/howardism/topic-label";
 import { InternalLink } from "@/components/internal-link";
 import { formatDateShort } from "@/utils/time";
@@ -131,7 +131,7 @@ export function KindPlate({
                     </InternalLink>
                     {article.meta.tags && article.meta.tags.length > 0 && (
                       <div className="mt-1.5">
-                        <TagChipList
+                        <SubjectChipList
                           limit={3}
                           navigable={navigable}
                           tags={article.meta.tags}

--- a/apps/blog/src/app/(blog)/articles/page.tsx
+++ b/apps/blog/src/app/(blog)/articles/page.tsx
@@ -9,7 +9,7 @@ import { KindPlate } from "./kind-plate";
 import { OperationsLog } from "./operations-log";
 import {
   type ArticleTopic,
-  getNavigableTags,
+  getNavigableTagSet,
   getTagCounts,
   getTagIndex,
   getVisibleArticles,
@@ -35,20 +35,18 @@ export const metadata: Metadata = {
 };
 
 export default async function ArticlesIndex() {
-  const [counts, visible, sections, navigableTags, tagIndex] =
-    await Promise.all([
-      getTagCounts(),
-      getVisibleArticles(),
-      Promise.all(
-        TAG_SECTIONS.map(async (section) => ({
-          section,
-          articles: await getSectionArticles(section),
-        }))
-      ),
-      getNavigableTags(),
-      getTagIndex(),
-    ]);
-  const navigable = new Set(navigableTags);
+  const [counts, visible, sections, navigable, tagIndex] = await Promise.all([
+    getTagCounts(),
+    getVisibleArticles(),
+    Promise.all(
+      TAG_SECTIONS.map(async (section) => ({
+        section,
+        articles: await getSectionArticles(section),
+      }))
+    ),
+    getNavigableTagSet(),
+    getTagIndex(),
+  ]);
 
   const total = Object.values(counts).reduce((sum, n) => sum + n, 0);
   const populated = sections.filter(({ articles }) => articles.length > 0);

--- a/apps/blog/src/app/(blog)/articles/page.tsx
+++ b/apps/blog/src/app/(blog)/articles/page.tsx
@@ -11,9 +11,11 @@ import {
   type ArticleTopic,
   getNavigableTags,
   getTagCounts,
+  getTagIndex,
   getVisibleArticles,
   getWikiLog,
 } from "./service";
+import { TagIndex } from "./tag-index";
 import { getSectionArticles, TAG_SECTIONS } from "./tag-sections";
 
 const ARTICLES_URL = `${env.NEXT_PUBLIC_DOMAIN_NAME}/articles`;
@@ -33,17 +35,19 @@ export const metadata: Metadata = {
 };
 
 export default async function ArticlesIndex() {
-  const [counts, visible, sections, navigableTags] = await Promise.all([
-    getTagCounts(),
-    getVisibleArticles(),
-    Promise.all(
-      TAG_SECTIONS.map(async (section) => ({
-        section,
-        articles: await getSectionArticles(section),
-      }))
-    ),
-    getNavigableTags(),
-  ]);
+  const [counts, visible, sections, navigableTags, tagIndex] =
+    await Promise.all([
+      getTagCounts(),
+      getVisibleArticles(),
+      Promise.all(
+        TAG_SECTIONS.map(async (section) => ({
+          section,
+          articles: await getSectionArticles(section),
+        }))
+      ),
+      getNavigableTags(),
+      getTagIndex(),
+    ]);
   const navigable = new Set(navigableTags);
 
   const total = Object.values(counts).reduce((sum, n) => sum + n, 0);
@@ -101,6 +105,8 @@ export default async function ArticlesIndex() {
           visibleLimit={VISIBLE_BY_SLUG[section.slug] ?? 10}
         />
       ))}
+
+      <TagIndex tags={tagIndex} />
 
       <OperationsLog
         entries={getWikiLog(OPS_LOG_LIMIT)}

--- a/apps/blog/src/app/(blog)/articles/page.tsx
+++ b/apps/blog/src/app/(blog)/articles/page.tsx
@@ -9,6 +9,7 @@ import { KindPlate } from "./kind-plate";
 import { OperationsLog } from "./operations-log";
 import {
   type ArticleTopic,
+  getNavigableTags,
   getTagCounts,
   getVisibleArticles,
   getWikiLog,
@@ -32,7 +33,7 @@ export const metadata: Metadata = {
 };
 
 export default async function ArticlesIndex() {
-  const [counts, visible, sections] = await Promise.all([
+  const [counts, visible, sections, navigableTags] = await Promise.all([
     getTagCounts(),
     getVisibleArticles(),
     Promise.all(
@@ -41,7 +42,9 @@ export default async function ArticlesIndex() {
         articles: await getSectionArticles(section),
       }))
     ),
+    getNavigableTags(),
   ]);
+  const navigable = new Set(navigableTags);
 
   const total = Object.values(counts).reduce((sum, n) => sum + n, 0);
   const populated = sections.filter(({ articles }) => articles.length > 0);
@@ -90,6 +93,7 @@ export default async function ArticlesIndex() {
           articles={articles}
           blurb={section.intro}
           key={section.slug}
+          navigable={navigable}
           position={i + 1}
           slug={section.slug}
           title={section.title}

--- a/apps/blog/src/app/(blog)/articles/service.ts
+++ b/apps/blog/src/app/(blog)/articles/service.ts
@@ -401,6 +401,15 @@ export const getNavigableTags = cache(async (): Promise<string[]> => {
     .map((entry) => entry.tag);
 });
 
+/**
+ * `getNavigableTags` as a membership set, memoised so chip surfaces (the index
+ * plates and each article page) test `navigable.has(tag)` without rebuilding
+ * the set per render.
+ */
+export const getNavigableTagSet = cache(
+  async (): Promise<ReadonlySet<string>> => new Set(await getNavigableTags())
+);
+
 /* ── wiki activity log + reading-list manifests (emitted by the importer) ── */
 
 export interface WikiLogEntry {

--- a/apps/blog/src/app/(blog)/articles/service.ts
+++ b/apps/blog/src/app/(blog)/articles/service.ts
@@ -81,6 +81,14 @@ const ArticleMetaSchema = z.object({
    */
   sources: z.array(SourceRefSchema).optional(),
   tag: z.enum(ARTICLE_TAGS),
+  /**
+   * The wiki note's real subject labels (lowercase kebab), passed through by
+   * the importer. NOTE the deliberate naming proximity: singular `tag` above
+   * is the article "kind" (Concept/Entity/…); plural `tags` here are the
+   * free-form subjects that drive the chips and `/articles/tagged/[tag]`
+   * routes; `topic` below is the single derived accent/grouping bucket.
+   */
+  tags: z.array(z.string()).optional(),
   title: z.string(),
   /**
    * Curated subject bucket derived by the wiki importer from the note's tags.
@@ -307,6 +315,55 @@ export const getTopicCounts = cache(
     return counts;
   }
 );
+
+/**
+ * Minimum number of articles a free-form subject `tag` must appear on before
+ * it earns a `/articles/tagged/[tag]` page. Rarer tags still render as chips,
+ * just non-clickable — this keeps us from generating dozens of thin pages.
+ */
+const MIN_TAGGED_ARTICLES = 2;
+
+/**
+ * Visible articles carrying `tag` in their free-form `tags` list, newest
+ * first. Distinct from `getArticlesByTag`, which matches the singular `tag`
+ * "kind" enum.
+ */
+export const getTaggedArticles = cache(
+  async (tag: string): Promise<ArticleEntity[]> => {
+    const visible = await getVisibleArticles();
+    const matches: ArticleEntity[] = [];
+    for (const id of visible.ids) {
+      const entity = visible.entities[id];
+      if (entity?.meta.tags?.includes(tag)) {
+        matches.push(entity);
+      }
+    }
+    return matches;
+  }
+);
+
+/**
+ * Subject tags that appear on at least `MIN_TAGGED_ARTICLES` visible
+ * articles, sorted by frequency then name. These are the tags that get a
+ * static `/articles/tagged/[tag]` page and clickable chips.
+ */
+export const getNavigableTags = cache(async (): Promise<string[]> => {
+  const visible = await getVisibleArticles();
+  const counts = new Map<string, number>();
+  for (const id of visible.ids) {
+    const tags = visible.entities[id]?.meta.tags;
+    if (!tags) {
+      continue;
+    }
+    for (const tag of tags) {
+      counts.set(tag, (counts.get(tag) ?? 0) + 1);
+    }
+  }
+  return [...counts.entries()]
+    .filter(([, count]) => count >= MIN_TAGGED_ARTICLES)
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([tag]) => tag);
+});
 
 /* ── wiki activity log + reading-list manifests (emitted by the importer) ── */
 

--- a/apps/blog/src/app/(blog)/articles/service.ts
+++ b/apps/blog/src/app/(blog)/articles/service.ts
@@ -12,6 +12,7 @@ import { z } from "zod";
 import graphData from "@/data/article-graph.json";
 import wikiLogData from "@/data/wiki-log.json";
 import wikiSourcesData from "@/data/wiki-sources.json";
+import { taggedHref } from "@/utils/tagged-href";
 
 export interface Normalise<T> {
   entities: Record<string, T | undefined>;
@@ -342,27 +343,62 @@ export const getTaggedArticles = cache(
   }
 );
 
+export interface TagIndexEntry {
+  count: number;
+  /**
+   * Where the chip links: the `/articles/tagged/[tag]` page for tags carried
+   * by enough articles to earn one, or — for a tag on a single article — that
+   * article itself.
+   */
+  href: string;
+  tag: string;
+}
+
 /**
- * Subject tags that appear on at least `MIN_TAGGED_ARTICLES` visible
- * articles, sorted by frequency then name. These are the tags that get a
- * static `/articles/tagged/[tag]` page and clickable chips.
+ * Every subject tag across visible articles as a clickable chip target,
+ * ordered by reference count (descending) then name. Tags on at least
+ * `MIN_TAGGED_ARTICLES` articles link to their `/articles/tagged/[tag]` page;
+ * a tag on exactly one article has no such page and links straight to it.
  */
-export const getNavigableTags = cache(async (): Promise<string[]> => {
+export const getTagIndex = cache(async (): Promise<TagIndexEntry[]> => {
   const visible = await getVisibleArticles();
-  const counts = new Map<string, number>();
+  const slugsByTag = new Map<string, string[]>();
   for (const id of visible.ids) {
     const tags = visible.entities[id]?.meta.tags;
     if (!tags) {
       continue;
     }
     for (const tag of tags) {
-      counts.set(tag, (counts.get(tag) ?? 0) + 1);
+      const slugs = slugsByTag.get(tag);
+      if (slugs) {
+        slugs.push(id);
+      } else {
+        slugsByTag.set(tag, [id]);
+      }
     }
   }
-  return [...counts.entries()]
-    .filter(([, count]) => count >= MIN_TAGGED_ARTICLES)
-    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
-    .map(([tag]) => tag);
+  return [...slugsByTag.entries()]
+    .map(([tag, slugs]) => ({
+      tag,
+      count: slugs.length,
+      href:
+        slugs.length >= MIN_TAGGED_ARTICLES
+          ? taggedHref(tag)
+          : `/articles/${slugs[0]}`,
+    }))
+    .sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag));
+});
+
+/**
+ * Subject tags that appear on at least `MIN_TAGGED_ARTICLES` visible
+ * articles, sorted by frequency then name. These are the tags that get a
+ * static `/articles/tagged/[tag]` page and clickable chips.
+ */
+export const getNavigableTags = cache(async (): Promise<string[]> => {
+  const index = await getTagIndex();
+  return index
+    .filter((entry) => entry.count >= MIN_TAGGED_ARTICLES)
+    .map((entry) => entry.tag);
 });
 
 /* ── wiki activity log + reading-list manifests (emitted by the importer) ── */

--- a/apps/blog/src/app/(blog)/articles/tag-index.tsx
+++ b/apps/blog/src/app/(blog)/articles/tag-index.tsx
@@ -1,0 +1,54 @@
+import { TagChip } from "@/components/howardism/tag-chip";
+
+import type { TagIndexEntry } from "./service";
+
+interface TagIndexProps {
+  tags: TagIndexEntry[];
+}
+
+/**
+ * "By subject" plate — every free-form subject tag across the wiki as a
+ * clickable chip, most-referenced first. Multi-article tags open their tag
+ * page; a tag carried by a single article jumps straight to that article.
+ */
+export function TagIndex({ tags }: TagIndexProps) {
+  if (tags.length === 0) {
+    return null;
+  }
+
+  return (
+    <section
+      className="border-border border-b px-[clamp(20px,5vw,56px)] py-10"
+      id="subjects"
+    >
+      <div className="grid grid-cols-1 gap-x-11 gap-y-7 lg:grid-cols-[180px_1fr]">
+        <div>
+          <div className="font-medium font-mono text-[10.5px] text-brand uppercase tracking-[0.22em]">
+            Plate · #
+          </div>
+          <div className="mt-2 font-display font-light text-[96px] text-brand leading-[0.86] tracking-[-0.045em]">
+            {tags.length}
+          </div>
+          <div className="mt-1 font-mono text-[10.5px] text-foreground-subtle uppercase tracking-[0.14em]">
+            subjects
+          </div>
+          <p className="mt-4 max-w-[200px] font-body text-[14px] text-muted-foreground leading-[1.5]">
+            Free-form subjects across the wiki, most-referenced first.
+          </p>
+        </div>
+
+        <div>
+          <h2 className="m-0 font-display font-normal text-[clamp(30px,4vw,40px)] text-foreground leading-[1.04] tracking-[-0.022em]">
+            By subject,{" "}
+            <em className="font-light text-brand italic">most cited.</em>
+          </h2>
+          <div className="mt-6 flex flex-wrap">
+            {tags.map(({ tag, href }) => (
+              <TagChip href={href} key={tag} tag={tag} />
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/blog/src/app/(blog)/articles/tag-index.tsx
+++ b/apps/blog/src/app/(blog)/articles/tag-index.tsx
@@ -1,4 +1,4 @@
-import { TagChip } from "@/components/howardism/tag-chip";
+import { SubjectChip } from "@/components/howardism/subject-chip";
 
 import type { TagIndexEntry } from "./service";
 
@@ -44,7 +44,7 @@ export function TagIndex({ tags }: TagIndexProps) {
           </h2>
           <div className="mt-6 flex flex-wrap">
             {tags.map(({ tag, href }) => (
-              <TagChip href={href} key={tag} tag={tag} />
+              <SubjectChip href={href} key={tag} tag={tag} />
             ))}
           </div>
         </div>

--- a/apps/blog/src/app/(blog)/articles/tagged/[tag]/page.tsx
+++ b/apps/blog/src/app/(blog)/articles/tagged/[tag]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { DiscPageHeader } from "@/components/howardism/disc-page-header";
 import { env } from "@/config/env";
 import { humanizeTag } from "@/utils/humanize-tag";
+import { taggedHref } from "@/utils/tagged-href";
 import { formatDateShort } from "@/utils/time";
 
 import { ArticlesTable } from "../../articles-table";
@@ -34,7 +35,7 @@ export async function generateMetadata({
     return { title: "Not found — Howardism" };
   }
   const label = humanizeTag(tag);
-  const url = `${env.NEXT_PUBLIC_DOMAIN_NAME}/articles/tagged/${tag}`;
+  const url = `${env.NEXT_PUBLIC_DOMAIN_NAME}${taggedHref(tag)}`;
   return {
     title: `${label} — Howardism`,
     description: `Articles tagged ${label} from the Howardism wiki.`,

--- a/apps/blog/src/app/(blog)/articles/tagged/[tag]/page.tsx
+++ b/apps/blog/src/app/(blog)/articles/tagged/[tag]/page.tsx
@@ -1,0 +1,84 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import { DiscPageHeader } from "@/components/howardism/disc-page-header";
+import { env } from "@/config/env";
+import { humanizeTag } from "@/utils/humanize-tag";
+import { formatDateShort } from "@/utils/time";
+
+import { ArticlesTable } from "../../articles-table";
+import { getNavigableTags, getTaggedArticles } from "../../service";
+
+interface TaggedPageParams {
+  tag: string;
+}
+
+interface TaggedPageProps {
+  params: Promise<TaggedPageParams>;
+}
+
+export const dynamic = "error";
+export const dynamicParams = false;
+
+export async function generateStaticParams(): Promise<TaggedPageParams[]> {
+  const tags = await getNavigableTags();
+  return tags.map((tag) => ({ tag }));
+}
+
+export async function generateMetadata({
+  params,
+}: TaggedPageProps): Promise<Metadata> {
+  const { tag } = await params;
+  const navigable = await getNavigableTags();
+  if (!navigable.includes(tag)) {
+    return { title: "Not found — Howardism" };
+  }
+  const label = humanizeTag(tag);
+  const url = `${env.NEXT_PUBLIC_DOMAIN_NAME}/articles/tagged/${tag}`;
+  return {
+    title: `${label} — Howardism`,
+    description: `Articles tagged ${label} from the Howardism wiki.`,
+    alternates: { canonical: url },
+    openGraph: { url },
+  };
+}
+
+export default async function TaggedPage({ params }: TaggedPageProps) {
+  const { tag } = await params;
+  const navigable = await getNavigableTags();
+  if (!navigable.includes(tag)) {
+    notFound();
+  }
+
+  const label = humanizeTag(tag);
+  const articles = await getTaggedArticles(tag);
+  const newestDate = articles.at(0)?.meta.date;
+  const oldestDate = articles.at(-1)?.meta.date;
+
+  return (
+    <div className="hw-page-enter mx-auto max-w-[1120px] px-8 pb-20">
+      <DiscPageHeader
+        data={[
+          ["Notes", String(articles.length)],
+          ["Tag", label],
+          ["Oldest", oldestDate ? formatDateShort(oldestDate) : "—"],
+          ["Newest", newestDate ? formatDateShort(newestDate) : "—"],
+        ]}
+        number="02"
+        plate="Plate II"
+        title={`${label},`}
+        titleAccent="tagged."
+        volume="Howardism · Vol. 03"
+      />
+
+      <p className="mt-10 mb-12 max-w-[60ch] font-body text-[15px] text-muted-foreground leading-[1.6]">
+        Every article tagged <em>{label.toLowerCase()}</em>, newest first.
+      </p>
+
+      <ArticlesTable
+        articles={articles}
+        srCaption={`Articles tagged ${label}, sorted by date, newest first.`}
+      />
+    </div>
+  );
+}

--- a/apps/blog/src/components/howardism/subject-chip-list.tsx
+++ b/apps/blog/src/components/howardism/subject-chip-list.tsx
@@ -1,8 +1,8 @@
 import { taggedHref } from "@/utils/tagged-href";
 
-import { TagChip } from "./tag-chip";
+import { SubjectChip } from "./subject-chip";
 
-interface TagChipListProps {
+interface SubjectChipListProps {
   /** When set, show at most this many chips and a `+N` overflow marker. */
   limit?: number;
   /** Tags that have a `/articles/tagged/[tag]` page — these chips link. */
@@ -15,14 +15,18 @@ interface TagChipListProps {
  * link to their tag page; the rest are inert. With `limit`, extra tags
  * collapse into a `+N` marker (used in dense index rows).
  */
-export function TagChipList({ tags, navigable, limit }: TagChipListProps) {
+export function SubjectChipList({
+  tags,
+  navigable,
+  limit,
+}: SubjectChipListProps) {
   const shown = limit ? tags.slice(0, limit) : tags;
   const overflow = tags.length - shown.length;
 
   return (
     <span>
       {shown.map((tag) => (
-        <TagChip
+        <SubjectChip
           href={navigable.has(tag) ? taggedHref(tag) : undefined}
           key={tag}
           tag={tag}

--- a/apps/blog/src/components/howardism/subject-chip.tsx
+++ b/apps/blog/src/components/howardism/subject-chip.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 
 import { humanizeTag } from "@/utils/humanize-tag";
 
-interface TagChipProps {
+interface SubjectChipProps {
   /** When set, the chip links to its tag page; otherwise it renders inert. */
   href?: string;
   tag: string;
@@ -15,9 +15,10 @@ const SPACING = "mr-1.5 mb-1";
 /**
  * A single free-form subject tag, rendered with the design system's `chip`
  * badge. Clickable (linking to `/articles/tagged/[tag]`) only when an `href`
- * is supplied — rare singleton tags have no page and render inert.
+ * is supplied — rare singleton tags have no page and render inert. Distinct
+ * from `TagChip` (`components/tag-chip`), which renders the singular kind enum.
  */
-export function TagChip({ tag, href }: TagChipProps) {
+export function SubjectChip({ tag, href }: SubjectChipProps) {
   const label = humanizeTag(tag);
   if (href) {
     return (

--- a/apps/blog/src/components/howardism/tag-chip-list.tsx
+++ b/apps/blog/src/components/howardism/tag-chip-list.tsx
@@ -1,0 +1,36 @@
+import { TagChip } from "./tag-chip";
+
+interface TagChipListProps {
+  /** When set, show at most this many chips and a `+N` overflow marker. */
+  limit?: number;
+  /** Tags that have a `/articles/tagged/[tag]` page — these chips link. */
+  navigable: ReadonlySet<string>;
+  tags: readonly string[];
+}
+
+/**
+ * Renders an article's subject tags as wrapping chips. Tags in `navigable`
+ * link to their tag page; the rest are inert. With `limit`, extra tags
+ * collapse into a `+N` marker (used in dense index rows).
+ */
+export function TagChipList({ tags, navigable, limit }: TagChipListProps) {
+  const shown = limit ? tags.slice(0, limit) : tags;
+  const overflow = tags.length - shown.length;
+
+  return (
+    <span>
+      {shown.map((tag) => (
+        <TagChip
+          href={navigable.has(tag) ? `/articles/tagged/${tag}` : undefined}
+          key={tag}
+          tag={tag}
+        />
+      ))}
+      {overflow > 0 && (
+        <span className="mb-1 inline-block font-mono text-[10.5px] text-foreground-subtle leading-none">
+          +{overflow}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/apps/blog/src/components/howardism/tag-chip-list.tsx
+++ b/apps/blog/src/components/howardism/tag-chip-list.tsx
@@ -1,3 +1,5 @@
+import { taggedHref } from "@/utils/tagged-href";
+
 import { TagChip } from "./tag-chip";
 
 interface TagChipListProps {
@@ -21,7 +23,7 @@ export function TagChipList({ tags, navigable, limit }: TagChipListProps) {
     <span>
       {shown.map((tag) => (
         <TagChip
-          href={navigable.has(tag) ? `/articles/tagged/${tag}` : undefined}
+          href={navigable.has(tag) ? taggedHref(tag) : undefined}
           key={tag}
           tag={tag}
         />

--- a/apps/blog/src/components/howardism/tag-chip.tsx
+++ b/apps/blog/src/components/howardism/tag-chip.tsx
@@ -1,0 +1,38 @@
+import { Badge } from "@howardism/ui/components/badge";
+import Link from "next/link";
+
+import { humanizeTag } from "@/utils/humanize-tag";
+
+interface TagChipProps {
+  /** When set, the chip links to its tag page; otherwise it renders inert. */
+  href?: string;
+  tag: string;
+}
+
+/** Trailing spacing so chips wrap with breathing room in dense lists. */
+const SPACING = "mr-1.5 mb-1";
+
+/**
+ * A single free-form subject tag, rendered with the design system's `chip`
+ * badge. Clickable (linking to `/articles/tagged/[tag]`) only when an `href`
+ * is supplied — rare singleton tags have no page and render inert.
+ */
+export function TagChip({ tag, href }: TagChipProps) {
+  const label = humanizeTag(tag);
+  if (href) {
+    return (
+      <Badge
+        asChild
+        className={`${SPACING} transition-colors hover:border-brand hover:text-brand`}
+        variant="chip"
+      >
+        <Link href={href}>{label}</Link>
+      </Badge>
+    );
+  }
+  return (
+    <Badge className={SPACING} variant="chip">
+      {label}
+    </Badge>
+  );
+}

--- a/apps/blog/src/content/articles/agent-harness-engineering.mdx
+++ b/apps/blog/src/content/articles/agent-harness-engineering.mdx
@@ -6,6 +6,10 @@ description: "Patterns for scaffolding long-running LLM agents: environment
   agent code review"
 tag: Concept
 topic: harness
+tags:
+  - agent-engineering
+  - llm-architecture
+  - software-development
 readingTime: 11
 imageAlt: Illustration for Agent Harness Engineering
 sources:

--- a/apps/blog/src/content/articles/agent-loop-pattern.mdx
+++ b/apps/blog/src/content/articles/agent-loop-pattern.mdx
@@ -6,6 +6,10 @@ description: '`/loop` (cron-scheduled) and Ralph Wiggum (backlog-draining) loops
   are the future"'
 tag: Concept
 topic: harness
+tags:
+  - agent-engineering
+  - harness
+  - automation
 readingTime: 6
 imageAlt: Illustration for Agent Loop Pattern
 sources:

--- a/apps/blog/src/content/articles/agentic-misalignment.mdx
+++ b/apps/blog/src/content/articles/agentic-misalignment.mdx
@@ -6,6 +6,12 @@ description: "Lynch et al. 2025 eval and threat model: LLM email-agent discovers
   AFT; primary eval surface for Model Spec Midtraining"
 tag: Concept
 topic: alignment
+tags:
+  - alignment
+  - safety
+  - evaluation
+  - agents
+  - misalignment
 readingTime: 4
 imageAlt: Illustration for Agentic Misalignment (AM)
 sources:

--- a/apps/blog/src/content/articles/ai-brain-fry.mdx
+++ b/apps/blog/src/content/articles/ai-brain-fry.mdx
@@ -6,6 +6,11 @@ description: "Kropp et al. 2026/03: mental fatigue from excessive AI oversight
   both tool and employee framings"
 tag: Concept
 topic: orgs
+tags:
+  - workforce
+  - cognitive-load
+  - ai-adoption
+  - hr
 readingTime: 3
 imageAlt: Illustration for AI Brain Fry
 sources:

--- a/apps/blog/src/content/articles/ai-employee-framing.mdx
+++ b/apps/blog/src/content/articles/ai-employee-framing.mdx
@@ -6,6 +6,13 @@ description: 'Kropp et al. (HBR May 2026, n=1,261): framing AI agents as
   +44%, reduces error catching −18%, no adoption gain'
 tag: Concept
 topic: orgs
+tags:
+  - workforce
+  - ai-adoption
+  - governance
+  - hr
+  - accountability
+  - empirical
 readingTime: 6
 imageAlt: Illustration for AI Employee Framing
 sources:

--- a/apps/blog/src/content/articles/ai-native-product-cadence.mdx
+++ b/apps/blog/src/content/articles/ai-native-product-cadence.mdx
@@ -6,6 +6,10 @@ description: "Cat Wu's 6mo→1mo→1day cadence at Anthropic: research-preview
   metrics readouts"
 tag: Concept
 topic: orgs
+tags:
+  - product-management
+  - process
+  - team-design
 readingTime: 8
 imageAlt: Illustration for AI Native Product Cadence
 sources:

--- a/apps/blog/src/content/articles/ai-tools-opinions-and-future-of-swe-role.mdx
+++ b/apps/blog/src/content/articles/ai-tools-opinions-and-future-of-swe-role.mdx
@@ -7,6 +7,12 @@ description: "Debate map of four stances on using AI tools (bullish-insider /
   what stays human, which moats survive, honest caveats"
 tag: Essay
 topic: orgs
+tags:
+  - career
+  - ai-coworking
+  - opinions
+  - software-economics
+  - debate-map
 readingTime: 12
 imageAlt: Illustration for Opinions on Using AI Tools & the Future of the
   Software Engineering Role

--- a/apps/blog/src/content/articles/alignment-fine-tuning.mdx
+++ b/apps/blog/src/content/articles/alignment-fine-tuning.mdx
@@ -5,6 +5,11 @@ description: Standard post-pretraining stage (SFT + RLHF) for installing values;
   shallow-alignment failure mode motivates Model Spec Midtraining
 tag: Concept
 topic: alignment
+tags:
+  - alignment
+  - training
+  - rlhf
+  - sft
 readingTime: 3
 imageAlt: Illustration for Alignment Fine-Tuning (AFT)
 sources:

--- a/apps/blog/src/content/articles/anthropic.mdx
+++ b/apps/blog/src/content/articles/anthropic.mdx
@@ -5,6 +5,10 @@ description: AI safety company / vendor of Claude; mission-as-tiebreaker
   culture; ~30–40 PMs across teams; Mike Krieger leads Labs round 2
 tag: Entity
 topic: orgs
+tags:
+  - entity
+  - org
+  - ai
 readingTime: 5
 imageAlt: Illustration for Anthropic
 sources:

--- a/apps/blog/src/content/articles/boris-cherny.mdx
+++ b/apps/blog/src/content/articles/boris-cherny.mdx
@@ -6,6 +6,10 @@ description: Creator of Claude Code at Anthropic; phone-driven workflow with
   (for me)" thesis
 tag: Entity
 topic: orgs
+tags:
+  - entity
+  - person
+  - anthropic
 readingTime: 4
 imageAlt: Illustration for Boris Cherny
 sources:

--- a/apps/blog/src/content/articles/cat-wu.mdx
+++ b/apps/blog/src/content/articles/cat-wu.mdx
@@ -5,6 +5,10 @@ description: Head of Product for Claude Code and Cowork at Anthropic; primary
   articulator of AI-native product cadence and engineer-PM convergence
 tag: Entity
 topic: orgs
+tags:
+  - entity
+  - person
+  - anthropic
 readingTime: 4
 imageAlt: Illustration for Cat Wu
 sources:

--- a/apps/blog/src/content/articles/chloe-li.mdx
+++ b/apps/blog/src/content/articles/chloe-li.mdx
@@ -5,6 +5,11 @@ description: Lead author of MSM paper (arXiv 2605.02087); Anthropic Fellows
   Program; designed all specs and experiments
 tag: Entity
 topic: orgs
+tags:
+  - entity
+  - person
+  - anthropic
+  - alignment-researcher
 readingTime: 2
 imageAlt: Illustration for Chloe Li
 sources:

--- a/apps/blog/src/content/articles/claire-vo.mdx
+++ b/apps/blog/src/content/articles/claire-vo.mdx
@@ -6,6 +6,10 @@ description: Host of the "How I AI" interview series (ChatPRD); interviewed
   non-technical stakeholders
 tag: Entity
 topic: orgs
+tags:
+  - entity
+  - person
+  - media
 readingTime: 2
 imageAlt: Illustration for Claire Vo
 sources:

--- a/apps/blog/src/content/articles/claude-character-as-product.mdx
+++ b/apps/blog/src/content/articles/claude-character-as-product.mdx
@@ -6,6 +6,10 @@ description: Personality as load-bearing product surface; Amanda's role at
   *doesn't* shrink
 tag: Concept
 topic: orgs
+tags:
+  - product-management
+  - llm-character
+  - anthropic
 readingTime: 6
 imageAlt: Illustration for Claude Character as Product
 sources:

--- a/apps/blog/src/content/articles/claude-code-auto-mode.mdx
+++ b/apps/blog/src/content/articles/claude-code-auto-mode.mdx
@@ -6,6 +6,11 @@ description: Claude Code permission mode using a classifier to auto-approve safe
   `--dangerously-skip-permissions`
 tag: Concept
 topic: harness
+tags:
+  - claude-code
+  - permissions
+  - agent-safety
+  - developer-workflow
 readingTime: 6
 imageAlt: Illustration for Claude Code Auto Mode
 sources:

--- a/apps/blog/src/content/articles/claude-code-best-practices.mdx
+++ b/apps/blog/src/content/articles/claude-code-best-practices.mdx
@@ -6,6 +6,10 @@ description: "Anthropic's guide to effective Claude Code usage: context
   environment config"
 tag: Concept
 topic: harness
+tags:
+  - claude-code
+  - ai-tools
+  - developer-workflow
 readingTime: 11
 imageAlt: Illustration for Claude Code Best Practices
 sources:

--- a/apps/blog/src/content/articles/claude-code.mdx
+++ b/apps/blog/src/content/articles/claude-code.mdx
@@ -6,6 +6,11 @@ description: Anthropic's agentic coding product; created by Boris Cherny late
   across all 2026 sources
 tag: Entity
 topic: orgs
+tags:
+  - entity
+  - product
+  - anthropic
+  - ai-coding
 readingTime: 5
 imageAlt: Illustration for Claude Code
 sources:

--- a/apps/blog/src/content/articles/claude-constitution.mdx
+++ b/apps/blog/src/content/articles/claude-constitution.mdx
@@ -6,6 +6,12 @@ description: Anthropic Model Spec / Constitution by Askell et al.; document
   direct training input via MSM
 tag: Entity
 topic: orgs
+tags:
+  - entity
+  - alignment
+  - anthropic
+  - model-spec
+  - document
 readingTime: 4
 imageAlt: Illustration for Claude's Constitution / Model Spec
 sources:

--- a/apps/blog/src/content/articles/claude-opus-4-7.mdx
+++ b/apps/blog/src/content/articles/claude-opus-4-7.mdx
@@ -6,6 +6,11 @@ description: GA frontier model from Anthropic; direct upgrade to 4.6 at same
   `xhigh` effort, first post-Glasswing safeguards
 tag: Entity
 topic: orgs
+tags:
+  - entity
+  - claude
+  - anthropic
+  - llm-model
 readingTime: 7
 imageAlt: Illustration for Claude Opus 4.7
 sources:

--- a/apps/blog/src/content/articles/client-side-agent-optimization.mdx
+++ b/apps/blog/src/content/articles/client-side-agent-optimization.mdx
@@ -6,6 +6,11 @@ description: AgentOpt's framing of developer-controlled agent optimization
   combo abstraction; 13–32× cost gaps between best/worst combinations
 tag: Concept
 topic: harness
+tags:
+  - agent-engineering
+  - llm-architecture
+  - optimization
+  - model-routing
 readingTime: 9
 imageAlt: Illustration for Client-Side Agent Optimization
 sources:

--- a/apps/blog/src/content/articles/codex-app-server-protocol.mdx
+++ b/apps/blog/src/content/articles/codex-app-server-protocol.mdx
@@ -6,6 +6,11 @@ description: "JSON-RPC stdio protocol for headless Codex sessions:
   reuse thread_id, dynamic tool calls for token-isolated tool injection"
 tag: Concept
 topic: harness
+tags:
+  - protocol
+  - codex
+  - agent-runtime
+  - integration
 readingTime: 7
 imageAlt: Illustration for Codex App Server Protocol
 sources:

--- a/apps/blog/src/content/articles/compute-allocator.mdx
+++ b/apps/blog/src/content/articles/compute-allocator.mdx
@@ -6,6 +6,10 @@ description: "The human's evolving role: deciding what's worth spending compute
   alignment/communication; abundance mindset"
 tag: Concept
 topic: interaction
+tags:
+  - human-ai-collaboration
+  - agent-engineering
+  - role-evolution
 readingTime: 6
 imageAlt: Illustration for Compute Allocator
 sources:

--- a/apps/blog/src/content/articles/context-window-smart-zone.mdx
+++ b/apps/blog/src/content/articles/context-window-smart-zone.mdx
@@ -7,6 +7,10 @@ description: "Smart zone vs dumb zone (Dex Hardy / Matt Pocock): quadratic
   discipline"
 tag: Concept
 topic: harness
+tags:
+  - llm-architecture
+  - agent-engineering
+  - context-management
 readingTime: 5
 imageAlt: Illustration for Context Window Smart Zone
 sources:

--- a/apps/blog/src/content/articles/cot-monitorability.mdx
+++ b/apps/blog/src/content/articles/cot-monitorability.mdx
@@ -5,6 +5,12 @@ description: "Korbak et al. 2025: chain-of-thought traces are a fragile monitor;
   direct CoT training compromises faithfulness; MSM offers an alternative path"
 tag: Concept
 topic: alignment
+tags:
+  - alignment
+  - safety
+  - chain-of-thought
+  - monitoring
+  - interpretability
 readingTime: 3
 imageAlt: Illustration for Chain-of-Thought Monitorability
 sources:

--- a/apps/blog/src/content/articles/cowork.mdx
+++ b/apps/blog/src/content/articles/cowork.mdx
@@ -5,6 +5,10 @@ description: Anthropic's non-code knowledge-work agent product; sibling to
   Claude Code; output is decks/inbox/dossiers; same MCP/computer-use primitives
 tag: Entity
 topic: orgs
+tags:
+  - entity
+  - product
+  - anthropic
 readingTime: 4
 imageAlt: Illustration for Cowork
 sources:

--- a/apps/blog/src/content/articles/deep-modules-for-agents.mdx
+++ b/apps/blog/src/content/articles/deep-modules-for-agents.mdx
@@ -6,6 +6,10 @@ description: Ousterhout deep-vs-shallow modules applied to agent-friendly
   Sandcastle three-agent pattern
 tag: Concept
 topic: harness
+tags:
+  - software-design
+  - agent-engineering
+  - architecture
 readingTime: 6
 imageAlt: Illustration for Deep Modules for Agents
 sources:

--- a/apps/blog/src/content/articles/deliberative-alignment.mdx
+++ b/apps/blog/src/content/articles/deliberative-alignment.mdx
@@ -6,6 +6,11 @@ description: "Guan et al. 2025 (OpenAI): SFT on (prompt, CoT, response) tuples
   Monitorability"
 tag: Concept
 topic: alignment
+tags:
+  - alignment
+  - training
+  - chain-of-thought
+  - openai
 readingTime: 4
 imageAlt: Illustration for Deliberative Alignment
 sources:

--- a/apps/blog/src/content/articles/design-concept-grilling.mdx
+++ b/apps/blog/src/content/articles/design-concept-grilling.mdx
@@ -6,6 +6,10 @@ description: Matt Pocock's `grill-me` skill; reach Brooks "design concept"
   journey doc
 tag: Concept
 topic: harness
+tags:
+  - agent-engineering
+  - planning
+  - alignment
 readingTime: 6
 imageAlt: Illustration for Design Concept Grilling
 sources:

--- a/apps/blog/src/content/articles/disposable-micro-apps.mdx
+++ b/apps/blog/src/content/articles/disposable-micro-apps.mdx
@@ -6,6 +6,10 @@ description: Throwaway custom UIs built per-task to edit a plan ("micro-software
   abundance mindset
 tag: Concept
 topic: interaction
+tags:
+  - agent-engineering
+  - software-economics
+  - human-ai-collaboration
 readingTime: 4
 imageAlt: Illustration for Disposable Micro-Apps
 sources:

--- a/apps/blog/src/content/articles/encoder-free-early-fusion.mdx
+++ b/apps/blog/src/content/articles/encoder-free-early-fusion.mdx
@@ -6,6 +6,9 @@ description: "Multimodal design with minimal pre-processing instead of large
   head for audio out, all co-trained from scratch in one transformer"
 tag: Concept
 topic: interaction
+tags:
+  - llm-architecture
+  - multimodal
 readingTime: 3
 imageAlt: Illustration for Encoder-Free Early Fusion
 sources:

--- a/apps/blog/src/content/articles/engineer-pm-convergence.mdx
+++ b/apps/blog/src/content/articles/engineer-pm-convergence.mdx
@@ -5,6 +5,10 @@ description: Generalists across disciplines; product taste as bottleneck skill;
   Anthropic Claude Code team as case study; "just do things" cultural substrate
 tag: Concept
 topic: orgs
+tags:
+  - product-management
+  - team-design
+  - generalists
 readingTime: 7
 imageAlt: Illustration for Engineer PM Convergence
 sources:

--- a/apps/blog/src/content/articles/full-duplex-interaction.mdx
+++ b/apps/blog/src/content/articles/full-duplex-interaction.mdx
@@ -7,6 +7,9 @@ description: Perceive-and-respond simultaneously across modalities; proactive
   behavior
 tag: Concept
 topic: interaction
+tags:
+  - human-ai-collaboration
+  - multimodal
 readingTime: 3
 imageAlt: Illustration for Full-Duplex Interaction
 sources:

--- a/apps/blog/src/content/articles/harness-shrinkage-as-models-improve.mdx
+++ b/apps/blog/src/content/articles/harness-shrinkage-as-models-improve.mdx
@@ -6,6 +6,10 @@ description: Prompt scaffolding shrinks each model release; Cat Wu's pruning
   verification stays load-bearing
 tag: Concept
 topic: harness
+tags:
+  - llm-architecture
+  - agent-engineering
+  - harness
 readingTime: 8
 imageAlt: Illustration for Harness Shrinkage as Models Improve
 sources:

--- a/apps/blog/src/content/articles/hermes-agent.mdx
+++ b/apps/blog/src/content/articles/hermes-agent.mdx
@@ -6,6 +6,12 @@ description: Nous Research's CLI agent + Gateway daemon
   memory files, DM-pairing auth, container-as-security-boundary model
 tag: Entity
 topic: harness
+tags:
+  - entity
+  - nous-research
+  - agent-runtime
+  - cli-agent
+  - messaging-platform
 readingTime: 9
 imageAlt: Illustration for Hermes Agent
 sources:

--- a/apps/blog/src/content/articles/html-as-the-new-markdown.mdx
+++ b/apps/blog/src/content/articles/html-as-the-new-markdown.mdx
@@ -7,6 +7,10 @@ description: "Thariq Shihipar's thesis: as models improve, thousand-line
   human-facing harness grows"
 tag: Concept
 topic: harness
+tags:
+  - agent-engineering
+  - human-ai-collaboration
+  - planning
 readingTime: 7
 imageAlt: Illustration for HTML as the New Markdown
 sources:

--- a/apps/blog/src/content/articles/human-ai-accountability-redesign.mdx
+++ b/apps/blog/src/content/articles/human-ai-accountability-redesign.mdx
@@ -6,6 +6,12 @@ description: "HBR five-pillar prescription: span-of-control redesign, role
   decision-rights/escalation/consequences, agentic-unit-not-human-role design"
 tag: Concept
 topic: orgs
+tags:
+  - workforce
+  - governance
+  - ai-adoption
+  - org-design
+  - accountability
 readingTime: 6
 imageAlt: Illustration for Human-AI Accountability Redesign
 sources:

--- a/apps/blog/src/content/articles/human-facing-harness-bloat-ceiling.mdx
+++ b/apps/blog/src/content/articles/human-facing-harness-bloat-ceiling.mdx
@@ -7,6 +7,11 @@ description: Yes — HTML raises and reshapes the human-attention ceiling but
   improve (inverse of the shrinking model-facing harness)
 tag: Essay
 topic: interaction
+tags:
+  - harness
+  - human-ai-collaboration
+  - agent-engineering
+  - cognitive-load
 readingTime: 6
 imageAlt: Illustration for Does the Human-Facing Harness (HTML Artifacts) Hit
   Its Own Bloat Ceiling?

--- a/apps/blog/src/content/articles/interaction-background-model-split.mdx
+++ b/apps/blog/src/content/articles/interaction-background-model-split.mdx
@@ -7,6 +7,10 @@ description: 'Dual-model architecture: time-aware interaction model stays
   latency"'
 tag: Concept
 topic: interaction
+tags:
+  - llm-architecture
+  - agent-engineering
+  - multimodal
 readingTime: 3
 imageAlt: Illustration for Interaction / Background Model Split
 sources:

--- a/apps/blog/src/content/articles/interaction-models.mdx
+++ b/apps/blog/src/content/articles/interaction-models.mdx
@@ -6,6 +6,10 @@ description: "Thinking Machines Lab (May 2026): models that handle
   interactivity scales with intelligence only if it's in the model"
 tag: Concept
 topic: interaction
+tags:
+  - llm-architecture
+  - multimodal
+  - human-ai-collaboration
 readingTime: 6
 imageAlt: Illustration for Interaction Models
 sources:

--- a/apps/blog/src/content/articles/interactivity-benchmarks.mdx
+++ b/apps/blog/src/content/articles/interactivity-benchmarks.mdx
@@ -7,6 +7,10 @@ description: "FD-bench, Audio MultiChallenge + new TimeSpeak/CueSpeak (proactive
   quality"
 tag: Concept
 topic: interaction
+tags:
+  - llm-evaluation
+  - multimodal
+  - human-ai-collaboration
 readingTime: 4
 imageAlt: Illustration for Interactivity Benchmarks
 sources:

--- a/apps/blog/src/content/articles/learning-to-cowork-with-ai-engineer-guide.mdx
+++ b/apps/blog/src/content/articles/learning-to-cowork-with-ai-engineer-guide.mdx
@@ -7,6 +7,11 @@ description: "Field guide for software engineers in the AI era: 6 skill clusters
   plan"
 tag: Essay
 topic: interaction
+tags:
+  - career
+  - learning-guide
+  - ai-coworking
+  - skills-development
 readingTime: 17
 imageAlt: "Illustration for Learning to Co-Work with AI: A Software Engineer's
   Field Guide"

--- a/apps/blog/src/content/articles/living-design-system.mdx
+++ b/apps/blog/src/content/articles/living-design-system.mdx
@@ -6,6 +6,10 @@ description: "`design_system.html` extracted from repos as a portable, human-
   engineering ↔ non-technical stakeholders"
 tag: Concept
 topic: interaction
+tags:
+  - agent-engineering
+  - design-systems
+  - human-ai-collaboration
 readingTime: 4
 imageAlt: Illustration for Living Design System
 sources:

--- a/apps/blog/src/content/articles/llm-as-compiler-knowledge-base.mdx
+++ b/apps/blog/src/content/articles/llm-as-compiler-knowledge-base.mdx
@@ -6,6 +6,10 @@ description: "Karpathy's architecture: LLM incrementally compiles raw docs into
   ingest→compile→query→lint pipeline"
 tag: Concept
 topic: architecture
+tags:
+  - knowledge-management
+  - llm-architecture
+  - personal-knowledge-base
 readingTime: 8
 imageAlt: Illustration for LLM-as-Compiler Knowledge Base
 sources:

--- a/apps/blog/src/content/articles/llm-driven-vulnerability-research.mdx
+++ b/apps/blog/src/content/articles/llm-driven-vulnerability-research.mdx
@@ -6,6 +6,11 @@ description: "Claude Mythos Preview's emergent cybersecurity capabilities:
   Glasswing response"
 tag: Concept
 topic: alignment
+tags:
+  - cybersecurity
+  - llm-capabilities
+  - vulnerability-research
+  - exploit-development
 readingTime: 9
 imageAlt: Illustration for LLM-Driven Vulnerability Research
 sources:

--- a/apps/blog/src/content/articles/matt-pocock.mdx
+++ b/apps/blog/src/content/articles/matt-pocock.mdx
@@ -6,6 +6,10 @@ description: Independent AI-coding educator; built Sandcastle library;
   bad agents"
 tag: Entity
 topic: orgs
+tags:
+  - entity
+  - person
+  - ai-coding
 readingTime: 4
 imageAlt: Illustration for Matt Pocock
 sources:

--- a/apps/blog/src/content/articles/model-introspection-feedback.mdx
+++ b/apps/blog/src/content/articles/model-introspection-feedback.mdx
@@ -6,6 +6,10 @@ description: "Cat Wu's underrated technique: ask the model why it failed; treat
   self-report fidelity"
 tag: Concept
 topic: harness
+tags:
+  - agent-engineering
+  - debugging
+  - prompting
 readingTime: 5
 imageAlt: Illustration for Model Introspection Feedback
 sources:

--- a/apps/blog/src/content/articles/model-spec-midtraining.mdx
+++ b/apps/blog/src/content/articles/model-spec-midtraining.mdx
@@ -6,6 +6,13 @@ description: "New training phase between pretrain and AFT: train base model on
   agentic misalignment 54%→7%; beats deliberative alignment baseline"
 tag: Concept
 topic: architecture
+tags:
+  - alignment
+  - training
+  - synthetic-data
+  - generalization
+  - midtraining
+  - anthropic
 readingTime: 7
 imageAlt: Illustration for Model Spec Midtraining (MSM)
 sources:

--- a/apps/blog/src/content/articles/model-spec-science.mdx
+++ b/apps/blog/src/content/articles/model-spec-science.mdx
@@ -6,6 +6,11 @@ description: Empirical study of which Model Spec features best generalize
   framing; first concrete examples in Li et al. 2026
 tag: Concept
 topic: architecture
+tags:
+  - alignment
+  - model-spec
+  - empirical
+  - methodology
 readingTime: 5
 imageAlt: Illustration for Model Spec Science
 sources:

--- a/apps/blog/src/content/articles/mythos-model.mdx
+++ b/apps/blog/src/content/articles/mythos-model.mdx
@@ -5,6 +5,10 @@ description: Anthropic preview-tier frontier model; gated for safety; used
   internally alongside Opus 4.7; descendant expected to ship publicly later
 tag: Entity
 topic: orgs
+tags:
+  - entity
+  - model
+  - anthropic
 readingTime: 3
 imageAlt: Illustration for Mythos Model
 sources:

--- a/apps/blog/src/content/articles/printing-press-software-democratization.mdx
+++ b/apps/blog/src/content/articles/printing-press-software-democratization.mdx
@@ -6,6 +6,10 @@ description: "Boris Cherny's analogy: 1400s literacy expansion → AI
   disruption-grade startups predicted"
 tag: Concept
 topic: orgs
+tags:
+  - macro
+  - software-economics
+  - history
 readingTime: 6
 imageAlt: Illustration for Printing Press Software Democratization
 sources:

--- a/apps/blog/src/content/articles/scale-dependent-prompt-sensitivity.mdx
+++ b/apps/blog/src/content/articles/scale-dependent-prompt-sensitivity.mdx
@@ -6,6 +6,12 @@ description: Large models underperform small ones on 7.7% of standard benchmarks
   hierarchy on GSM8K/MMLU-STEM
 tag: Concept
 topic: architecture
+tags:
+  - llm-evaluation
+  - prompt-engineering
+  - inverse-scaling
+  - scaling-laws
+  - rlhf
 readingTime: 8
 imageAlt: Illustration for Scale-Dependent Prompt Sensitivity
 sources:

--- a/apps/blog/src/content/articles/seven-powers-applied-to-ai.mdx
+++ b/apps/blog/src/content/articles/seven-powers-applied-to-ai.mdx
@@ -6,6 +6,10 @@ description: "Helmer/Acquired framework re-evaluated for AI: switching costs and
   counter-positioning amplifies"
 tag: Concept
 topic: orgs
+tags:
+  - business-strategy
+  - moats
+  - ai-economy
 readingTime: 6
 imageAlt: Illustration for Seven Powers Applied to AI
 sources:

--- a/apps/blog/src/content/articles/symphony.mdx
+++ b/apps/blog/src/content/articles/symphony.mdx
@@ -6,6 +6,11 @@ description: "OpenAI's open-source agent orchestrator (March 2026): turns Linear
   SPEC.md-as-product, hedged 500% landed-PRs claim"
 tag: Entity
 topic: harness
+tags:
+  - entity
+  - openai
+  - agent-orchestration
+  - codex
 readingTime: 9
 imageAlt: Illustration for Symphony
 sources:

--- a/apps/blog/src/content/articles/synthetic-document-finetuning.mdx
+++ b/apps/blog/src/content/articles/synthetic-document-finetuning.mdx
@@ -6,6 +6,11 @@ description: Wang et al. 2025 technique for modifying model beliefs via
   builds on
 tag: Concept
 topic: alignment
+tags:
+  - synthetic-data
+  - training
+  - alignment
+  - belief-modification
 readingTime: 4
 imageAlt: Illustration for Synthetic Document Finetuning (SDF)
 sources:

--- a/apps/blog/src/content/articles/thariq-shihipar.mdx
+++ b/apps/blog/src/content/articles/thariq-shihipar.mdx
@@ -5,6 +5,10 @@ description: Engineer on the Claude Code team at Anthropic; "HTML is the new
   markdown" and "compute allocator" framings; three HTML-first workflows
 tag: Entity
 topic: orgs
+tags:
+  - entity
+  - person
+  - anthropic
 readingTime: 3
 imageAlt: Illustration for Thariq Shihipar
 sources:

--- a/apps/blog/src/content/articles/the-bitter-lesson.mdx
+++ b/apps/blog/src/content/articles/the-bitter-lesson.mdx
@@ -7,6 +7,9 @@ description: "Sutton 2019: scaled general methods beat hand-engineered
   inward"
 tag: Concept
 topic: architecture
+tags:
+  - llm-architecture
+  - principle
 readingTime: 4
 imageAlt: Illustration for The Bitter Lesson
 sources:

--- a/apps/blog/src/content/articles/thinking-machines-lab.mdx
+++ b/apps/blog/src/content/articles/thinking-machines-lab.mdx
@@ -6,6 +6,9 @@ description: AI research lab behind interaction models (May 2026);
   benchmarks against GPT-realtime / Gemini-live; research grants open
 tag: Entity
 topic: orgs
+tags:
+  - type/entity
+  - ai-lab
 readingTime: 3
 imageAlt: Illustration for Thinking Machines Lab
 sources:

--- a/apps/blog/src/content/articles/ticket-driven-agent-orchestration.mdx
+++ b/apps/blog/src/content/articles/ticket-driven-agent-orchestration.mdx
@@ -6,6 +6,10 @@ description: 'The inversion that makes Symphony work: tickets as units of work
   not transitions"'
 tag: Concept
 topic: harness
+tags:
+  - agent-engineering
+  - orchestration
+  - workflow-design
 readingTime: 8
 imageAlt: Illustration for Ticket-Driven Agent Orchestration
 sources:

--- a/apps/blog/src/content/articles/time-aligned-micro-turns.mdx
+++ b/apps/blog/src/content/articles/time-aligned-micro-turns.mdx
@@ -7,6 +7,10 @@ description: "The core interaction-model move: input/output as continuous
   trainer-sampler alignment"
 tag: Concept
 topic: architecture
+tags:
+  - llm-architecture
+  - multimodal
+  - inference
 readingTime: 4
 imageAlt: Illustration for Time-Aligned Micro-Turns
 sources:

--- a/apps/blog/src/content/articles/tml-interaction-small.mdx
+++ b/apps/blog/src/content/articles/tml-interaction-small.mdx
@@ -6,6 +6,9 @@ description: "TML's first interaction model: 276B MoE / 12B active,
   agent; best turn-taking latency of any model; research preview May 2026"
 tag: Entity
 topic: architecture
+tags:
+  - type/entity
+  - llm-model
 readingTime: 3
 imageAlt: Illustration for TML-Interaction-Small
 sources:

--- a/apps/blog/src/content/articles/turn-based-interface-bottleneck.mdx
+++ b/apps/blog/src/content/articles/turn-based-interface-bottleneck.mdx
@@ -6,6 +6,10 @@ description: "Why current AI interfaces limit collaboration: single-thread
   the work; less-intelligent harness (VAD/turn-detection) should dissolve"
 tag: Concept
 topic: interaction
+tags:
+  - human-ai-collaboration
+  - llm-architecture
+  - interface
 readingTime: 3
 imageAlt: Illustration for Turn-Based Interface Bottleneck
 sources:

--- a/apps/blog/src/content/articles/vertical-slice-tracer-bullets.mdx
+++ b/apps/blog/src/content/articles/vertical-slice-tracer-bullets.mdx
@@ -6,6 +6,10 @@ description: Pragmatic-Programmer tracer-bullet pattern applied to agent task
   over numbered phase plans
 tag: Concept
 topic: harness
+tags:
+  - agent-engineering
+  - software-design
+  - planning
 readingTime: 4
 imageAlt: Illustration for Vertical Slice Tracer Bullets
 sources:

--- a/apps/blog/src/utils/humanize-tag.ts
+++ b/apps/blog/src/utils/humanize-tag.ts
@@ -1,0 +1,34 @@
+const WORD_SPLIT = /[\s-]+/;
+
+/** Domain acronyms that should render upper-case rather than title-cased. */
+const ACRONYMS = new Set([
+  "ai",
+  "api",
+  "cli",
+  "cot",
+  "gpu",
+  "hr",
+  "llm",
+  "mcp",
+  "rag",
+  "rlhf",
+  "sft",
+  "ui",
+  "ux",
+]);
+
+/**
+ * Render a stored subject tag (lowercase kebab, e.g. `human-ai-collaboration`)
+ * as a display label (`Human AI Collaboration`), upper-casing known acronyms.
+ */
+export function humanizeTag(tag: string): string {
+  return tag
+    .split(WORD_SPLIT)
+    .filter(Boolean)
+    .map((word) =>
+      ACRONYMS.has(word)
+        ? word.toUpperCase()
+        : word.charAt(0).toUpperCase() + word.slice(1)
+    )
+    .join(" ");
+}

--- a/apps/blog/src/utils/tagged-href.ts
+++ b/apps/blog/src/utils/tagged-href.ts
@@ -1,0 +1,8 @@
+/**
+ * Link to a subject tag's `/articles/tagged/[tag]` page. The segment is
+ * encoded because a few wiki tags carry a `/` (e.g. `type/entity`), which Next
+ * prerenders as `%2F` and must be linked the same way to resolve to the single
+ * dynamic segment.
+ */
+export const taggedHref = (tag: string): string =>
+  `/articles/tagged/${encodeURIComponent(tag)}`;

--- a/apps/cli/src/import-wiki/emit.ts
+++ b/apps/cli/src/import-wiki/emit.ts
@@ -27,6 +27,14 @@ export interface ArticleMeta {
    */
   sources?: SourceRef[];
   tag: WikiTag;
+  /**
+   * The wiki note's real subject labels, passed through verbatim (lowercase
+   * kebab) from its frontmatter `tags`. NOTE: distinct from the singular
+   * `tag` above (the article "kind") and the single derived `topic` below
+   * (the accent/grouping bucket). Drives the tag chips and `/articles/tagged`
+   * routes. Omitted when the note has no tags.
+   */
+  tags?: string[];
   title: string;
   /**
    * Curated subject bucket derived from the wiki note's `tags`. Drives the
@@ -57,6 +65,7 @@ export function buildArticleSource(
     description: meta.description,
     tag: meta.tag,
     ...(meta.topic ? { topic: meta.topic } : {}),
+    ...(meta.tags && meta.tags.length > 0 ? { tags: meta.tags } : {}),
     readingTime: meta.readingTime,
     imageAlt,
     ...(meta.sources && meta.sources.length > 0

--- a/apps/cli/src/import-wiki/index.ts
+++ b/apps/cli/src/import-wiki/index.ts
@@ -22,6 +22,7 @@ import {
   extractRawSlugsFromBody,
   extractRawSlugsFromSources,
   loadRawDoc,
+  normaliseTags,
   type ParsedWikiFile,
   parseIndexSummaries,
   parseWikiFile,
@@ -293,6 +294,8 @@ async function processArticle(
     explicitOverride ??
     (isEntity && defaultTag === "Concept" ? "Entity" : defaultTag);
 
+  const tags = normaliseTags(frontmatter.tags);
+
   const meta: ArticleMeta = {
     date: resolveDate(parsed),
     title,
@@ -300,6 +303,7 @@ async function processArticle(
     readingTime: computeReadingTime(body),
     tag,
     topic: deriveTopic(frontmatter.tags),
+    ...(tags.length > 0 ? { tags } : {}),
     ...(sources.length > 0 ? { sources } : {}),
   };
 

--- a/apps/cli/src/import-wiki/parse.ts
+++ b/apps/cli/src/import-wiki/parse.ts
@@ -334,6 +334,28 @@ export function titleFromSlug(slug: string): string {
 }
 
 /**
+ * Normalise a wiki note's raw `tags` into the list emitted to article
+ * frontmatter: trimmed, lowercased, de-duplicated, empties dropped, source
+ * order preserved. The note's `tags` are the real subject labels — distinct
+ * from the single derived `topic` bucket (see `topics.ts`).
+ */
+export function normaliseTags(tags: readonly string[] | undefined): string[] {
+  if (!tags) {
+    return [];
+  }
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const raw of tags) {
+    const tag = raw.trim().toLowerCase();
+    if (tag.length > 0 && !seen.has(tag)) {
+      seen.add(tag);
+      result.push(tag);
+    }
+  }
+  return result;
+}
+
+/**
  * Resolve the article's publish date:
  *   concepts → created → updated → mtime
  *   derived  → generated → updated → mtime


### PR DESCRIPTION
## Summary

Replaces topic-only navigation with the wiki notes' **real, multi-valued `tags`** — additively. The derived single `topic` is kept solely as the 5-colour accent + home-page plate-stack grouping; the free-form `tags` become the surfaced, navigable content layer on top.

- **CLI importer** now passes a note's frontmatter `tags` straight through to article frontmatter (trimmed, lower-cased, de-duped, order preserved). `topic`/`deriveTopic` are untouched.
- **Blog** renders tags as chips using the design system's `Badge` `chip` variant:
  - article **detail** metadata grid — a new "Tags" row (all tags)
  - articles **index** rows — under each title, capped to 3 with a `+N` overflow
  - a new **"By subject" plate** on the articles index — every subject tag as a clickable chip, ordered by reference count; multi-article tags open their tag page, a single-article tag links straight to that article
  - the dense home plate stack and backlink rows keep just the existing topic dot
- New **`/articles/tagged/[tag]`** static route, generated only for tags shared by **≥2 articles**; rarer/singleton tags render as inert (non-clickable) chips.
- Re-ran the wiki importer to **backfill `tags:`** across the articles.

## Design notes

- The route is `/articles/tagged/[tag]`, **not** `/articles/tag/[tag]` — the latter is already the article-*kind* route (`tag-sections.ts`). Three deliberately-distinct fields now coexist: singular `tag` (kind: Concept/Entity/…), `topic` (derived accent bucket), and plural `tags` (free-form subjects). The proximity is documented in the schema JSDoc.
- `tags` are stored verbatim (lowercase kebab) and humanised only at render (`humanize-tag.ts`).
- The Badge-based subject chip is named **`SubjectChip`/`SubjectChipList`** to keep it distinct from the existing kind-enum `TagChip` (`components/tag-chip`). `taggedHref` centralises and URL-encodes the tag-page link; `getNavigableTagSet` shares one memoised `ReadonlySet` across the chip surfaces rather than rebuilding it per page.

## Commits (atomic)

1. `feat(cli)` — emit wiki note tags into article frontmatter
2. `feat(blog)` — subject tag chips + `/articles/tagged` routes
3. `chore(blog)` — backfill article tags from wiki import
4. `feat(blog)` — add by-subject tag index plate
5. `refactor(blog)` — disambiguate subject chip + memoise navigable set
6. `fix(blog)` — encode tag segment in tagged-page canonical URL

## Verification (run this session)

- `bun run type-check` — pass (all 5 packages)
- `bun run lint` (ultracite) — clean
- `bun run build` — 122 static pages, including 39 `/articles/tagged/*` pages generated from real data
- `bun run test` — 81 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)
