### PR TITLE
:recycle: refactor(cli): consolidate manifest emission behind one seam

### DIFF
--- a/apps/cli/src/__tests__/manifests.test.ts
+++ b/apps/cli/src/__tests__/manifests.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtemp, readFile, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  buildManifests,
+  writeManifests,
+} from "../import-wiki/pages/manifests.ts";
+import type { ParsedWikiFile } from "../import-wiki/parse.ts";
+
+function makeParsed(
+  slug: string,
+  body: string,
+  overrides: Partial<ParsedWikiFile> = {}
+): ParsedWikiFile {
+  return {
+    source: { slug, folder: "concepts", absolutePath: `/tmp/${slug}.md` },
+    frontmatter: {},
+    body,
+    mtime: new Date("2026-01-01"),
+    ...overrides,
+  };
+}
+
+describe("buildManifests", () => {
+  it("is deterministic: same inputs produce identical JSON", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "manifests-det-"));
+    const args = {
+      parsed: [makeParsed("a", "[[b]]"), makeParsed("b", "[[a]]")],
+      logBody: "## [2026-05-01] ingest | Test\nSome body [[a]]",
+      rawRoot: dir,
+      generatedOn: "2026-05-14",
+    };
+
+    const a = await buildManifests(args);
+    const b = await buildManifests(args);
+
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+
+  it("threads generatedOn to all three manifests", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "manifests-gen-"));
+    const set = await buildManifests({
+      parsed: [makeParsed("x", "")],
+      logBody: "## [2026-05-01] ingest | X\nbody",
+      rawRoot: dir,
+      generatedOn: "2026-05-14",
+    });
+
+    expect(set.graph.generatedOn).toBe("2026-05-14");
+    expect(set.log?.generatedOn).toBe("2026-05-14");
+    expect(set.sources.generatedOn).toBe("2026-05-14");
+  });
+
+  it("excludes archived articles from graph and sources", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "manifests-arch-"));
+    const set = await buildManifests({
+      parsed: [
+        makeParsed("live", ""),
+        makeParsed("dead", "", { frontmatter: { archived: true } }),
+      ],
+      logBody: null,
+      rawRoot: dir,
+      generatedOn: "2026-05-14",
+    });
+
+    expect(Object.keys(set.graph.outgoing)).toEqual(["live"]);
+    expect(set.log).toBeNull();
+  });
+
+  it("returns null log when logBody is null", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "manifests-nolog-"));
+    const set = await buildManifests({
+      parsed: [makeParsed("a", "")],
+      logBody: null,
+      rawRoot: dir,
+      generatedOn: "2026-05-14",
+    });
+
+    expect(set.log).toBeNull();
+  });
+});
+
+describe("writeManifests", () => {
+  it("writes three files and returns graphPath", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "manifests-write-"));
+    const graphPath = join(dir, "graph.json");
+    const logPath = join(dir, "log.json");
+    const sourcesPath = join(dir, "sources.json");
+
+    const set = await buildManifests({
+      parsed: [makeParsed("a", "[[b]]"), makeParsed("b", "")],
+      logBody: "## [2026-05-01] ingest | Test\nbody [[a]]",
+      rawRoot: dir,
+      generatedOn: "2026-05-14",
+    });
+
+    const result = await writeManifests({
+      set,
+      graphOutputPath: graphPath,
+      logOutputPath: logPath,
+      sourcesOutputPath: sourcesPath,
+      dryRun: false,
+    });
+
+    expect(result.graphPath).toBe(graphPath);
+    const graphData = JSON.parse(await readFile(graphPath, "utf8"));
+    expect(graphData.generatedOn).toBe("2026-05-14");
+    const logData = JSON.parse(await readFile(logPath, "utf8"));
+    expect(logData.generatedOn).toBe("2026-05-14");
+    const sourcesData = JSON.parse(await readFile(sourcesPath, "utf8"));
+    expect(sourcesData.generatedOn).toBe("2026-05-14");
+  });
+
+  it("dry-run writes no files but returns graphPath", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "manifests-dry-"));
+    const graphPath = join(dir, "graph.json");
+    const logPath = join(dir, "log.json");
+    const sourcesPath = join(dir, "sources.json");
+
+    const set = await buildManifests({
+      parsed: [makeParsed("a", "")],
+      logBody: "## [2026-05-01] ingest | X\nbody",
+      rawRoot: dir,
+      generatedOn: "2026-05-14",
+    });
+
+    const result = await writeManifests({
+      set,
+      graphOutputPath: graphPath,
+      logOutputPath: logPath,
+      sourcesOutputPath: sourcesPath,
+      dryRun: true,
+    });
+
+    expect(result.graphPath).toBe(graphPath);
+    await expect(stat(graphPath)).rejects.toThrow();
+    await expect(stat(logPath)).rejects.toThrow();
+    await expect(stat(sourcesPath)).rejects.toThrow();
+  });
+});

--- a/apps/cli/src/__tests__/wiki-log.test.ts
+++ b/apps/cli/src/__tests__/wiki-log.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "bun:test";
+
+import { buildWikiLog } from "../import-wiki/pages/wiki-log.ts";
+
+describe("buildWikiLog", () => {
+  it("parses entries newest-first", () => {
+    const body = [
+      "Preamble text.",
+      "",
+      "## [2026-05-01] ingest | First Entry",
+      "Body of first.",
+      "",
+      "## [2026-05-10] query | Second Entry",
+      "Body of second.",
+    ].join("\n");
+
+    const log = buildWikiLog({ body, generatedOn: "2026-05-14" });
+
+    expect(log.entries).toHaveLength(2);
+    expect(log.entries[0].date).toBe("2026-05-10");
+    expect(log.entries[0].operation).toBe("query");
+    expect(log.entries[0].subject).toBe("Second Entry");
+    expect(log.entries[1].date).toBe("2026-05-01");
+    expect(log.entries[1].operation).toBe("ingest");
+    expect(log.entries[1].subject).toBe("First Entry");
+  });
+
+  it("sets generatedOn as date-only string", () => {
+    const log = buildWikiLog({
+      body: "## [2026-01-01] lint | X\nbody",
+      generatedOn: "2026-05-14",
+    });
+
+    expect(log.generatedOn).toBe("2026-05-14");
+  });
+
+  it("extracts refs from entry body, deduped, in document order", () => {
+    const body = [
+      "## [2026-05-01] ingest | Refs Test",
+      "See [[alpha]] and [[beta]].",
+      "Also [[alpha]] again and [[raw/external]] ignored.",
+      "Then [[gamma]].",
+    ].join("\n");
+
+    const log = buildWikiLog({ body, generatedOn: "2026-05-14" });
+
+    expect(log.entries[0].refs).toEqual(["alpha", "beta", "gamma"]);
+  });
+
+  it("preserves stable order for entries with equal dates", () => {
+    const body = [
+      "## [2026-05-01] ingest | A",
+      "body a",
+      "",
+      "## [2026-05-01] query | B",
+      "body b",
+      "",
+      "## [2026-05-01] lint | C",
+      "body c",
+    ].join("\n");
+
+    const log = buildWikiLog({ body, generatedOn: "2026-05-14" });
+
+    // Same date → stable sort preserves document (parse) order
+    expect(log.entries.map((e) => e.subject)).toEqual(["A", "B", "C"]);
+  });
+
+  it("returns empty entries for body with no headings", () => {
+    const log = buildWikiLog({
+      body: "Just some text without any entry headings.",
+      generatedOn: "2026-05-14",
+    });
+
+    expect(log.entries).toEqual([]);
+  });
+});

--- a/apps/cli/src/__tests__/wiki-sources.test.ts
+++ b/apps/cli/src/__tests__/wiki-sources.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "bun:test";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { buildWikiSources } from "../import-wiki/pages/wiki-sources.ts";
+import type { ParsedWikiFile } from "../import-wiki/parse.ts";
+
+function makeParsed(
+  slug: string,
+  sources: string[],
+  overrides: Partial<ParsedWikiFile> = {}
+): ParsedWikiFile {
+  return {
+    source: { slug, folder: "concepts", absolutePath: `/tmp/${slug}.md` },
+    frontmatter: { sources },
+    body: "",
+    mtime: new Date("2026-01-01"),
+    ...overrides,
+  };
+}
+
+async function writeRawDoc(
+  rawRoot: string,
+  slug: string,
+  frontmatter: Record<string, string>
+): Promise<void> {
+  const dir = join(rawRoot, ...slug.split("/").slice(0, -1));
+  if (dir !== rawRoot) {
+    await mkdir(dir, { recursive: true });
+  }
+  const lines = ["---"];
+  for (const [k, v] of Object.entries(frontmatter)) {
+    lines.push(`${k}: ${v}`);
+  }
+  lines.push("---", "", "Body content.");
+  await writeFile(join(rawRoot, `${slug}.md`), lines.join("\n"), "utf8");
+}
+
+describe("buildWikiSources", () => {
+  it("sorts by citedBy count desc, then published desc, then title asc", async () => {
+    const rawRoot = await mkdtemp(join(tmpdir(), "ws-sort-"));
+    await writeRawDoc(rawRoot, "many-cites", {
+      title: "Many Cites",
+      source: "https://example.com/many",
+      published: "2020-01-01",
+    });
+    await writeRawDoc(rawRoot, "one-cite-new", {
+      title: "One Cite New",
+      source: "https://example.com/new",
+      published: "2025-01-01",
+    });
+    await writeRawDoc(rawRoot, "one-cite-old", {
+      title: "One Cite Old",
+      source: "https://example.com/old",
+      published: "2020-01-01",
+    });
+
+    const parsed = [
+      makeParsed("a", ["[[raw/many-cites]]", "[[raw/one-cite-new]]"]),
+      makeParsed("b", ["[[raw/many-cites]]", "[[raw/one-cite-old]]"]),
+    ];
+
+    const manifest = await buildWikiSources({
+      parsed,
+      rawRoot,
+      generatedOn: "2026-05-14",
+    });
+
+    expect(manifest.sources.map((s) => s.title)).toEqual([
+      "Many Cites",
+      "One Cite New",
+      "One Cite Old",
+    ]);
+  });
+
+  it("sorts citedBy alphabetically", async () => {
+    const rawRoot = await mkdtemp(join(tmpdir(), "ws-cited-"));
+    await writeRawDoc(rawRoot, "src", {
+      title: "Source",
+      source: "https://example.com",
+    });
+
+    const parsed = [
+      makeParsed("zebra", ["[[raw/src]]"]),
+      makeParsed("alpha", ["[[raw/src]]"]),
+    ];
+
+    const manifest = await buildWikiSources({
+      parsed,
+      rawRoot,
+      generatedOn: "2026-05-14",
+    });
+
+    expect(manifest.sources[0].citedBy).toEqual(["alpha", "zebra"]);
+  });
+
+  it("classifies URL to kind correctly", async () => {
+    const rawRoot = await mkdtemp(join(tmpdir(), "ws-kind-"));
+    await writeRawDoc(rawRoot, "talk", {
+      title: "Talk",
+      source: "https://youtube.com/watch?v=123",
+    });
+    await writeRawDoc(rawRoot, "paper", {
+      title: "Paper",
+      source: "https://arxiv.org/abs/123",
+    });
+    await writeRawDoc(rawRoot, "repo", {
+      title: "Repo",
+      source: "https://github.com/user/repo",
+    });
+    await writeRawDoc(rawRoot, "article", {
+      title: "Article",
+      source: "https://blog.example.com/post",
+    });
+    await writeRawDoc(rawRoot, "note", { title: "Note" });
+
+    const parsed = [
+      makeParsed("x", [
+        "[[raw/talk]]",
+        "[[raw/paper]]",
+        "[[raw/repo]]",
+        "[[raw/article]]",
+        "[[raw/note]]",
+      ]),
+    ];
+
+    const manifest = await buildWikiSources({
+      parsed,
+      rawRoot,
+      generatedOn: "2026-05-14",
+    });
+
+    const byTitle = new Map(manifest.sources.map((s) => [s.title, s.kind]));
+    expect(byTitle.get("Talk")).toBe("Talk");
+    expect(byTitle.get("Paper")).toBe("Paper");
+    expect(byTitle.get("Repo")).toBe("Repo");
+    expect(byTitle.get("Article")).toBe("Article");
+    expect(byTitle.get("Note")).toBe("Note");
+  });
+
+  it("sets generatedOn as date-only string", async () => {
+    const rawRoot = await mkdtemp(join(tmpdir(), "ws-gen-"));
+    const manifest = await buildWikiSources({
+      parsed: [makeParsed("a", [])],
+      rawRoot,
+      generatedOn: "2026-05-14",
+    });
+
+    expect(manifest.generatedOn).toBe("2026-05-14");
+  });
+});

--- a/apps/cli/src/import-wiki/index.ts
+++ b/apps/cli/src/import-wiki/index.ts
@@ -8,14 +8,8 @@ import {
 } from "@howardism/article-contract";
 import { generateHeroImage } from "./codex.ts";
 import { type ArticleMeta, emitArticle } from "./emit.ts";
-import {
-  type ArticleGraph,
-  buildArticleGraph,
-  emitArticleGraph,
-} from "./pages/graph.ts";
+import { buildManifests, writeManifests } from "./pages/manifests.ts";
 import { buildWikiChangelogPage } from "./pages/wiki-changelog.ts";
-import { buildWikiLog, emitWikiLog } from "./pages/wiki-log.ts";
-import { buildWikiSources, emitWikiSources } from "./pages/wiki-sources.ts";
 import {
   buildSlugTitleMap,
   discoverWikiSources,
@@ -135,67 +129,25 @@ async function main(): Promise<void> {
       summary,
       slugTitleMap: ctx.slugTitleMap,
     });
-    await emitGraph({ ctx, opts, summary });
-    await emitWikiLogManifest({ opts });
-    await emitWikiSourcesManifest({ ctx, opts });
+    const generatedOn = new Date().toISOString().slice(0, 10);
+    const logParsed = await tryParseWikiLog(join(opts.wikiPath, "log.md"));
+    const set = await buildManifests({
+      parsed: ctx.parsedAll,
+      logBody: logParsed?.body ?? null,
+      rawRoot: opts.rawPath,
+      generatedOn,
+    });
+    const { graphPath } = await writeManifests({
+      set,
+      graphOutputPath: opts.graphOutputPath,
+      logOutputPath: opts.logOutputPath,
+      sourcesOutputPath: opts.sourcesOutputPath,
+      dryRun: opts.dryRun,
+    });
+    summary.graphPath = graphPath;
   }
 
   printSummary(summary);
-}
-
-async function emitGraph(args: {
-  ctx: ImportContext;
-  opts: RunOptions;
-  summary: ImportSummary;
-}): Promise<void> {
-  const { ctx, opts, summary } = args;
-  const graph: ArticleGraph = buildArticleGraph({
-    parsed: ctx.parsedAll,
-    generatedOn: new Date().toISOString().slice(0, 10),
-    isArchived: (p) => p.frontmatter.archived === true,
-  });
-  const graphPath = await emitArticleGraph({
-    graph,
-    outputPath: opts.graphOutputPath,
-    dryRun: opts.dryRun,
-  });
-  summary.graphPath = graphPath;
-}
-
-async function emitWikiLogManifest(args: { opts: RunOptions }): Promise<void> {
-  const { opts } = args;
-  const logSource = join(opts.wikiPath, "log.md");
-  const logParsed = await tryParseWikiLog(logSource);
-  if (!logParsed) {
-    return;
-  }
-  const log = buildWikiLog({
-    body: logParsed.body,
-    generatedOn: new Date().toISOString().slice(0, 10),
-  });
-  await emitWikiLog({
-    log,
-    outputPath: opts.logOutputPath,
-    dryRun: opts.dryRun,
-  });
-}
-
-async function emitWikiSourcesManifest(args: {
-  ctx: ImportContext;
-  opts: RunOptions;
-}): Promise<void> {
-  const { ctx, opts } = args;
-  const live = ctx.parsedAll.filter((p) => p.frontmatter.archived !== true);
-  const manifest = await buildWikiSources({
-    parsed: live,
-    rawRoot: opts.rawPath,
-    generatedOn: new Date().toISOString().slice(0, 10),
-  });
-  await emitWikiSources({
-    manifest,
-    outputPath: opts.sourcesOutputPath,
-    dryRun: opts.dryRun,
-  });
 }
 
 interface ImportContext {

--- a/apps/cli/src/import-wiki/pages/manifests.ts
+++ b/apps/cli/src/import-wiki/pages/manifests.ts
@@ -1,0 +1,83 @@
+import type { ParsedWikiFile } from "../parse.ts";
+import {
+  type ArticleGraph,
+  buildArticleGraph,
+  emitArticleGraph,
+} from "./graph.ts";
+import { buildWikiLog, emitWikiLog, type WikiLog } from "./wiki-log.ts";
+import {
+  buildWikiSources,
+  emitWikiSources,
+  type WikiSourcesManifest,
+} from "./wiki-sources.ts";
+
+export interface ManifestSet {
+  graph: ArticleGraph;
+  log: WikiLog | null;
+  sources: WikiSourcesManifest;
+}
+
+export interface BuildManifestsArgs {
+  /** YYYY-MM-DD, injected once by the caller. */
+  generatedOn: string;
+  logBody: string | null;
+  parsed: ParsedWikiFile[];
+  rawRoot: string;
+}
+
+export async function buildManifests(
+  args: BuildManifestsArgs
+): Promise<ManifestSet> {
+  const { parsed, logBody, rawRoot, generatedOn } = args;
+
+  const graph = buildArticleGraph({
+    parsed,
+    generatedOn,
+    isArchived: (p) => p.frontmatter.archived === true,
+  });
+
+  const log =
+    logBody === null ? null : buildWikiLog({ body: logBody, generatedOn });
+
+  const live = parsed.filter((p) => p.frontmatter.archived !== true);
+  const sources = await buildWikiSources({
+    parsed: live,
+    rawRoot,
+    generatedOn,
+  });
+
+  return { graph, log, sources };
+}
+
+export interface WriteManifestsArgs {
+  dryRun: boolean;
+  graphOutputPath: string;
+  logOutputPath: string;
+  set: ManifestSet;
+  sourcesOutputPath: string;
+}
+
+export async function writeManifests(
+  args: WriteManifestsArgs
+): Promise<{ graphPath: string }> {
+  const { set, graphOutputPath, logOutputPath, sourcesOutputPath, dryRun } =
+    args;
+
+  const graphPath = await emitArticleGraph({
+    graph: set.graph,
+    outputPath: graphOutputPath,
+    dryRun,
+  });
+
+  if (set.log) {
+    await emitWikiLog({ log: set.log, outputPath: logOutputPath, dryRun });
+  }
+
+  await emitWikiSources({
+    manifest: set.sources,
+    outputPath: sourcesOutputPath,
+    dryRun,
+  });
+
+  return { graphPath };
+}


### PR DESCRIPTION
## What

`main()` emitted the three JSON manifests through three near-identical private helpers (`emitGraph`/`emitWikiLogManifest`/`emitWikiSourcesManifest`), each reading its own `new Date()` for `generatedOn`. This adds `pages/manifests.ts`:

- `buildManifests({ parsed, logBody, rawRoot, generatedOn })` → `{ graph, log, sources }` (pure compute, returns a `ManifestSet` value)
- `writeManifests({ set, ...paths, dryRun })` → does the I/O

`main()` now computes `generatedOn` **once** and threads it to all three builders, and the three helpers are gone.

## Why (honest scope)

The manifest timestamps were **already date-only and deterministic** (a prior commit fixed that), so this is **not** a determinism fix. The value is locality + testability:

- one clock instead of three (no midnight-boundary skew across the three manifests);
- the manifest pipeline becomes a unit-testable value, which let me **fill a real test gap** — `pages/wiki-log.ts` and `pages/wiki-sources.ts` builders were previously untested.

Output is byte-identical to before for the same inputs and date (same `isArchived` predicate, same `live` filter, same sort orders, same emit order).

## Tests added

- `manifests.test.ts` (6) — determinism (build twice → identical), one shared `generatedOn`, archived exclusion, null-log, write + parse-back, dryRun.
- `wiki-log.test.ts` (5) — ordering, date-only stamp, ref extraction, stable equal-date order, empty.
- `wiki-sources.test.ts` (4) — multi-key sort, sorted `citedBy`, URL→kind classification, date-only stamp.

## Verification (run in this worktree)

- `bun run type-check` — ✅ 4/4
- `bun run lint` — ✅ clean
- `bun run test` — ✅ 210 tests (89 blog + 121 CLI; +15 new)

No data files were regenerated. (CLI runs via Bun; no build step. Blog untouched.)

## Notes

Stacked on #811 (base `feat/wikilink-module`). Fourth of five. **Re-scoped from the original review candidate**, whose headline (fix non-deterministic full-ISO timestamps) was already resolved on `main`; the surviving value is the single-clock seam + the builder test gap. The per-article raw-doc load-once optimisation is intentionally left as a separate future change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)