### PR TITLE
:recycle: refactor: extract shared @howardism/article-contract module

### DIFF
--- a/apps/blog/next.config.ts
+++ b/apps/blog/next.config.ts
@@ -102,7 +102,7 @@ const nextConfig: NextConfig = {
     dirname(fileURLToPath(import.meta.url)),
     "../../"
   ),
-  transpilePackages: ["@howardism/ui"],
+  transpilePackages: ["@howardism/ui", "@howardism/article-contract"],
   images: {
     remotePatterns: [{ protocol: "https", hostname: "images.unsplash.com" }],
   },

--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -13,6 +13,7 @@
     "start": "next start"
   },
   "dependencies": {
+    "@howardism/article-contract": "workspace:*",
     "@howardism/ui": "workspace:*",
     "@mdx-js/loader": "^3.0.1",
     "@next/mdx": "^16.2.2",

--- a/apps/blog/src/app/(blog)/articles/service.ts
+++ b/apps/blog/src/app/(blog)/articles/service.ts
@@ -3,6 +3,16 @@ import "server-only";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 
+import {
+  WIKI_TAGS,
+  WIKI_TOPICS,
+  type WikiTag,
+  type WikiTopic,
+} from "@howardism/article-contract";
+import {
+  ArticleContractSchema,
+  type SourceRefSchema,
+} from "@howardism/article-contract/schema";
 import glob from "fast-glob";
 import GithubSlugger from "github-slugger";
 import type { StaticImageData } from "next/image";
@@ -13,6 +23,13 @@ import graphData from "@/data/article-graph.json";
 import wikiLogData from "@/data/wiki-log.json";
 import wikiSourcesData from "@/data/wiki-sources.json";
 import { taggedHref } from "@/utils/tagged-href";
+
+export type ArticleTag = WikiTag;
+export type ArticleTopic = WikiTopic;
+export const ARTICLE_TAGS = WIKI_TAGS;
+export const ARTICLE_TOPICS = WIKI_TOPICS;
+
+export type SourceRef = z.infer<typeof SourceRefSchema>;
 
 export interface Normalise<T> {
   entities: Record<string, T | undefined>;
@@ -26,77 +43,10 @@ export interface ArticleEntity {
   slug: string;
 }
 
-/**
- * Mirror of `WIKI_TAGS` in `apps/cli/src/import-wiki/emit.ts`. Keep these
- * unions aligned — the wiki importer is the source of truth for which tags
- * can appear in graph-derived articles.
- */
-export type ArticleTag = "Concept" | "Entity" | "Essay" | "Index" | "Changelog";
-
-const ARTICLE_TAGS: readonly ArticleTag[] = [
-  "Concept",
-  "Entity",
-  "Essay",
-  "Index",
-  "Changelog",
-];
-
-/**
- * Mirror of `WIKI_TOPICS` in `apps/cli/src/import-wiki/topics.ts`. The importer
- * derives an article's `topic` from its wiki tags; the home page groups work
- * into these five subject buckets.
- */
-export type ArticleTopic =
-  | "interaction"
-  | "architecture"
-  | "harness"
-  | "alignment"
-  | "orgs";
-
-export const ARTICLE_TOPICS: readonly ArticleTopic[] = [
-  "interaction",
-  "architecture",
-  "harness",
-  "alignment",
-  "orgs",
-];
-
-const SourceRefSchema = z.object({
-  title: z.string(),
-  url: z.url().optional(),
-});
-
-export type SourceRef = z.infer<typeof SourceRefSchema>;
-
-const ArticleMetaSchema = z.object({
+const ArticleMetaSchema = ArticleContractSchema.extend({
   archived: z.boolean().optional(),
-  date: z.string(),
-  description: z.string(),
   dropCap: z.boolean().optional(),
   imageAlt: z.string(),
-  readingTime: z.number(),
-  /**
-   * Audit trail of external source documents the article was synthesised
-   * from. Set by the wiki importer from `raw/<slug>.md` frontmatter; the
-   * rendered `## Sources` block in the MDX body is derived from this list.
-   */
-  sources: z.array(SourceRefSchema).optional(),
-  tag: z.enum(ARTICLE_TAGS),
-  /**
-   * The wiki note's real subject labels (lowercase kebab), passed through by
-   * the importer. NOTE the deliberate naming proximity: singular `tag` above
-   * is the article "kind" (Concept/Entity/…); plural `tags` here are the
-   * free-form subjects that drive the chips and `/articles/tagged/[tag]`
-   * routes; `topic` below is the single derived accent/grouping bucket.
-   */
-  tags: z.array(z.string()).optional(),
-  title: z.string(),
-  /**
-   * Curated subject bucket derived by the wiki importer from the note's tags.
-   * Drives the home page's topic plate stack. Absent on non-topical pages
-   * (e.g. the wiki changelog).
-   */
-  topic: z.enum(ARTICLE_TOPICS).optional(),
 });
 
 export type ArticleMeta = z.infer<typeof ArticleMetaSchema>;

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -10,6 +10,7 @@
     "import:wiki": "bun src/import-wiki/index.ts"
   },
   "dependencies": {
+    "@howardism/article-contract": "workspace:*",
     "gray-matter": "^4.0.3",
     "yaml": "^2.9.0"
   },

--- a/apps/cli/src/import-wiki/emit.ts
+++ b/apps/cli/src/import-wiki/emit.ts
@@ -1,48 +1,10 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
+import type { ArticleContract } from "@howardism/article-contract";
 import YAML from "yaml";
-import type { WikiTopic } from "./topics.ts";
-import type { SourceRef } from "./transform.ts";
 
-export type WikiTag = "Concept" | "Entity" | "Essay" | "Index" | "Changelog";
-
-export const WIKI_TAGS: readonly WikiTag[] = [
-  "Concept",
-  "Entity",
-  "Essay",
-  "Index",
-  "Changelog",
-];
-
-export interface ArticleMeta {
-  date: string;
-  description: string;
-  readingTime: number;
-  /**
-   * Per-article audit trail of external raw source documents. Frontmatter
-   * is the structured source of truth; the rendered `## Sources` section
-   * in the body is derived from this list at import time. Omitted from
-   * frontmatter when empty.
-   */
-  sources?: SourceRef[];
-  tag: WikiTag;
-  /**
-   * The wiki note's real subject labels, passed through verbatim (lowercase
-   * kebab) from its frontmatter `tags`. NOTE: distinct from the singular
-   * `tag` above (the article "kind") and the single derived `topic` below
-   * (the accent/grouping bucket). Drives the tag chips and `/articles/tagged`
-   * routes. Omitted when the note has no tags.
-   */
-  tags?: string[];
-  title: string;
-  /**
-   * Curated subject bucket derived from the wiki note's `tags`. Drives the
-   * home page's topic plate stack. Omitted for non-topical pages (the wiki
-   * changelog). See `topics.ts`.
-   */
-  topic?: WikiTopic;
-}
+export type ArticleMeta = ArticleContract;
 
 export interface EmitArticleArgs {
   articlesDir: string;

--- a/apps/cli/src/import-wiki/index.ts
+++ b/apps/cli/src/import-wiki/index.ts
@@ -1,13 +1,13 @@
 import { access, mkdir, readFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 
-import { generateHeroImage } from "./codex.ts";
 import {
-  type ArticleMeta,
-  emitArticle,
+  type SourceRef,
   WIKI_TAGS,
   type WikiTag,
-} from "./emit.ts";
+} from "@howardism/article-contract";
+import { generateHeroImage } from "./codex.ts";
+import { type ArticleMeta, emitArticle } from "./emit.ts";
 import {
   type ArticleGraph,
   buildArticleGraph,
@@ -40,7 +40,6 @@ import {
   firstParagraph,
   redactLocalPaths,
   rewriteWikilinks,
-  type SourceRef,
   stripDuplicateLeadingHeading,
 } from "./transform.ts";
 

--- a/apps/cli/src/import-wiki/topics.ts
+++ b/apps/cli/src/import-wiki/topics.ts
@@ -7,24 +7,11 @@
  * that is *about* something technical still lands in its technical bucket even
  * when it also carries a categorical `entity`/`org` tag.
  *
- * This is the source of truth for the topic axis — the importer emits the
- * derived `topic` into each article's MDX frontmatter, and the blog mirrors the
- * `WikiTopic` union in `apps/blog/src/app/(blog)/articles/service.ts`.
+ * The `@howardism/article-contract` package is the source of truth for the
+ * `WikiTopic` union and `WIKI_TOPICS` array. This file owns only the
+ * derivation logic that maps wiki tags → topics.
  */
-export type WikiTopic =
-  | "interaction"
-  | "architecture"
-  | "harness"
-  | "alignment"
-  | "orgs";
-
-export const WIKI_TOPICS: readonly WikiTopic[] = [
-  "interaction",
-  "architecture",
-  "harness",
-  "alignment",
-  "orgs",
-];
+import { WIKI_TOPICS, type WikiTopic } from "@howardism/article-contract";
 
 /**
  * Tie-break order (earlier wins). The categorical `orgs` bucket is last so an

--- a/apps/cli/src/import-wiki/transform.ts
+++ b/apps/cli/src/import-wiki/transform.ts
@@ -1,9 +1,6 @@
-import { type RawDoc, titleFromSlug } from "./parse.ts";
+import type { SourceRef } from "@howardism/article-contract";
 
-export interface SourceRef {
-  title: string;
-  url?: string;
-}
+import { type RawDoc, titleFromSlug } from "./parse.ts";
 
 // Accepts both `[[target|label]]` and `[[target\|label]]` — the latter is the
 // Obsidian convention for embedding pipes inside markdown tables.

--- a/bun.lock
+++ b/bun.lock
@@ -33,6 +33,7 @@
       "name": "@howardism/blog",
       "version": "2.9.0",
       "dependencies": {
+        "@howardism/article-contract": "workspace:*",
         "@howardism/ui": "workspace:*",
         "@mdx-js/loader": "^3.0.1",
         "@next/mdx": "^16.2.2",
@@ -75,11 +76,23 @@
       "name": "@howardism/cli",
       "version": "0.0.0",
       "dependencies": {
+        "@howardism/article-contract": "workspace:*",
         "gray-matter": "^4.0.3",
         "yaml": "^2.9.0",
       },
       "devDependencies": {
         "@howardism/tsconfig": "workspace:*",
+      },
+    },
+    "packages/article-contract": {
+      "name": "@howardism/article-contract",
+      "version": "0.0.1",
+      "dependencies": {
+        "zod": "^4.3.6",
+      },
+      "devDependencies": {
+        "@howardism/tsconfig": "workspace:*",
+        "typescript": "^6.0.2",
       },
     },
     "packages/test-config": {
@@ -218,6 +231,8 @@
     "@gitmoji/parser-opts": ["@gitmoji/parser-opts@1.4.0", "", { "dependencies": { "@gitmoji/gitmoji-regex": "1.0.0" } }, "sha512-zzmx/vtpdB/ijjUm7u9OzHNCXWKpSbzVEgVzOzhilMgoTBlUDyInZFUtiCTV+Wf4oCP9nxGa/kQGQFfN+XLH1g=="],
 
     "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.8.9", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.8.9" } }, "sha512-DtZeRRHY9A/bisTJziUBBPrdnPui7+R185G/hzi6/Boymhqh7/wi53AY+IvQHS1+7OPaqfO/1XNpngNwthLz+A=="],
+
+    "@howardism/article-contract": ["@howardism/article-contract@workspace:packages/article-contract"],
 
     "@howardism/blog": ["@howardism/blog@workspace:apps/blog"],
 

--- a/packages/article-contract/package.json
+++ b/packages/article-contract/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@howardism/article-contract",
+  "version": "0.0.1",
+  "private": true,
+  "license": "MIT",
+  "exports": {
+    ".": "./src/index.ts",
+    "./schema": "./src/schema.ts"
+  },
+  "scripts": {
+    "type-check": "tsc --noEmit",
+    "clean": "rm -rf node_modules"
+  },
+  "dependencies": {
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@howardism/tsconfig": "workspace:*",
+    "typescript": "^6.0.2"
+  }
+}

--- a/packages/article-contract/src/index.ts
+++ b/packages/article-contract/src/index.ts
@@ -1,0 +1,57 @@
+export const WIKI_TAGS = [
+  "Concept",
+  "Entity",
+  "Essay",
+  "Index",
+  "Changelog",
+] as const;
+
+export type WikiTag = (typeof WIKI_TAGS)[number];
+
+export const WIKI_TOPICS = [
+  "interaction",
+  "architecture",
+  "harness",
+  "alignment",
+  "orgs",
+] as const;
+
+export type WikiTopic = (typeof WIKI_TOPICS)[number];
+
+export interface SourceRef {
+  title: string;
+  url?: string;
+}
+
+/**
+ * Write-side article contract: exactly the fields the wiki importer emits into
+ * MDX frontmatter and the blog validates on read. Blog-only read-time fields
+ * (archived, dropCap, imageAlt) are NOT here — see ./schema and the blog.
+ */
+export interface ArticleContract {
+  date: string;
+  description: string;
+  readingTime: number;
+  /**
+   * Audit trail of external source documents the article was synthesised from.
+   * Set by the wiki importer from `raw/<slug>.md` frontmatter; the rendered
+   * `## Sources` block in the MDX body is derived from this list.
+   */
+  sources?: SourceRef[];
+  /** The article "kind" (Concept/Entity/Essay/Index/Changelog). */
+  tag: WikiTag;
+  /**
+   * The wiki note's free-form subject labels (lowercase kebab), passed through
+   * verbatim by the importer. Distinct from singular `tag` (the kind) and from
+   * `topic` (the single derived bucket); these drive the tag chips and
+   * `/articles/tagged/[tag]` routes. Omitted when the note has no tags.
+   */
+  tags?: string[];
+  title: string;
+  /**
+   * Curated subject bucket derived by the importer from the note's `tags`.
+   * Drives the home page's topic plate stack. Absent on non-topical pages
+   * (e.g. the wiki changelog).
+   */
+  topic?: WikiTopic;
+}

--- a/packages/article-contract/src/schema.ts
+++ b/packages/article-contract/src/schema.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+import { WIKI_TAGS, WIKI_TOPICS } from "./index";
+
+export const SourceRefSchema = z.object({
+  title: z.string(),
+  url: z.url().optional(),
+});
+
+export const ArticleContractSchema = z.object({
+  date: z.string(),
+  description: z.string(),
+  readingTime: z.number(),
+  sources: z.array(SourceRefSchema).optional(),
+  tag: z.enum(WIKI_TAGS),
+  tags: z.array(z.string()).optional(),
+  title: z.string(),
+  topic: z.enum(WIKI_TOPICS).optional(),
+});

--- a/packages/article-contract/tsconfig.json
+++ b/packages/article-contract/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@howardism/tsconfig/base",
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}


### PR DESCRIPTION
## What

Extracts the duplicated **article contract** into one new workspace package, `@howardism/article-contract`:

- `src/index.ts` — the `tag`/`topic` unions (`WIKI_TAGS`/`WIKI_TOPICS`), `SourceRef`, and the write-side `ArticleContract` shape (incl. the `tags` free-form array), with no runtime deps.
- `src/schema.ts` — `SourceRefSchema` + `ArticleContractSchema` (zod v4), behind a `./schema` sub-export so type-only consumers never pull in zod.

The wiki importer (`emit.ts`/`topics.ts`/`transform.ts`/`index.ts`) now imports the contract for **types**; the blog (`service.ts`) imports it for **runtime validation** and extends it locally.

## Why

The contract was written **twice** — once in the CLI, once in the blog — and kept in sync by hand-comments ("keep these unions aligned"). Drift was silent and type-check-invisible. This collapses the two mirrors into one module: the comment becomes a real dependency edge.

Blog **read-time-only** fields (`archived`, `dropCap`, `imageAlt`) deliberately stay local via `ArticleContractSchema.extend(...)` — they are not part of the importer's contract. Importer-only topic-derivation logic stays in `topics.ts`.

The blog keeps its public names (`ArticleTag`, `ArticleTopic`, `ARTICLE_TAGS`, `ARTICLE_TOPICS`) via re-alias, so no downstream blog files change.

## Verification (run in this worktree)

- `bun run type-check` — ✅ 4/4 packages
- `bun run test` — ✅ 166 tests (89 blog + 77 CLI)
- `bun x ultracite check` — ✅ clean
- `bun run build` — ✅ blog production build green

## Notes

First of a stacked series of five "deepening" refactors (#1 → #4 → #2 → #5 → #3). Branched off `main`; later PRs stack on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)