### PR TITLE
:recycle: refactor(cli): give the [[wikilink]] grammar one module

### DIFF
--- a/apps/cli/src/__tests__/graph.test.ts
+++ b/apps/cli/src/__tests__/graph.test.ts
@@ -7,7 +7,7 @@ import {
   emitArticleGraph,
 } from "../import-wiki/pages/graph.ts";
 import type { ParsedWikiFile } from "../import-wiki/parse.ts";
-import { extractInternalSlugs } from "../import-wiki/transform.ts";
+import { extractInternalSlugs } from "../import-wiki/wikilink.ts";
 
 function makeParsed(
   slug: string,

--- a/apps/cli/src/__tests__/manifests.test.ts
+++ b/apps/cli/src/__tests__/manifests.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtemp, readFile, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  buildManifests,
+  writeManifests,
+} from "../import-wiki/pages/manifests.ts";
+import type { ParsedWikiFile } from "../import-wiki/parse.ts";
+
+function makeParsed(
+  slug: string,
+  body: string,
+  overrides: Partial<ParsedWikiFile> = {}
+): ParsedWikiFile {
+  return {
+    source: { slug, folder: "concepts", absolutePath: `/tmp/${slug}.md` },
+    frontmatter: {},
+    body,
+    mtime: new Date("2026-01-01"),
+    ...overrides,
+  };
+}
+
+describe("buildManifests", () => {
+  it("is deterministic: same inputs produce identical JSON", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "manifests-det-"));
+    const args = {
+      parsed: [makeParsed("a", "[[b]]"), makeParsed("b", "[[a]]")],
+      logBody: "## [2026-05-01] ingest | Test\nSome body [[a]]",
+      rawRoot: dir,
+      generatedOn: "2026-05-14",
+    };
+
+    const a = await buildManifests(args);
+    const b = await buildManifests(args);
+
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+
+  it("threads generatedOn to all three manifests", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "manifests-gen-"));
+    const set = await buildManifests({
+      parsed: [makeParsed("x", "")],
+      logBody: "## [2026-05-01] ingest | X\nbody",
+      rawRoot: dir,
+      generatedOn: "2026-05-14",
+    });
+
+    expect(set.graph.generatedOn).toBe("2026-05-14");
+    expect(set.log?.generatedOn).toBe("2026-05-14");
+    expect(set.sources.generatedOn).toBe("2026-05-14");
+  });
+
+  it("excludes archived articles from graph and sources", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "manifests-arch-"));
+    const set = await buildManifests({
+      parsed: [
+        makeParsed("live", ""),
+        makeParsed("dead", "", { frontmatter: { archived: true } }),
+      ],
+      logBody: null,
+      rawRoot: dir,
+      generatedOn: "2026-05-14",
+    });
+
+    expect(Object.keys(set.graph.outgoing)).toEqual(["live"]);
+    expect(set.log).toBeNull();
+  });
+
+  it("returns null log when logBody is null", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "manifests-nolog-"));
+    const set = await buildManifests({
+      parsed: [makeParsed("a", "")],
+      logBody: null,
+      rawRoot: dir,
+      generatedOn: "2026-05-14",
+    });
+
+    expect(set.log).toBeNull();
+  });
+});
+
+describe("writeManifests", () => {
+  it("writes three files and returns graphPath", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "manifests-write-"));
+    const graphPath = join(dir, "graph.json");
+    const logPath = join(dir, "log.json");
+    const sourcesPath = join(dir, "sources.json");
+
+    const set = await buildManifests({
+      parsed: [makeParsed("a", "[[b]]"), makeParsed("b", "")],
+      logBody: "## [2026-05-01] ingest | Test\nbody [[a]]",
+      rawRoot: dir,
+      generatedOn: "2026-05-14",
+    });
+
+    const result = await writeManifests({
+      set,
+      graphOutputPath: graphPath,
+      logOutputPath: logPath,
+      sourcesOutputPath: sourcesPath,
+      dryRun: false,
+    });
+
+    expect(result.graphPath).toBe(graphPath);
+    const graphData = JSON.parse(await readFile(graphPath, "utf8"));
+    expect(graphData.generatedOn).toBe("2026-05-14");
+    const logData = JSON.parse(await readFile(logPath, "utf8"));
+    expect(logData.generatedOn).toBe("2026-05-14");
+    const sourcesData = JSON.parse(await readFile(sourcesPath, "utf8"));
+    expect(sourcesData.generatedOn).toBe("2026-05-14");
+  });
+
+  it("dry-run writes no files but returns graphPath", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "manifests-dry-"));
+    const graphPath = join(dir, "graph.json");
+    const logPath = join(dir, "log.json");
+    const sourcesPath = join(dir, "sources.json");
+
+    const set = await buildManifests({
+      parsed: [makeParsed("a", "")],
+      logBody: "## [2026-05-01] ingest | X\nbody",
+      rawRoot: dir,
+      generatedOn: "2026-05-14",
+    });
+
+    const result = await writeManifests({
+      set,
+      graphOutputPath: graphPath,
+      logOutputPath: logPath,
+      sourcesOutputPath: sourcesPath,
+      dryRun: true,
+    });
+
+    expect(result.graphPath).toBe(graphPath);
+    await expect(stat(graphPath)).rejects.toThrow();
+    await expect(stat(logPath)).rejects.toThrow();
+    await expect(stat(sourcesPath)).rejects.toThrow();
+  });
+});

--- a/apps/cli/src/__tests__/parse.test.ts
+++ b/apps/cli/src/__tests__/parse.test.ts
@@ -13,8 +13,8 @@ import {
   parseWikiFile,
   resolveDate,
   stripWikilinksToText,
-  titleFromSlug,
 } from "../import-wiki/parse.ts";
+import { titleFromSlug } from "../import-wiki/wikilink.ts";
 
 async function tempFile(content: string, filename: string): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), "wiki-test-"));

--- a/apps/cli/src/__tests__/wiki-log.test.ts
+++ b/apps/cli/src/__tests__/wiki-log.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "bun:test";
+
+import { buildWikiLog } from "../import-wiki/pages/wiki-log.ts";
+
+describe("buildWikiLog", () => {
+  it("parses entries newest-first", () => {
+    const body = [
+      "Preamble text.",
+      "",
+      "## [2026-05-01] ingest | First Entry",
+      "Body of first.",
+      "",
+      "## [2026-05-10] query | Second Entry",
+      "Body of second.",
+    ].join("\n");
+
+    const log = buildWikiLog({ body, generatedOn: "2026-05-14" });
+
+    expect(log.entries).toHaveLength(2);
+    expect(log.entries[0].date).toBe("2026-05-10");
+    expect(log.entries[0].operation).toBe("query");
+    expect(log.entries[0].subject).toBe("Second Entry");
+    expect(log.entries[1].date).toBe("2026-05-01");
+    expect(log.entries[1].operation).toBe("ingest");
+    expect(log.entries[1].subject).toBe("First Entry");
+  });
+
+  it("sets generatedOn as date-only string", () => {
+    const log = buildWikiLog({
+      body: "## [2026-01-01] lint | X\nbody",
+      generatedOn: "2026-05-14",
+    });
+
+    expect(log.generatedOn).toBe("2026-05-14");
+  });
+
+  it("extracts refs from entry body, deduped, in document order", () => {
+    const body = [
+      "## [2026-05-01] ingest | Refs Test",
+      "See [[alpha]] and [[beta]].",
+      "Also [[alpha]] again and [[raw/external]] ignored.",
+      "Then [[gamma]].",
+    ].join("\n");
+
+    const log = buildWikiLog({ body, generatedOn: "2026-05-14" });
+
+    expect(log.entries[0].refs).toEqual(["alpha", "beta", "gamma"]);
+  });
+
+  it("preserves stable order for entries with equal dates", () => {
+    const body = [
+      "## [2026-05-01] ingest | A",
+      "body a",
+      "",
+      "## [2026-05-01] query | B",
+      "body b",
+      "",
+      "## [2026-05-01] lint | C",
+      "body c",
+    ].join("\n");
+
+    const log = buildWikiLog({ body, generatedOn: "2026-05-14" });
+
+    // Same date → stable sort preserves document (parse) order
+    expect(log.entries.map((e) => e.subject)).toEqual(["A", "B", "C"]);
+  });
+
+  it("returns empty entries for body with no headings", () => {
+    const log = buildWikiLog({
+      body: "Just some text without any entry headings.",
+      generatedOn: "2026-05-14",
+    });
+
+    expect(log.entries).toEqual([]);
+  });
+});

--- a/apps/cli/src/__tests__/wiki-sources.test.ts
+++ b/apps/cli/src/__tests__/wiki-sources.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "bun:test";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { buildWikiSources } from "../import-wiki/pages/wiki-sources.ts";
+import type { ParsedWikiFile } from "../import-wiki/parse.ts";
+
+function makeParsed(
+  slug: string,
+  sources: string[],
+  overrides: Partial<ParsedWikiFile> = {}
+): ParsedWikiFile {
+  return {
+    source: { slug, folder: "concepts", absolutePath: `/tmp/${slug}.md` },
+    frontmatter: { sources },
+    body: "",
+    mtime: new Date("2026-01-01"),
+    ...overrides,
+  };
+}
+
+async function writeRawDoc(
+  rawRoot: string,
+  slug: string,
+  frontmatter: Record<string, string>
+): Promise<void> {
+  const dir = join(rawRoot, ...slug.split("/").slice(0, -1));
+  if (dir !== rawRoot) {
+    await mkdir(dir, { recursive: true });
+  }
+  const lines = ["---"];
+  for (const [k, v] of Object.entries(frontmatter)) {
+    lines.push(`${k}: ${v}`);
+  }
+  lines.push("---", "", "Body content.");
+  await writeFile(join(rawRoot, `${slug}.md`), lines.join("\n"), "utf8");
+}
+
+describe("buildWikiSources", () => {
+  it("sorts by citedBy count desc, then published desc, then title asc", async () => {
+    const rawRoot = await mkdtemp(join(tmpdir(), "ws-sort-"));
+    await writeRawDoc(rawRoot, "many-cites", {
+      title: "Many Cites",
+      source: "https://example.com/many",
+      published: "2020-01-01",
+    });
+    await writeRawDoc(rawRoot, "one-cite-new", {
+      title: "One Cite New",
+      source: "https://example.com/new",
+      published: "2025-01-01",
+    });
+    await writeRawDoc(rawRoot, "one-cite-old", {
+      title: "One Cite Old",
+      source: "https://example.com/old",
+      published: "2020-01-01",
+    });
+
+    const parsed = [
+      makeParsed("a", ["[[raw/many-cites]]", "[[raw/one-cite-new]]"]),
+      makeParsed("b", ["[[raw/many-cites]]", "[[raw/one-cite-old]]"]),
+    ];
+
+    const manifest = await buildWikiSources({
+      parsed,
+      rawRoot,
+      generatedOn: "2026-05-14",
+    });
+
+    expect(manifest.sources.map((s) => s.title)).toEqual([
+      "Many Cites",
+      "One Cite New",
+      "One Cite Old",
+    ]);
+  });
+
+  it("sorts citedBy alphabetically", async () => {
+    const rawRoot = await mkdtemp(join(tmpdir(), "ws-cited-"));
+    await writeRawDoc(rawRoot, "src", {
+      title: "Source",
+      source: "https://example.com",
+    });
+
+    const parsed = [
+      makeParsed("zebra", ["[[raw/src]]"]),
+      makeParsed("alpha", ["[[raw/src]]"]),
+    ];
+
+    const manifest = await buildWikiSources({
+      parsed,
+      rawRoot,
+      generatedOn: "2026-05-14",
+    });
+
+    expect(manifest.sources[0].citedBy).toEqual(["alpha", "zebra"]);
+  });
+
+  it("classifies URL to kind correctly", async () => {
+    const rawRoot = await mkdtemp(join(tmpdir(), "ws-kind-"));
+    await writeRawDoc(rawRoot, "talk", {
+      title: "Talk",
+      source: "https://youtube.com/watch?v=123",
+    });
+    await writeRawDoc(rawRoot, "paper", {
+      title: "Paper",
+      source: "https://arxiv.org/abs/123",
+    });
+    await writeRawDoc(rawRoot, "repo", {
+      title: "Repo",
+      source: "https://github.com/user/repo",
+    });
+    await writeRawDoc(rawRoot, "article", {
+      title: "Article",
+      source: "https://blog.example.com/post",
+    });
+    await writeRawDoc(rawRoot, "note", { title: "Note" });
+
+    const parsed = [
+      makeParsed("x", [
+        "[[raw/talk]]",
+        "[[raw/paper]]",
+        "[[raw/repo]]",
+        "[[raw/article]]",
+        "[[raw/note]]",
+      ]),
+    ];
+
+    const manifest = await buildWikiSources({
+      parsed,
+      rawRoot,
+      generatedOn: "2026-05-14",
+    });
+
+    const byTitle = new Map(manifest.sources.map((s) => [s.title, s.kind]));
+    expect(byTitle.get("Talk")).toBe("Talk");
+    expect(byTitle.get("Paper")).toBe("Paper");
+    expect(byTitle.get("Repo")).toBe("Repo");
+    expect(byTitle.get("Article")).toBe("Article");
+    expect(byTitle.get("Note")).toBe("Note");
+  });
+
+  it("sets generatedOn as date-only string", async () => {
+    const rawRoot = await mkdtemp(join(tmpdir(), "ws-gen-"));
+    const manifest = await buildWikiSources({
+      parsed: [makeParsed("a", [])],
+      rawRoot,
+      generatedOn: "2026-05-14",
+    });
+
+    expect(manifest.generatedOn).toBe("2026-05-14");
+  });
+});

--- a/apps/cli/src/__tests__/wikilink.test.ts
+++ b/apps/cli/src/__tests__/wikilink.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  extractInternalSlugs,
+  extractRawSlugs,
+  humanize,
+  rewriteToMarkdown,
+  stripToText,
+  titleFromSlug,
+  tokenizeWikilinks,
+  type WikiToken,
+} from "../import-wiki/wikilink.ts";
+
+describe("tokenizeWikilinks", () => {
+  it("parses a bare internal link", () => {
+    const tokens = tokenizeWikilinks("See [[claude-code]].");
+    expect(tokens).toEqual([
+      {
+        label: null,
+        target: { kind: "internal", slug: "claude-code", anchor: null },
+      },
+    ]);
+  });
+
+  it("captures a label after |", () => {
+    const tokens = tokenizeWikilinks("[[claude-code|Claude]]");
+    expect(tokens).toEqual([
+      {
+        label: "Claude",
+        target: { kind: "internal", slug: "claude-code", anchor: null },
+      },
+    ]);
+  });
+
+  it("captures a label after escaped \\|", () => {
+    const tokens = tokenizeWikilinks("[[codex-app-server-protocol\\|Codex]]");
+    expect(tokens).toEqual([
+      {
+        label: "Codex",
+        target: {
+          kind: "internal",
+          slug: "codex-app-server-protocol",
+          anchor: null,
+        },
+      },
+    ]);
+  });
+
+  it("classifies raw/ targets", () => {
+    const tokens = tokenizeWikilinks("[[raw/Best Practices for Claude]]");
+    expect(tokens).toEqual([
+      {
+        label: null,
+        target: { kind: "raw", rawSlug: "Best Practices for Claude" },
+      },
+    ]);
+  });
+
+  it("splits anchor from internal target", () => {
+    const tokens = tokenizeWikilinks("[[claude-code#Section One]]");
+    expect(tokens).toEqual([
+      {
+        label: null,
+        target: {
+          kind: "internal",
+          slug: "claude-code",
+          anchor: "Section One",
+        },
+      },
+    ]);
+  });
+
+  it("strips wiki/<folder>/ prefix", () => {
+    const tokens = tokenizeWikilinks("[[wiki/derived/what-are-ai-tools]]");
+    expect(tokens).toEqual([
+      {
+        label: null,
+        target: { kind: "internal", slug: "what-are-ai-tools", anchor: null },
+      },
+    ]);
+  });
+
+  it("preserves raw sub-paths", () => {
+    const tokens = tokenizeWikilinks(
+      "[[raw/Claude Mythos Preview / red.anthropic.com]]"
+    );
+    expect(tokens).toEqual([
+      {
+        label: null,
+        target: {
+          kind: "raw",
+          rawSlug: "Claude Mythos Preview / red.anthropic.com",
+        },
+      },
+    ]);
+  });
+
+  it("returns multiple tokens in source order", () => {
+    const tokens = tokenizeWikilinks("[[a]] and [[raw/b]] and [[c#x]]");
+    expect(tokens).toHaveLength(3);
+    expect(tokens[0].target).toEqual({
+      kind: "internal",
+      slug: "a",
+      anchor: null,
+    });
+    expect(tokens[1].target).toEqual({ kind: "raw", rawSlug: "b" });
+    expect(tokens[2].target).toEqual({
+      kind: "internal",
+      slug: "c",
+      anchor: "x",
+    });
+  });
+});
+
+describe("extractInternalSlugs", () => {
+  it("lowercases slugs", () => {
+    expect(extractInternalSlugs("[[Anthropic]]")).toEqual(["anthropic"]);
+  });
+
+  it("strips anchors", () => {
+    expect(extractInternalSlugs("[[claude-code#Section]]")).toEqual([
+      "claude-code",
+    ]);
+  });
+
+  it("skips raw/ targets", () => {
+    expect(extractInternalSlugs("[[raw/foo]]")).toEqual([]);
+  });
+
+  it("preserves duplicates by default", () => {
+    expect(extractInternalSlugs("[[a]] [[a]]")).toEqual(["a", "a"]);
+  });
+
+  it("deduplicates when dedup=true", () => {
+    expect(extractInternalSlugs("[[a]] [[b]] [[a]]", { dedup: true })).toEqual([
+      "a",
+      "b",
+    ]);
+  });
+
+  // Bug-fix regression: capitalised wikilinks must lowercase
+  it("regression: [[Anthropic]] with dedup returns lowercased", () => {
+    expect(extractInternalSlugs("[[Anthropic]]", { dedup: true })).toEqual([
+      "anthropic",
+    ]);
+  });
+
+  // Bug-fix regression: anchored wikilinks must strip anchor
+  it("regression: [[claude-code#Section]] strips anchor", () => {
+    expect(extractInternalSlugs("[[claude-code#Section]]")).toEqual([
+      "claude-code",
+    ]);
+  });
+});
+
+describe("extractRawSlugs", () => {
+  it("extracts raw slugs preserving case", () => {
+    expect(extractRawSlugs("[[raw/Best Practices]]")).toEqual([
+      "Best Practices",
+    ]);
+  });
+
+  it("preserves sub-paths", () => {
+    expect(
+      extractRawSlugs("[[raw/Claude Mythos Preview / red.anthropic.com]]")
+    ).toEqual(["Claude Mythos Preview / red.anthropic.com"]);
+  });
+
+  it("preserves duplicates by default", () => {
+    expect(extractRawSlugs("[[raw/a]] [[raw/a]]")).toEqual(["a", "a"]);
+  });
+
+  it("deduplicates when dedup=true", () => {
+    expect(
+      extractRawSlugs("[[raw/a]] [[raw/b]] [[raw/a]]", { dedup: true })
+    ).toEqual(["a", "b"]);
+  });
+
+  it("skips non-raw targets", () => {
+    expect(extractRawSlugs("[[claude-code]] [[wiki/concepts/x]]")).toEqual([]);
+  });
+});
+
+describe("stripToText", () => {
+  it("replaces bare internal link with title-cased slug", () => {
+    expect(stripToText("see [[model-spec-midtraining]]")).toBe(
+      "see Model Spec Midtraining"
+    );
+  });
+
+  it("uses explicit label", () => {
+    expect(stripToText("[[claude-code|Claude]]")).toBe("Claude");
+  });
+
+  it("humanises raw/ targets", () => {
+    expect(stripToText("[[raw/Best Practices for Claude]]")).toBe(
+      "Best Practices for Claude"
+    );
+  });
+
+  it("leaves text without wikilinks unchanged", () => {
+    expect(stripToText("nothing here")).toBe("nothing here");
+  });
+});
+
+describe("rewriteToMarkdown", () => {
+  it("calls the resolver for each wikilink", () => {
+    const resolve = (token: WikiToken): string => {
+      if (token.target.kind === "internal") {
+        return `[${token.label ?? token.target.slug}](/articles/${token.target.slug})`;
+      }
+      return token.label ?? token.target.rawSlug;
+    };
+    const { body } = rewriteToMarkdown(
+      "See [[claude-code]] and [[raw/foo]].",
+      resolve
+    );
+    expect(body).toBe("See [claude-code](/articles/claude-code) and foo.");
+  });
+
+  it("passes anchor to resolver", () => {
+    const resolve = (token: WikiToken): string => {
+      if (token.target.kind === "internal") {
+        const anchor = token.target.anchor ? `#${token.target.anchor}` : "";
+        return `[link](/articles/${token.target.slug}${anchor})`;
+      }
+      return "raw";
+    };
+    const { body } = rewriteToMarkdown("[[slug#heading]]", resolve);
+    expect(body).toBe("[link](/articles/slug#heading)");
+  });
+});
+
+describe("humanize", () => {
+  it("replaces dots, underscores, dashes with spaces", () => {
+    expect(humanize("my_file.name-here")).toBe("my file name here");
+  });
+
+  it("collapses multiple separators", () => {
+    expect(humanize("a---b___c...d")).toBe("a b c d");
+  });
+});
+
+describe("titleFromSlug", () => {
+  it("capitalises hyphenated slugs", () => {
+    expect(titleFromSlug("claude-code-best-practices")).toBe(
+      "Claude Code Best Practices"
+    );
+  });
+});

--- a/apps/cli/src/import-wiki/index.ts
+++ b/apps/cli/src/import-wiki/index.ts
@@ -8,14 +8,8 @@ import {
 } from "@howardism/article-contract";
 import { generateHeroImage } from "./codex.ts";
 import { type ArticleMeta, emitArticle } from "./emit.ts";
-import {
-  type ArticleGraph,
-  buildArticleGraph,
-  emitArticleGraph,
-} from "./pages/graph.ts";
+import { buildManifests, writeManifests } from "./pages/manifests.ts";
 import { buildWikiChangelogPage } from "./pages/wiki-changelog.ts";
-import { buildWikiLog, emitWikiLog } from "./pages/wiki-log.ts";
-import { buildWikiSources, emitWikiSources } from "./pages/wiki-sources.ts";
 import {
   buildSlugTitleMap,
   discoverWikiSources,
@@ -135,67 +129,25 @@ async function main(): Promise<void> {
       summary,
       slugTitleMap: ctx.slugTitleMap,
     });
-    await emitGraph({ ctx, opts, summary });
-    await emitWikiLogManifest({ opts });
-    await emitWikiSourcesManifest({ ctx, opts });
+    const generatedOn = new Date().toISOString().slice(0, 10);
+    const logParsed = await tryParseWikiLog(join(opts.wikiPath, "log.md"));
+    const set = await buildManifests({
+      parsed: ctx.parsedAll,
+      logBody: logParsed?.body ?? null,
+      rawRoot: opts.rawPath,
+      generatedOn,
+    });
+    const { graphPath } = await writeManifests({
+      set,
+      graphOutputPath: opts.graphOutputPath,
+      logOutputPath: opts.logOutputPath,
+      sourcesOutputPath: opts.sourcesOutputPath,
+      dryRun: opts.dryRun,
+    });
+    summary.graphPath = graphPath;
   }
 
   printSummary(summary);
-}
-
-async function emitGraph(args: {
-  ctx: ImportContext;
-  opts: RunOptions;
-  summary: ImportSummary;
-}): Promise<void> {
-  const { ctx, opts, summary } = args;
-  const graph: ArticleGraph = buildArticleGraph({
-    parsed: ctx.parsedAll,
-    generatedOn: new Date().toISOString().slice(0, 10),
-    isArchived: (p) => p.frontmatter.archived === true,
-  });
-  const graphPath = await emitArticleGraph({
-    graph,
-    outputPath: opts.graphOutputPath,
-    dryRun: opts.dryRun,
-  });
-  summary.graphPath = graphPath;
-}
-
-async function emitWikiLogManifest(args: { opts: RunOptions }): Promise<void> {
-  const { opts } = args;
-  const logSource = join(opts.wikiPath, "log.md");
-  const logParsed = await tryParseWikiLog(logSource);
-  if (!logParsed) {
-    return;
-  }
-  const log = buildWikiLog({
-    body: logParsed.body,
-    generatedOn: new Date().toISOString().slice(0, 10),
-  });
-  await emitWikiLog({
-    log,
-    outputPath: opts.logOutputPath,
-    dryRun: opts.dryRun,
-  });
-}
-
-async function emitWikiSourcesManifest(args: {
-  ctx: ImportContext;
-  opts: RunOptions;
-}): Promise<void> {
-  const { ctx, opts } = args;
-  const live = ctx.parsedAll.filter((p) => p.frontmatter.archived !== true);
-  const manifest = await buildWikiSources({
-    parsed: live,
-    rawRoot: opts.rawPath,
-    generatedOn: new Date().toISOString().slice(0, 10),
-  });
-  await emitWikiSources({
-    manifest,
-    outputPath: opts.sourcesOutputPath,
-    dryRun: opts.dryRun,
-  });
 }
 
 interface ImportContext {

--- a/apps/cli/src/import-wiki/index.ts
+++ b/apps/cli/src/import-wiki/index.ts
@@ -29,7 +29,6 @@ import {
   type RawDoc,
   resolveDate,
   stripWikilinksToText,
-  titleFromSlug,
 } from "./parse.ts";
 import { deriveTopic } from "./topics.ts";
 import {
@@ -42,6 +41,7 @@ import {
   rewriteWikilinks,
   stripDuplicateLeadingHeading,
 } from "./transform.ts";
+import { titleFromSlug } from "./wikilink.ts";
 
 interface RunOptions {
   blogArticlesPath: string;

--- a/apps/cli/src/import-wiki/pages/graph.ts
+++ b/apps/cli/src/import-wiki/pages/graph.ts
@@ -2,7 +2,7 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 
 import type { ParsedWikiFile } from "../parse.ts";
-import { extractInternalSlugs } from "../transform.ts";
+import { extractInternalSlugs } from "../wikilink.ts";
 
 const RELATED_LIMIT = 5;
 

--- a/apps/cli/src/import-wiki/pages/manifests.ts
+++ b/apps/cli/src/import-wiki/pages/manifests.ts
@@ -1,0 +1,83 @@
+import type { ParsedWikiFile } from "../parse.ts";
+import {
+  type ArticleGraph,
+  buildArticleGraph,
+  emitArticleGraph,
+} from "./graph.ts";
+import { buildWikiLog, emitWikiLog, type WikiLog } from "./wiki-log.ts";
+import {
+  buildWikiSources,
+  emitWikiSources,
+  type WikiSourcesManifest,
+} from "./wiki-sources.ts";
+
+export interface ManifestSet {
+  graph: ArticleGraph;
+  log: WikiLog | null;
+  sources: WikiSourcesManifest;
+}
+
+export interface BuildManifestsArgs {
+  /** YYYY-MM-DD, injected once by the caller. */
+  generatedOn: string;
+  logBody: string | null;
+  parsed: ParsedWikiFile[];
+  rawRoot: string;
+}
+
+export async function buildManifests(
+  args: BuildManifestsArgs
+): Promise<ManifestSet> {
+  const { parsed, logBody, rawRoot, generatedOn } = args;
+
+  const graph = buildArticleGraph({
+    parsed,
+    generatedOn,
+    isArchived: (p) => p.frontmatter.archived === true,
+  });
+
+  const log =
+    logBody === null ? null : buildWikiLog({ body: logBody, generatedOn });
+
+  const live = parsed.filter((p) => p.frontmatter.archived !== true);
+  const sources = await buildWikiSources({
+    parsed: live,
+    rawRoot,
+    generatedOn,
+  });
+
+  return { graph, log, sources };
+}
+
+export interface WriteManifestsArgs {
+  dryRun: boolean;
+  graphOutputPath: string;
+  logOutputPath: string;
+  set: ManifestSet;
+  sourcesOutputPath: string;
+}
+
+export async function writeManifests(
+  args: WriteManifestsArgs
+): Promise<{ graphPath: string }> {
+  const { set, graphOutputPath, logOutputPath, sourcesOutputPath, dryRun } =
+    args;
+
+  const graphPath = await emitArticleGraph({
+    graph: set.graph,
+    outputPath: graphOutputPath,
+    dryRun,
+  });
+
+  if (set.log) {
+    await emitWikiLog({ log: set.log, outputPath: logOutputPath, dryRun });
+  }
+
+  await emitWikiSources({
+    manifest: set.sources,
+    outputPath: sourcesOutputPath,
+    dryRun,
+  });
+
+  return { graphPath };
+}

--- a/apps/cli/src/import-wiki/pages/wiki-log.ts
+++ b/apps/cli/src/import-wiki/pages/wiki-log.ts
@@ -1,6 +1,8 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 
+import { extractInternalSlugs } from "../wikilink.ts";
+
 /**
  * One operation from the wiki's `log.md`, parsed into structured form for the
  * blog's "Currents" (home) and "Operations log" (articles) strips.
@@ -24,7 +26,6 @@ export interface WikiLog {
 // `## [2026-05-13] ingest | Interaction Models`
 const ENTRY_HEADING_RE =
   /^##\s+\[(\d{4}-\d{2}-\d{2})\]\s+([\w-]+)\s*\|\s*(.+?)\s*$/;
-const WIKILINK_RE = /\[\[([^\]|\\]+)(?:\\?\|[^\]]+)?\]\]/g;
 const LINE_SPLIT_RE = /\r?\n/;
 
 /**
@@ -51,7 +52,7 @@ export function buildWikiLog(args: {
       date,
       operation,
       subject,
-      refs: extractInternalRefs(entryBody),
+      refs: extractInternalSlugs(entryBody, { dedup: true }),
     });
   };
 
@@ -72,29 +73,6 @@ export function buildWikiLog(args: {
   entries.sort((a, b) => b.date.localeCompare(a.date));
 
   return { entries, generatedOn };
-}
-
-/**
- * Pull internal article slugs from an entry body. Drops `raw/` source links
- * and reduces `wiki/<folder>/<slug>` (and bare `[[slug]]`) to the trailing
- * slug, which matches the blog's article slugs.
- */
-function extractInternalRefs(body: string): string[] {
-  const seen = new Set<string>();
-  const refs: string[] = [];
-  for (const match of body.matchAll(WIKILINK_RE)) {
-    const target = match[1];
-    if (!target || target.startsWith("raw/")) {
-      continue;
-    }
-    const slug = target.split("/").pop()?.trim();
-    if (!slug || seen.has(slug)) {
-      continue;
-    }
-    seen.add(slug);
-    refs.push(slug);
-  }
-  return refs;
 }
 
 export async function emitWikiLog(args: {

--- a/apps/cli/src/import-wiki/parse.ts
+++ b/apps/cli/src/import-wiki/parse.ts
@@ -3,6 +3,14 @@ import { basename, extname, join } from "node:path";
 
 import matter from "gray-matter";
 
+import {
+  extractRawSlugs,
+  humanize as humanizeSlug,
+  stripToText,
+  titleFromSlug,
+  tokenizeWikilinks,
+} from "./wikilink.ts";
+
 export type WikiFolder = "concepts" | "derived";
 
 export interface WikiSource {
@@ -53,15 +61,10 @@ export interface RawDoc {
   url?: string;
 }
 
-const WIKI_LINK_RE = /\[\[([^\]|\\]+)(?:\\?\|([^\]]+))?\]\]/;
-const STRIP_WIKILINK_RE = /\[\[([^\]|\\]+)(?:\\?\|([^\]]+))?\]\]/g;
-const RAW_REF_RE = /\[\[raw\/([^\]|\\]+)(?:\\?\|[^\]]+)?\]\]/g;
 const HTTP_URL_RE = /^https?:\/\//i;
 const TABLE_ROW_RE = /^\s*\|\s*\[\[[^\]]+\]\][^|]*\|[^|]+\|/;
 const HEADING_RE = /^##\s+(.+)$/;
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
-const HUMANIZE_RAW_RE = /[._-]+/g;
-const WHITESPACE_RE = /\s+/g;
 
 export async function discoverWikiSources(
   wikiRoot: string
@@ -158,13 +161,15 @@ export async function parseIndexSummaries(
       continue;
     }
 
-    const linkMatch = WIKI_LINK_RE.exec(pageCell);
-    if (!linkMatch) {
+    const token = tokenizeWikilinks(pageCell)[0];
+    if (!token) {
       continue;
     }
 
-    const target = linkMatch[1];
-    const slug = target.split("/").pop();
+    const slug =
+      token.target.kind === "internal"
+        ? token.target.slug
+        : token.target.rawSlug.split("/").pop();
     if (!slug) {
       continue;
     }
@@ -193,16 +198,12 @@ export function extractRawSlugsFromSources(
   const seen = new Set<string>();
   const slugs: string[] = [];
   for (const entry of sources) {
-    for (const match of entry.matchAll(RAW_REF_RE)) {
-      // Keep the full path after `raw/` — Obsidian allows subdirectories
-      // (e.g. `raw/Claude Mythos Preview / red.anthropic.com`), and the
-      // path-segments map straight onto the on-disk layout under `raw/`.
-      const fullPath = match[1];
-      if (!fullPath || seen.has(fullPath)) {
+    for (const rawSlug of extractRawSlugs(entry)) {
+      if (seen.has(rawSlug)) {
         continue;
       }
-      seen.add(fullPath);
-      slugs.push(fullPath);
+      seen.add(rawSlug);
+      slugs.push(rawSlug);
     }
   }
   return slugs;
@@ -215,14 +216,7 @@ export function extractRawSlugsFromSources(
  * preserved so callers can keep their own per-target state if needed.
  */
 export function extractRawSlugsFromBody(body: string): string[] {
-  const slugs: string[] = [];
-  for (const match of body.matchAll(RAW_REF_RE)) {
-    const fullPath = match[1];
-    if (fullPath) {
-      slugs.push(fullPath);
-    }
-  }
-  return slugs;
+  return extractRawSlugs(body);
 }
 
 /**
@@ -294,24 +288,11 @@ function normalisePublished(value: unknown): string | undefined {
 }
 
 function humanizeRawSlug(slug: string): string {
-  return slug.replace(HUMANIZE_RAW_RE, " ").replace(WHITESPACE_RE, " ").trim();
+  return humanizeSlug(slug);
 }
 
 export function stripWikilinksToText(input: string): string {
-  return input.replace(STRIP_WIKILINK_RE, (_match, target, label) => {
-    if (label) {
-      return String(label).trim();
-    }
-    const path = String(target);
-    const slug = path.split("/").pop() ?? path;
-    if (path.startsWith("raw/")) {
-      return slug
-        .replace(HUMANIZE_RAW_RE, " ")
-        .replace(WHITESPACE_RE, " ")
-        .trim();
-    }
-    return titleFromSlug(slug);
-  });
+  return stripToText(input);
 }
 
 export function buildSlugTitleMap(
@@ -324,13 +305,6 @@ export function buildSlugTitleMap(
     map.set(file.source.slug, title);
   }
   return map;
-}
-
-export function titleFromSlug(slug: string): string {
-  return slug
-    .split("-")
-    .map((part) => (part ? part[0].toUpperCase() + part.slice(1) : part))
-    .join(" ");
 }
 
 /**

--- a/apps/cli/src/import-wiki/transform.ts
+++ b/apps/cli/src/import-wiki/transform.ts
@@ -1,10 +1,15 @@
 import type { SourceRef } from "@howardism/article-contract";
 
-import { type RawDoc, titleFromSlug } from "./parse.ts";
+import type { RawDoc } from "./parse.ts";
+import {
+  humanize,
+  rewriteToMarkdown,
+  titleFromSlug,
+  type WikiResolver,
+} from "./wikilink.ts";
 
 // Accepts both `[[target|label]]` and `[[target\|label]]` — the latter is the
 // Obsidian convention for embedding pipes inside markdown tables.
-const WIKI_LINK_RE = /\[\[([^\]|\\]+)(?:\\?\|([^\]]+))?\]\]/g;
 const FENCE_RE = /^(\s*)(```+|~~~+)/;
 const WORD_RE = /\b\w+\b/g;
 const LEADING_H1_RE = /^#\s+.+\n+/;
@@ -14,7 +19,6 @@ const FENCE_START_RE = /^(```+|~~~+)/;
 const LEADING_BLANKS_RE = /^\s*\n+/;
 const LEADING_HASH_RE = /^#\s+/;
 const WHITESPACE_RE = /\s+/g;
-const HUMANIZE_PUNCT_RE = /[._-]+/g;
 // Obsidian convention: a leading `_Entity._` (or `*Entity.*`) marker on the
 // first prose line signals that the article documents a named real-world
 // entity rather than an abstract concept. Both delimiter styles are valid
@@ -83,38 +87,6 @@ export function detectEntityPrefix(description: string): EntityPrefixResult {
   };
 }
 
-/**
- * Extracts the bare slugs of all in-vault wikilinks from a wiki body in
- * source order. Mirrors the resolution rules in `rewriteWikilinks`:
- *
- * - `raw/...` references are external sources, not vault entries → skipped.
- * - `wiki/<folder>/<slug>` paths are stripped down to the trailing slug.
- * - `<slug>#anchor` is reduced to the bare slug; the anchor is irrelevant
- *   for graph adjacency.
- * - Slugs are lowercased to match `slugTitleMap` keys.
- *
- * Duplicates are preserved (caller may need to count) and unresolved targets
- * are returned alongside live ones — the graph builder filters them against
- * the set of live slugs.
- */
-export function extractInternalSlugs(body: string): string[] {
-  const slugs: string[] = [];
-  for (const match of body.matchAll(WIKI_LINK_RE)) {
-    const target = match[1];
-    if (target.startsWith("raw/")) {
-      continue;
-    }
-    const bareTarget = target.split("/").pop();
-    if (!bareTarget) {
-      continue;
-    }
-    const hashIdx = bareTarget.indexOf("#");
-    const rawSlug = hashIdx >= 0 ? bareTarget.slice(0, hashIdx) : bareTarget;
-    slugs.push(rawSlug.toLowerCase());
-  }
-  return slugs;
-}
-
 export interface WikilinkTransformResult {
   body: string;
   hasInternalLink: boolean;
@@ -143,58 +115,29 @@ export function rewriteWikilinks(
   let hasInternalLink = false;
   const unresolved: string[] = [];
 
-  const rewritten = body.replace(WIKI_LINK_RE, (_match, target, label) => {
-    const targetPath = String(target);
-    const linkLabel = label ? String(label).trim() : null;
-
-    if (targetPath.startsWith("raw/")) {
-      return resolveRawWikilink({
-        targetPath,
-        linkLabel,
-        rawIndex,
-      });
+  const resolve: WikiResolver = ({ target, label }) => {
+    if (target.kind === "raw") {
+      const rawDoc = rawIndex?.get(target.rawSlug);
+      const display = label ?? rawDoc?.title ?? humanize(target.rawSlug);
+      return rawDoc?.url ? `[${display}](${rawDoc.url})` : display;
     }
 
-    const bareTarget = targetPath.split("/").pop();
-    if (!bareTarget) {
-      return linkLabel ?? targetPath;
-    }
-
-    const hashIdx = bareTarget.indexOf("#");
-    const rawSlug = hashIdx >= 0 ? bareTarget.slice(0, hashIdx) : bareTarget;
-    const anchor =
-      hashIdx >= 0
-        ? `#${encodeURIComponent(bareTarget.slice(hashIdx + 1))}`
-        : "";
-    const slug = rawSlug.toLowerCase();
-
-    const title = slugTitleMap.get(slug);
+    const anchor = target.anchor ? `#${encodeURIComponent(target.anchor)}` : "";
+    const title = slugTitleMap.get(target.slug);
     if (title) {
       hasInternalLink = true;
-      const display = linkLabel ?? title;
-      return `[${display}](/articles/${slug}${anchor})`;
+      return `[${label ?? title}](/articles/${target.slug}${anchor})`;
     }
 
-    unresolved.push(slug);
-    return linkLabel ?? titleFromSlug(slug);
-  });
+    unresolved.push(target.slug);
+    return label ?? titleFromSlug(target.slug);
+  };
 
-  return { body: rewritten, hasInternalLink, unresolved };
-}
-
-function resolveRawWikilink(args: {
-  linkLabel: string | null;
-  rawIndex: Map<string, RawDoc> | undefined;
-  targetPath: string;
-}): string {
-  const { targetPath, linkLabel, rawIndex } = args;
-  const bareSlug = targetPath.slice("raw/".length);
-  const rawDoc = rawIndex?.get(bareSlug);
-  const display = linkLabel ?? rawDoc?.title ?? humanize(bareSlug);
-  if (rawDoc?.url) {
-    return `[${display}](${rawDoc.url})`;
-  }
-  return display;
+  return {
+    body: rewriteToMarkdown(body, resolve).body,
+    hasInternalLink,
+    unresolved,
+  };
 }
 
 /**
@@ -416,12 +359,4 @@ function updateFenceState(line: string, state: FenceState): boolean {
 
 function shouldSkipParagraphLine(line: string): boolean {
   return line.length === 0 || FIRST_PARAGRAPH_SKIP_RE.test(line);
-}
-
-function humanize(raw: string): string {
-  const decoded = raw
-    .replace(HUMANIZE_PUNCT_RE, " ")
-    .replace(WHITESPACE_RE, " ")
-    .trim();
-  return decoded.length > 0 ? decoded : raw;
 }

--- a/apps/cli/src/import-wiki/wikilink.ts
+++ b/apps/cli/src/import-wiki/wikilink.ts
@@ -1,0 +1,142 @@
+/** Single source of truth for the [[wikilink]] grammar.
+ *  Group 1 = target (incl. any wiki/ or raw/ prefix and #anchor).
+ *  Group 2 = optional label, after `|` or Obsidian's table-escaped `\|`. */
+const WIKILINK_RE = /\[\[([^\]|\\]+)(?:\\?\|([^\]]+))?\]\]/g;
+
+const HUMANIZE_RE = /[._-]+/g;
+const WHITESPACE_RE = /\s+/g;
+
+export type WikiTarget =
+  | { kind: "internal"; slug: string; anchor: string | null }
+  | { kind: "raw"; rawSlug: string };
+
+export interface WikiToken {
+  label: string | null;
+  target: WikiTarget;
+}
+
+/** Normalisation lives HERE and nowhere else. */
+function classifyTarget(rawTarget: string): WikiTarget {
+  if (rawTarget.startsWith("raw/")) {
+    return { kind: "raw", rawSlug: rawTarget.slice("raw/".length) };
+  }
+  const bare = rawTarget.split("/").pop() ?? rawTarget;
+  const hash = bare.indexOf("#");
+  const slugPart = hash >= 0 ? bare.slice(0, hash) : bare;
+  const anchor = hash >= 0 ? bare.slice(hash + 1) : null;
+  return { kind: "internal", slug: slugPart.trim().toLowerCase(), anchor };
+}
+
+/** Humanise a raw slug: replace punctuation with spaces, collapse whitespace. */
+export function humanize(raw: string): string {
+  const decoded = raw
+    .replace(HUMANIZE_RE, " ")
+    .replace(WHITESPACE_RE, " ")
+    .trim();
+  return decoded.length > 0 ? decoded : raw;
+}
+
+/** Title-case a hyphenated slug. */
+export function titleFromSlug(slug: string): string {
+  return slug
+    .split("-")
+    .map((part) => (part ? part[0].toUpperCase() + part.slice(1) : part))
+    .join(" ");
+}
+
+/** Scan once; classify every match. Source order. No dedup. */
+export function tokenizeWikilinks(input: string): WikiToken[] {
+  const tokens: WikiToken[] = [];
+  for (const match of input.matchAll(WIKILINK_RE)) {
+    const target = match[1];
+    const label = match[2] ? match[2].trim() : null;
+    tokens.push({ label, target: classifyTarget(target) });
+  }
+  return tokens;
+}
+
+/** Internal slugs (kind==="internal"), source order, lowercased + anchor-stripped. */
+export function extractInternalSlugs(
+  input: string,
+  opts?: { dedup?: boolean }
+): string[] {
+  const slugs: string[] = [];
+  const seen = opts?.dedup ? new Set<string>() : null;
+  for (const match of input.matchAll(WIKILINK_RE)) {
+    const target = match[1];
+    if (target.startsWith("raw/")) {
+      continue;
+    }
+    const bare = target.split("/").pop();
+    if (!bare) {
+      continue;
+    }
+    const hash = bare.indexOf("#");
+    const slug = (hash >= 0 ? bare.slice(0, hash) : bare).trim().toLowerCase();
+    if (seen) {
+      if (seen.has(slug)) {
+        continue;
+      }
+      seen.add(slug);
+    }
+    slugs.push(slug);
+  }
+  return slugs;
+}
+
+/** Raw slugs (kind==="raw"), source order, ORIGINAL case + sub-paths. */
+export function extractRawSlugs(
+  input: string,
+  opts?: { dedup?: boolean }
+): string[] {
+  const slugs: string[] = [];
+  const seen = opts?.dedup ? new Set<string>() : null;
+  for (const match of input.matchAll(WIKILINK_RE)) {
+    const target = match[1];
+    if (!target.startsWith("raw/")) {
+      continue;
+    }
+    const rawSlug = target.slice("raw/".length);
+    if (!rawSlug) {
+      continue;
+    }
+    if (seen) {
+      if (seen.has(rawSlug)) {
+        continue;
+      }
+      seen.add(rawSlug);
+    }
+    slugs.push(rawSlug);
+  }
+  return slugs;
+}
+
+/** Replace each wikilink with its plain-text display form. Single-pass. */
+export function stripToText(input: string): string {
+  return input.replace(WIKILINK_RE, (_match, target, label) => {
+    if (label) {
+      return String(label).trim();
+    }
+    const path = String(target);
+    const slug = path.split("/").pop() ?? path;
+    if (path.startsWith("raw/")) {
+      return humanize(slug);
+    }
+    return titleFromSlug(slug);
+  });
+}
+
+export type WikiResolver = (token: WikiToken) => string;
+
+/** Replace each wikilink via the injected resolver. Single .replace pass. */
+export function rewriteToMarkdown(
+  input: string,
+  resolve: WikiResolver
+): { body: string } {
+  const body = input.replace(WIKILINK_RE, (_match, target, label) => {
+    const classified = classifyTarget(String(target));
+    const labelStr = label ? String(label).trim() : null;
+    return resolve({ label: labelStr, target: classified });
+  });
+  return { body };
+}


### PR DESCRIPTION
## What

Centralizes the `[[wikilink]]` grammar — previously four divergent regexes across `parse.ts`, `transform.ts`, and `pages/wiki-log.ts` plus several hand-rolled scanning helpers — into one module `apps/cli/src/import-wiki/wikilink.ts`:

- one canonical `WIKILINK_RE` and one `classifyTarget` (the only place slug normalisation lives);
- folds over it: `tokenizeWikilinks`, `extractInternalSlugs`, `extractRawSlugs`, `stripToText`, `rewriteToMarkdown` (+ injected `WikiResolver`).

`rewriteWikilinks` keeps its exact public signature as a thin resolver-closure adapter; `parse.ts`/`graph.ts`/`wiki-log.ts` import the shared primitives directly (no re-export barrels, per the repo's `noBarrelFile` rule). `titleFromSlug` now has one home in `wikilink.ts`.

## Bug fixes (latent, code-only)

Unifying `wiki-log.ts`'s ref extraction onto the shared `extractInternalSlugs(body, { dedup: true })` fixes two latent bugs: log refs previously did **not** lowercase and did **not** strip anchors, so `[[Anthropic]]` and `[[slug#section]]` never matched an article slug. New `wikilink.test.ts` adds explicit regression tests for both. The output change only takes effect on the next importer run; **no data files were regenerated in this PR**.

## Why

`[[wikilink]]` is a domain concept that had no module — the grammar was smeared across files and drifted (the wiki-log divergence was the bug). One grammar, one place to test, one place bugs concentrate.

## Verification (run in this worktree)

- `bun run type-check` — ✅ 4/4
- `bun run lint` — ✅ clean (`ultracite check`)
- `bun run test` — ✅ 195 tests (89 blog + 106 CLI; +29 new wikilink tests incl. the 2 bug regressions)

(The CLI runs via Bun with no build step; the blog is untouched by this PR.)

## Notes

Stacked on #810 (base `feat/graph-connections`). Third of five deepening refactors. The implementation was delegated to kiro-cli; its run was interrupted by a transient backend connection reset mid-edit, so the `transform.ts`/`wiki-log.ts` conversion and the barrel-rule fixes were completed and verified by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)