### PR TITLE
:construction_worker: ci: set up node 24 in release job for semantic-release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,11 @@ jobs:
         with:
           bun-version-file: package.json
 
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 


### PR DESCRIPTION
## Problem

The `release` job in the CI/CD workflow failed on the first run after switching to semantic-release (PR #805): [run 26267053183](https://github.com/howard86/howardism/actions/runs/26267053183/job/77312581775).

```
[semantic-release]: node version ^22.14.0 || >= 24.10.0 is required. Found v20.20.2.
```

## Root cause

The `release` job set up Bun but no Node. `bunx semantic-release` (without `--bun`) honors the bin's `#!/usr/bin/env node` shebang and runs on the runner's **default system Node (v20.20.2)** — not Bun's runtime — which fails `semantic-release@25`'s engine requirement (`^22.14.0 || >=24.10.0`).

## Fix

Add `actions/setup-node` (pinned to v6.4.0) with `node-version: "24"` to the release job, so semantic-release runs on Node 24. This matches `engines.node: ">=24"` and the `ci` job's `node-version: "24"`.

## Verification

- Confirmed locally that `bun run`/`bunx` honors a `#!/usr/bin/env node` shebang and spawns system Node rather than Bun's runtime, explaining the `v20.20.2` reading.
- `ci.yml` parses as valid YAML; release steps are now Checkout → Setup Bun → Setup Node → Install → Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)