### PR TITLE
:recycle: refactor(blog): collapse graph-connection trio into getArticleConnections

### DIFF
--- a/apps/blog/src/__tests__/articles/article-rail.test.tsx
+++ b/apps/blog/src/__tests__/articles/article-rail.test.tsx
@@ -3,8 +3,8 @@ import { describe, expect, it } from "bun:test";
 import { ArticleRail } from "@/app/(blog)/articles/[slug]/article-rail";
 import type { ArticleHeading } from "@/app/(blog)/articles/service";
 
-// A slug absent from the article graph: getBacklinks and getRelated both
-// resolve to empty arrays, so `headings` is the rail's only content source.
+// A slug absent from the article graph: getArticleConnections resolves to
+// empty arrays, so `headings` is the rail's only content source.
 const SLUG_WITHOUT_LINKS = "slug-absent-from-article-graph";
 
 const HEADING: ArticleHeading = { depth: 2, id: "intro", text: "Intro" };

--- a/apps/blog/src/__tests__/articles/service.test.ts
+++ b/apps/blog/src/__tests__/articles/service.test.ts
@@ -1,11 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import {
   type ArticleTag,
+  getArticleConnections,
   getArticlesByTag,
-  getBacklinks,
   getHeadings,
-  getOutgoing,
-  getRelated,
   getSlicedArticles,
   getTagCounts,
   getVisibleArticles,
@@ -21,18 +19,18 @@ const WIKI_TAGS = ["Concept", "Entity", "Essay", "Index", "Changelog"] as const;
 const tagsSet: ReadonlySet<string> = new Set(WIKI_TAGS);
 
 describe("graph-backed service helpers", () => {
-  it("getBacklinks returns ArticleLink entries in the graph's recorded order, visible only", async () => {
+  it("getArticleConnections returns backlinks in the graph's recorded order, visible only", async () => {
     const visible = await getVisibleArticles();
     const visibleSlugs = new Set(visible.ids);
 
     const graphSlugs = graphData.backlinks[KNOWN_SLUG] ?? [];
     const expectedVisible = graphSlugs.filter((slug) => visibleSlugs.has(slug));
 
-    const links = await getBacklinks(KNOWN_SLUG);
+    const { backlinks } = await getArticleConnections(KNOWN_SLUG);
 
-    expect(links.length).toBe(expectedVisible.length);
-    expect(links.map((link) => link.slug)).toEqual(expectedVisible);
-    for (const link of links) {
+    expect(backlinks.length).toBe(expectedVisible.length);
+    expect(backlinks.map((link) => link.slug)).toEqual(expectedVisible);
+    for (const link of backlinks) {
       expect(visibleSlugs.has(link.slug)).toBe(true);
       const entity = visible.entities[link.slug];
       expect(entity).toBeDefined();
@@ -40,35 +38,31 @@ describe("graph-backed service helpers", () => {
     }
   });
 
-  it("getOutgoing returns visible outgoing links in graph order", async () => {
-    const visible = await getVisibleArticles();
-    const visibleSlugs = new Set(visible.ids);
-
-    const graphSlugs = graphData.outgoing[KNOWN_SLUG] ?? [];
-    const expectedVisible = graphSlugs.filter((slug) => visibleSlugs.has(slug));
-
-    const links = await getOutgoing(KNOWN_SLUG);
-
-    expect(links.map((link) => link.slug)).toEqual(expectedVisible);
-  });
-
-  it("getRelated returns at most five visible related links", async () => {
-    const links = await getRelated(KNOWN_SLUG);
-    expect(links.length).toBeLessThanOrEqual(5);
+  it("getArticleConnections returns at most five visible related links", async () => {
+    const { related } = await getArticleConnections(KNOWN_SLUG);
+    expect(related.length).toBeLessThanOrEqual(5);
 
     const visible = await getVisibleArticles();
     const visibleSlugs = new Set(visible.ids);
-    for (const link of links) {
+    for (const link of related) {
       expect(visibleSlugs.has(link.slug)).toBe(true);
       expect(link.slug).not.toBe(KNOWN_SLUG);
     }
   });
 
-  it("graph-backed helpers return [] for an unknown slug", async () => {
+  it("getArticleConnections returns both backlinks and related in a single call", async () => {
+    const connections = await getArticleConnections(KNOWN_SLUG);
+    expect(connections).toHaveProperty("backlinks");
+    expect(connections).toHaveProperty("related");
+    expect(Array.isArray(connections.backlinks)).toBe(true);
+    expect(Array.isArray(connections.related)).toBe(true);
+  });
+
+  it("getArticleConnections returns empty arrays for an unknown slug", async () => {
     const unknown = "definitely-not-a-real-slug-xyz";
-    expect(await getBacklinks(unknown)).toEqual([]);
-    expect(await getOutgoing(unknown)).toEqual([]);
-    expect(await getRelated(unknown)).toEqual([]);
+    const { backlinks, related } = await getArticleConnections(unknown);
+    expect(backlinks).toEqual([]);
+    expect(related).toEqual([]);
   });
 });
 

--- a/apps/blog/src/app/(blog)/articles/[slug]/article-layout.tsx
+++ b/apps/blog/src/app/(blog)/articles/[slug]/article-layout.tsx
@@ -10,7 +10,7 @@ import { SubjectChipList } from "@/components/howardism/subject-chip-list";
 import { TopicLabel } from "@/components/howardism/topic-label";
 import { formatDate } from "@/utils/time";
 
-import type { ArticleHeading, ArticleMeta } from "../service";
+import type { ArticleHeading, ArticleMeta, SiblingNav } from "../service";
 import { TOPIC_META } from "../topic-meta";
 import { ArticleRail } from "./article-rail";
 import { BacklinksDisclosure } from "./backlinks-disclosure";
@@ -22,10 +22,7 @@ interface ArticleLayoutProps {
   meta: ArticleMeta;
   /** Subject tags with their own page — used to decide which chips link. */
   navigable?: ReadonlySet<string>;
-  nextSlug?: string;
-  nextTitle?: string;
-  previousSlug?: string;
-  previousTitle?: string;
+  siblings?: SiblingNav;
   slug: string;
 }
 
@@ -44,12 +41,10 @@ export function ArticleLayout({
   heroImage,
   meta,
   navigable = NO_NAVIGABLE_TAGS,
-  previousSlug,
-  previousTitle,
-  nextSlug,
-  nextTitle,
+  siblings,
   slug,
 }: ArticleLayoutProps) {
+  const { previousSlug, previousTitle, nextSlug, nextTitle } = siblings ?? {};
   const accent = meta.topic ? TOPIC_META[meta.topic].color : "var(--brand)";
   const topicRow: [string, ReactNode] | null = meta.topic
     ? ["Topic", <TopicLabel key="topic" topic={meta.topic} />]

--- a/apps/blog/src/app/(blog)/articles/[slug]/article-rail.tsx
+++ b/apps/blog/src/app/(blog)/articles/[slug]/article-rail.tsx
@@ -1,8 +1,7 @@
 import {
   type ArticleHeading,
   type ArticleLink,
-  getBacklinks,
-  getRelated,
+  getArticleConnections,
 } from "../service";
 import { ArticleLinkRow } from "./article-link-row";
 import { ArticleToc } from "./article-toc";
@@ -14,10 +13,7 @@ interface ArticleRailProps {
 }
 
 export async function ArticleRail({ headings, slug }: ArticleRailProps) {
-  const [backlinks, related] = await Promise.all([
-    getBacklinks(slug),
-    getRelated(slug),
-  ]);
+  const { backlinks, related } = await getArticleConnections(slug);
 
   const isEmpty =
     headings.length === 0 && related.length === 0 && backlinks.length === 0;

--- a/apps/blog/src/app/(blog)/articles/[slug]/backlinks-disclosure.tsx
+++ b/apps/blog/src/app/(blog)/articles/[slug]/backlinks-disclosure.tsx
@@ -1,4 +1,4 @@
-import { type ArticleLink, getBacklinks, getRelated } from "../service";
+import { type ArticleLink, getArticleConnections } from "../service";
 import { ArticleLinkRow } from "./article-link-row";
 
 interface BacklinksDisclosureProps {
@@ -10,10 +10,7 @@ export async function BacklinksDisclosure({
   defaultOpen = false,
   slug,
 }: BacklinksDisclosureProps) {
-  const [backlinks, related] = await Promise.all([
-    getBacklinks(slug),
-    getRelated(slug),
-  ]);
+  const { backlinks, related } = await getArticleConnections(slug);
 
   return (
     <BacklinksDisclosureView

--- a/apps/blog/src/app/(blog)/articles/[slug]/page.tsx
+++ b/apps/blog/src/app/(blog)/articles/[slug]/page.tsx
@@ -67,12 +67,7 @@ export async function generateMetadata({
 
 export default async function ArticlePage({ params }: ArticlePageProps) {
   const { slug } = await params;
-  const [
-    mod,
-    { previousSlug, previousTitle, nextSlug, nextTitle },
-    headings,
-    navigable,
-  ] = await Promise.all([
+  const [mod, siblings, headings, navigable] = await Promise.all([
     import(`@/content/articles/${slug}.mdx`) as Promise<ArticleModule>,
     getSiblings(slug),
     getHeadings(slug),
@@ -85,10 +80,7 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
       heroImage={mod.heroImage}
       meta={mod.meta}
       navigable={navigable}
-      nextSlug={nextSlug}
-      nextTitle={nextTitle}
-      previousSlug={previousSlug}
-      previousTitle={previousTitle}
+      siblings={siblings}
       slug={slug}
     >
       <mod.default />

--- a/apps/blog/src/app/(blog)/articles/service.ts
+++ b/apps/blog/src/app/(blog)/articles/service.ts
@@ -64,6 +64,16 @@ export interface ArticleLink {
   slug: string;
 }
 
+/**
+ * Cross-reference links for an article: inbound citations (`backlinks`) and
+ * curated `related` reading. Both lists are visible-only and preserve the
+ * graph's recorded edge order; an unknown/unlinked slug yields empty arrays.
+ */
+export interface ArticleConnections {
+  backlinks: ArticleLink[];
+  related: ArticleLink[];
+}
+
 export interface ArticleHeading {
   depth: 2 | 3;
   id: string;
@@ -178,24 +188,13 @@ export const getSlicedArticles = cache(
   }
 );
 
-export const getBacklinks = cache(
-  async (slug: string): Promise<ArticleLink[]> => {
+export const getArticleConnections = cache(
+  async (slug: string): Promise<ArticleConnections> => {
     const visible = await getVisibleArticles();
-    return toArticleLinks(graph.backlinks[slug], visible);
-  }
-);
-
-export const getOutgoing = cache(
-  async (slug: string): Promise<ArticleLink[]> => {
-    const visible = await getVisibleArticles();
-    return toArticleLinks(graph.outgoing[slug], visible);
-  }
-);
-
-export const getRelated = cache(
-  async (slug: string): Promise<ArticleLink[]> => {
-    const visible = await getVisibleArticles();
-    return toArticleLinks(graph.related[slug], visible);
+    return {
+      backlinks: toArticleLinks(graph.backlinks[slug], visible),
+      related: toArticleLinks(graph.related[slug], visible),
+    };
   }
 );
 


### PR DESCRIPTION
## What

Replaces the three shallow cached wrappers `getBacklinks` / `getOutgoing` / `getRelated` (each a one-liner over the private `toArticleLinks` helper) with one deep interface:

```ts
getArticleConnections(slug) => { backlinks: ArticleLink[]; related: ArticleLink[] }
```

- **Deletes `getOutgoing`** — it had no production caller (referenced only by a test).
- `toArticleLinks` stays a private internal helper; the graph JSON shape stays behind the interface.
- The article rail and the backlinks disclosure each replace a two-call `Promise.all` with a single destructure.
- **Bonus:** `ArticleLayout` now takes the cohesive `SiblingNav` object whole instead of four flattened `previousSlug`/`previousTitle`/`nextSlug`/`nextTitle` props that `page.tsx` was shredding and re-assembling.

## Why

Three near-identical functions, one of them dead, all fetched in fixed pairs — interface nearly as wide as the implementation. One interface callers learn once; bugs and graph-shape knowledge concentrate in one place.

## Verification (run in this worktree)

- `bun run type-check` — ✅
- `bun run test` — ✅ 166 tests
- `bun x ultracite check` — ✅ clean
- `bun run build` — ✅ blog SSG build green

## Notes

Stacked on #809 (base `feat/article-contract`). Second of five deepening refactors. The `getOutgoing` removal is an app-internal removal — `service.ts` is `server-only` and no other workspace imports it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)