### PR TITLE
refactor: centralize manifest schemas in article-contract with write-gate + read-parse validation

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,46 @@
+# CONTEXT
+
+Domain and architecture vocabulary for this monorepo. Add terms here as they
+crystallize; keep one definition per concept so reviews and agents share language.
+
+## Manifest
+
+A build-time JSON artifact the **CLI produces** and the **blog consumes** — the
+seam between the two apps. The five manifests live in `apps/blog/src/data/`:
+
+| Manifest | Produced by | Read by |
+|---|---|---|
+| `article-graph.json` | `import-wiki/pages/graph.ts` | `articles/service.ts` (build) |
+| `wiki-sources.json` | `import-wiki/pages/wiki-sources.ts` | `articles/service.ts` (build) |
+| `open-questions.json` | `import-wiki/pages/open-questions.ts` | `articles/service.ts` (build) |
+| `search-index.json` | `search-index.ts` | `components/search/search-data.ts` (browser) |
+| `translations.json` | `translate/tracking/projection.ts` | `articles/service.ts` (build) |
+
+### The contract rule
+
+Every manifest's **shape is owned once**, by `@howardism/article-contract` under
+`src/manifests/<name>.ts` — a zod schema, its inferred type, and (for
+build-time readers) a `parse*` function. Producer and consumer import the same
+shape; neither re-declares it. This is what makes the manifest a real **seam**
+rather than two interfaces that happen to agree.
+
+### Write-gate vs read-parse
+
+- **Write-gate** — the CLI runs `Schema.parse(...)` immediately before writing
+  every manifest, so a malformed manifest can never land on disk. All five are
+  gated on write.
+- **Read-parse** — the four manifests read at **build time** in `service.ts` are
+  re-validated via their `parse*` function on read, so a stale committed file
+  throws a named error at build instead of failing silently.
+- **Search-index carve-out** — `search-index.json` (~800 KB) is read in the
+  **visitor's browser** when the search palette opens. It shares the inferred
+  type and is gated on write, but is **not** zod-parsed on read — the browser
+  pays no validation cost. Its `domain`/`tag` fields stay loose `string` (not the
+  `WikiDomain`/`WikiTag` enums) so a new domain can land before an enum bump.
+
+## article-contract
+
+The shared package (`packages/article-contract`) that owns every cross-app shape:
+the MDX **frontmatter** contract (`./schema`), the translation **surface** hash
+(`./surface`), and the five **manifest** contracts (`./manifests/*`). Builders'
+algorithms stay in the CLI; only the interface lives here.

--- a/apps/blog/src/app/(blog)/articles/service.ts
+++ b/apps/blog/src/app/(blog)/articles/service.ts
@@ -9,6 +9,16 @@ import {
   type WikiDomain,
   type WikiTag,
 } from "@howardism/article-contract";
+import { parseArticleGraph } from "@howardism/article-contract/manifests/graph";
+import {
+  type OpenQuestionConcept,
+  parseOpenQuestions,
+} from "@howardism/article-contract/manifests/open-questions";
+import { parseTranslations } from "@howardism/article-contract/manifests/translations";
+import {
+  parseWikiSources,
+  type WikiSource,
+} from "@howardism/article-contract/manifests/wiki-sources";
 import {
   ArticleContractSchema,
   type SourceRefSchema,
@@ -81,14 +91,7 @@ export interface ArticleHeading {
   text: string;
 }
 
-interface ArticleGraph {
-  backlinks: Record<string, readonly string[] | undefined>;
-  generatedOn: string;
-  outgoing: Record<string, readonly string[] | undefined>;
-  related: Record<string, readonly string[] | undefined>;
-}
-
-const graph: ArticleGraph = graphData;
+const graph = parseArticleGraph(graphData);
 
 const isArticleTag = (value: string): value is ArticleTag =>
   (ARTICLE_TAGS as readonly string[]).includes(value);
@@ -383,19 +386,9 @@ export const getNavigableTagSet = cache(
 
 /* ── reading-list manifest (emitted by the importer) ── */
 
-export interface WikiSource {
-  author?: string;
-  citedBy: string[];
-  kind: string;
-  published?: string;
-  title: string;
-  url?: string;
-}
+export type { WikiSource } from "@howardism/article-contract/manifests/wiki-sources";
 
-const wikiSources = wikiSourcesData as {
-  generatedOn: string;
-  sources: WikiSource[];
-};
+const wikiSources = parseWikiSources(wikiSourcesData);
 
 /** Raw reading-list sources, pre-sorted by citation count then recency. */
 export const getWikiSources = (limit?: number): WikiSource[] =>
@@ -477,17 +470,9 @@ export const getDomainLeadSource = cache(
 
 /* ── open-questions backlog (emitted by the importer) ── */
 
-export interface OpenQuestionConcept {
-  domain: ArticleDomain;
-  questions: string[];
-  slug: string;
-  title: string;
-}
+export type { OpenQuestionConcept } from "@howardism/article-contract/manifests/open-questions";
 
-const openQuestions = openQuestionsData as {
-  byConcept: OpenQuestionConcept[];
-  generatedOn: string;
-};
+const openQuestions = parseOpenQuestions(openQuestionsData);
 
 /** Every concept that still has unanswered questions, title-sorted. */
 export const getOpenQuestions = (): OpenQuestionConcept[] =>
@@ -540,22 +525,7 @@ export const DEFAULT_LOCALE: Locale = "en";
 /** Non-default locales served under a path prefix (en stays unprefixed). */
 export const PREFIXED_LOCALES: readonly Locale[] = ["zh-TW"];
 
-interface TranslationRecord {
-  costUsd: number | null;
-  credits: number | null;
-  durationMs: number;
-  engine: string;
-  model: string | null;
-  sourceHash: string;
-  sourceTitle: string | null;
-  translatedAt: string;
-}
-
-const translations = translationsData as {
-  articles: Record<string, TranslationRecord>;
-  generatedOn: string;
-  locale: string;
-};
+const translations = parseTranslations(translationsData);
 
 const translatedSet = new Set(Object.keys(translations.articles));
 

--- a/apps/blog/src/components/search/search-data.ts
+++ b/apps/blog/src/components/search/search-data.ts
@@ -1,20 +1,15 @@
+import type {
+  SearchIndex,
+  SearchIndexEntry,
+} from "@howardism/article-contract/manifests/search-index";
 import Fuse, { type IFuseOptions } from "fuse.js";
 
-/** One searchable article — mirrors the CLI's `SearchIndexEntry`. */
-export interface SearchEntry {
-  body: string;
-  description: string;
-  domain?: string;
-  slug: string;
-  tag: string;
-  tags?: string[];
-  title: string;
-}
-
-interface SearchIndexFile {
-  entries: SearchEntry[];
-  generatedOn: string;
-}
+/**
+ * One searchable article. The shape is owned by `@howardism/article-contract`
+ * and gated at write time by the CLI; this ~800KB chunk loads in the browser, so
+ * it is read against the shared type without a zod parse on read.
+ */
+export type SearchEntry = SearchIndexEntry;
 
 const FUSE_OPTIONS: IFuseOptions<SearchEntry> = {
   keys: [
@@ -44,7 +39,7 @@ let indexPromise: Promise<SearchEntry[]> | null = null;
 export function loadSearchIndex(): Promise<SearchEntry[]> {
   if (!indexPromise) {
     indexPromise = import("@/data/search-index.json")
-      .then((mod) => (mod.default as SearchIndexFile).entries)
+      .then((mod) => (mod.default as SearchIndex).entries)
       .catch((err) => {
         // Drop the cached rejection so a later open retries the chunk fetch
         // instead of being stuck with a permanently-failed promise.

--- a/apps/cli/src/import-wiki/pages/graph.ts
+++ b/apps/cli/src/import-wiki/pages/graph.ts
@@ -1,23 +1,17 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 
+import {
+  type ArticleGraph,
+  ArticleGraphSchema,
+} from "@howardism/article-contract/manifests/graph";
+
 import type { ParsedWikiFile } from "../parse.ts";
 import { extractInternalSlugs } from "../wikilink.ts";
 
 const RELATED_LIMIT = 5;
 
-/**
- * Shape consumed by the blog's link-graph service layer
- * (`apps/blog/src/data/article-graph.json`). Value arrays are sorted
- * deterministically; archived nodes are filtered out everywhere so every
- * slug referenced in the graph is also a key.
- */
-export interface ArticleGraph {
-  backlinks: Record<string, string[]>;
-  generatedOn: string;
-  outgoing: Record<string, string[]>;
-  related: Record<string, string[]>;
-}
+export type { ArticleGraph } from "@howardism/article-contract/manifests/graph";
 
 export interface BuildArticleGraphArgs {
   generatedOn: string;
@@ -146,7 +140,7 @@ export async function emitArticleGraph(
   args: EmitArticleGraphArgs
 ): Promise<string> {
   const { graph, outputPath, dryRun } = args;
-  const json = JSON.stringify(graph);
+  const json = JSON.stringify(ArticleGraphSchema.parse(graph));
 
   if (dryRun) {
     console.log(

--- a/apps/cli/src/import-wiki/pages/open-questions.ts
+++ b/apps/cli/src/import-wiki/pages/open-questions.ts
@@ -2,28 +2,20 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 
 import type { WikiDomain } from "@howardism/article-contract";
+import {
+  type OpenQuestionConcept,
+  type OpenQuestionsManifest,
+  OpenQuestionsManifestSchema,
+} from "@howardism/article-contract/manifests/open-questions";
 
 import { OPEN_QUESTIONS_SLUG, resolveDomain } from "../domains.ts";
 import type { ParsedWikiFile } from "../parse.ts";
 import { extractInternalSlugs, titleFromSlug } from "../wikilink.ts";
 
-/**
- * The open-questions backlog, harvested from `derived/open-questions.md` and
- * regrouped under the blog's domains. Each concept that still has unanswered
- * `## Open Questions` becomes one entry; the blog buckets these by `domain`
- * for the `/questions` page and the per-domain sections on domain pages.
- */
-export interface OpenQuestionConcept {
-  domain: WikiDomain;
-  questions: string[];
-  slug: string;
-  title: string;
-}
-
-export interface OpenQuestionsManifest {
-  byConcept: OpenQuestionConcept[];
-  generatedOn: string;
-}
+export type {
+  OpenQuestionConcept,
+  OpenQuestionsManifest,
+} from "@howardism/article-contract/manifests/open-questions";
 
 const CONCEPT_HEADING_RE = /^##\s+\[\[[^\]]+\]\]/;
 const BULLET_RE = /^-\s+(.+)$/;
@@ -91,7 +83,7 @@ export async function emitOpenQuestions(args: {
   outputPath: string;
 }): Promise<string> {
   const { manifest, outputPath, dryRun } = args;
-  const json = JSON.stringify(manifest);
+  const json = JSON.stringify(OpenQuestionsManifestSchema.parse(manifest));
 
   if (dryRun) {
     console.log(

--- a/apps/cli/src/import-wiki/pages/wiki-sources.ts
+++ b/apps/cli/src/import-wiki/pages/wiki-sources.ts
@@ -2,33 +2,21 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 
 import {
+  type WikiSource,
+  type WikiSourcesManifest,
+  WikiSourcesManifestSchema,
+} from "@howardism/article-contract/manifests/wiki-sources";
+
+import {
   extractRawSlugsFromSources,
   loadRawDoc,
   type ParsedWikiFile,
 } from "../parse.ts";
 
-/**
- * A raw source document (`raw/<slug>.md`) aggregated across the wiki, for the
- * home page's "The Desk" reading list. `citedBy` lists the notes that cite the
- * source, which both ranks the desk and lets the blog pick the most-cited
- * source within a domain for the domain-plate aside.
- */
-export interface WikiSource {
-  author?: string;
-  /** Article slugs whose `sources:` frontmatter cites this doc. */
-  citedBy: string[];
-  /** Coarse medium derived from the URL: Talk | Paper | Repo | Article | Note. */
-  kind: string;
-  /** `published` date from the raw doc, `YYYY-MM-DD` when present. */
-  published?: string;
-  title: string;
-  url?: string;
-}
-
-export interface WikiSourcesManifest {
-  generatedOn: string;
-  sources: WikiSource[];
-}
+export type {
+  WikiSource,
+  WikiSourcesManifest,
+} from "@howardism/article-contract/manifests/wiki-sources";
 
 const PUNCT_RE = /[._-]+/g;
 const WS_RE = /\s+/g;
@@ -119,7 +107,7 @@ export async function emitWikiSources(args: {
   outputPath: string;
 }): Promise<string> {
   const { manifest, outputPath, dryRun } = args;
-  const json = JSON.stringify(manifest);
+  const json = JSON.stringify(WikiSourcesManifestSchema.parse(manifest));
 
   if (dryRun) {
     console.log(

--- a/apps/cli/src/search-index.ts
+++ b/apps/cli/src/search-index.ts
@@ -11,25 +11,19 @@
 import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 
+import {
+  type SearchIndex,
+  type SearchIndexEntry,
+  SearchIndexSchema,
+} from "@howardism/article-contract/manifests/search-index";
 import matter from "gray-matter";
 
 import { toPlainText } from "./import-wiki/plain-text.ts";
 
-/** One searchable article. Mirrored read-side by the blog's search loader. */
-export interface SearchIndexEntry {
-  body: string;
-  description: string;
-  domain?: string;
-  slug: string;
-  tag: string;
-  tags?: string[];
-  title: string;
-}
-
-export interface SearchIndex {
-  entries: SearchIndexEntry[];
-  generatedOn: string;
-}
+export type {
+  SearchIndex,
+  SearchIndexEntry,
+} from "@howardism/article-contract/manifests/search-index";
 
 const MDX_SUFFIX = /\.mdx$/;
 // The `export { default as heroImage } …` line every emitted MDX carries right
@@ -87,7 +81,7 @@ async function buildIndex(generatedOn: string): Promise<SearchIndex> {
 async function main(): Promise<void> {
   const generatedOn = new Date().toISOString().slice(0, 10);
   const index = await buildIndex(generatedOn);
-  const json = JSON.stringify(index);
+  const json = JSON.stringify(SearchIndexSchema.parse(index));
 
   if (process.env.DRY_RUN === "1") {
     console.log(

--- a/apps/cli/src/translate/tracking/projection.ts
+++ b/apps/cli/src/translate/tracking/projection.ts
@@ -1,23 +1,19 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 
-/**
- * Current-state record per translated slug. This is the DURABLE, committed
- * truth (lives at apps/blog/src/data/translations.json): it drives staleness
- * classification and is read by the blog at build time for the language
- * switcher. The SQLite DB is a per-machine history cache layered on top.
- */
-export interface TranslationRecord {
-  costUsd: number | null;
-  credits: number | null;
-  durationMs: number;
-  engine: string;
-  model: string | null;
-  sourceHash: string;
-  sourceTitle: string | null;
-  translatedAt: string;
-}
+import {
+  type TranslationRecord,
+  TranslationsManifestSchema,
+} from "@howardism/article-contract/manifests/translations";
 
+export type { TranslationRecord } from "@howardism/article-contract/manifests/translations";
+
+/**
+ * Current-state projection of all translated slugs — the DURABLE, committed
+ * truth (lives at apps/blog/src/data/translations.json). The per-slug record
+ * shape is owned by `@howardism/article-contract`; the SQLite DB is a
+ * per-machine history cache layered on top.
+ */
 export interface TranslationProjection {
   articles: Record<string, TranslationRecord>;
   generatedOn: string;
@@ -95,6 +91,10 @@ export async function writeProjection(
     articles: sorted,
   };
   await mkdir(dirname(path), { recursive: true });
-  await writeFile(path, `${JSON.stringify(next, null, 2)}\n`, "utf8");
+  await writeFile(
+    path,
+    `${JSON.stringify(TranslationsManifestSchema.parse(next), null, 2)}\n`,
+    "utf8"
+  );
   return next;
 }

--- a/packages/article-contract/package.json
+++ b/packages/article-contract/package.json
@@ -6,7 +6,12 @@
   "exports": {
     ".": "./src/index.ts",
     "./schema": "./src/schema.ts",
-    "./surface": "./src/surface.ts"
+    "./surface": "./src/surface.ts",
+    "./manifests/graph": "./src/manifests/graph.ts",
+    "./manifests/wiki-sources": "./src/manifests/wiki-sources.ts",
+    "./manifests/open-questions": "./src/manifests/open-questions.ts",
+    "./manifests/search-index": "./src/manifests/search-index.ts",
+    "./manifests/translations": "./src/manifests/translations.ts"
   },
   "scripts": {
     "type-check": "tsc --noEmit",

--- a/packages/article-contract/src/manifests/graph.ts
+++ b/packages/article-contract/src/manifests/graph.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+/**
+ * The link graph the wiki importer emits to `apps/blog/src/data/article-graph.json`
+ * and the blog reads at build time. Every value array is sorted deterministically
+ * and archived nodes are filtered out on the write side, so every slug referenced
+ * is also a key. A slug absent from a map has no edges (treat as `[]`).
+ */
+const slugList = z.array(z.string());
+
+export const ArticleGraphSchema = z.object({
+  backlinks: z.record(z.string(), slugList),
+  generatedOn: z.string(),
+  outgoing: z.record(z.string(), slugList),
+  related: z.record(z.string(), slugList),
+});
+
+export type ArticleGraph = z.infer<typeof ArticleGraphSchema>;
+
+/** Parse + validate a raw article-graph manifest; throws on drift. */
+export const parseArticleGraph = (data: unknown): ArticleGraph =>
+  ArticleGraphSchema.parse(data);

--- a/packages/article-contract/src/manifests/open-questions.ts
+++ b/packages/article-contract/src/manifests/open-questions.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+import { WIKI_DOMAINS } from "../index";
+
+/**
+ * The open-questions backlog, harvested from the vault and regrouped under the
+ * blog's domains. Each concept that still has unanswered questions becomes one
+ * entry; the blog buckets these by `domain` for the `/questions` page and the
+ * per-domain sections on domain pages.
+ */
+export const OpenQuestionConceptSchema = z.object({
+  domain: z.enum(WIKI_DOMAINS),
+  questions: z.array(z.string()),
+  slug: z.string(),
+  title: z.string(),
+});
+
+export type OpenQuestionConcept = z.infer<typeof OpenQuestionConceptSchema>;
+
+export const OpenQuestionsManifestSchema = z.object({
+  byConcept: z.array(OpenQuestionConceptSchema),
+  generatedOn: z.string(),
+});
+
+export type OpenQuestionsManifest = z.infer<typeof OpenQuestionsManifestSchema>;
+
+/** Parse + validate a raw open-questions manifest; throws on drift. */
+export const parseOpenQuestions = (data: unknown): OpenQuestionsManifest =>
+  OpenQuestionsManifestSchema.parse(data);

--- a/packages/article-contract/src/manifests/search-index.ts
+++ b/packages/article-contract/src/manifests/search-index.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+
+/**
+ * One searchable article in `apps/blog/src/data/search-index.json`. `domain` and
+ * `tag` stay loose strings (not the WikiDomain/WikiTag enums): the search index
+ * must tolerate a new domain landing before an enum bump, so the write-gate does
+ * not reject it. Read-side, the blog loads this ~800KB chunk in the browser, so
+ * it shares the inferred type but does NOT zod-parse on read — the write-gate is
+ * the validation point. See parseSearchIndex (used CLI-side only).
+ */
+export const SearchIndexEntrySchema = z.object({
+  body: z.string(),
+  description: z.string(),
+  domain: z.string().optional(),
+  slug: z.string(),
+  tag: z.string(),
+  tags: z.array(z.string()).optional(),
+  title: z.string(),
+});
+
+export type SearchIndexEntry = z.infer<typeof SearchIndexEntrySchema>;
+
+export const SearchIndexSchema = z.object({
+  entries: z.array(SearchIndexEntrySchema),
+  generatedOn: z.string(),
+});
+
+export type SearchIndex = z.infer<typeof SearchIndexSchema>;
+
+/** Parse + validate a raw search index; used to gate the CLI write, not reads. */
+export const parseSearchIndex = (data: unknown): SearchIndex =>
+  SearchIndexSchema.parse(data);

--- a/packages/article-contract/src/manifests/translations.ts
+++ b/packages/article-contract/src/manifests/translations.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+
+/**
+ * Current-state record per translated slug — the durable, committed truth at
+ * `apps/blog/src/data/translations.json`. Drives staleness classification on the
+ * CLI side and the blog's language switcher on read. The SQLite history DB is a
+ * per-machine cache layered on top; this manifest is authoritative across clones.
+ */
+export const TranslationRecordSchema = z.object({
+  costUsd: z.number().nullable(),
+  credits: z.number().nullable(),
+  durationMs: z.number(),
+  engine: z.string(),
+  model: z.string().nullable(),
+  sourceHash: z.string(),
+  sourceTitle: z.string().nullable(),
+  translatedAt: z.string(),
+});
+
+export type TranslationRecord = z.infer<typeof TranslationRecordSchema>;
+
+export const TranslationsManifestSchema = z.object({
+  articles: z.record(z.string(), TranslationRecordSchema),
+  generatedOn: z.string(),
+  locale: z.string(),
+});
+
+export type TranslationsManifest = z.infer<typeof TranslationsManifestSchema>;
+
+/** Parse + validate a raw translations manifest; throws on drift. */
+export const parseTranslations = (data: unknown): TranslationsManifest =>
+  TranslationsManifestSchema.parse(data);

--- a/packages/article-contract/src/manifests/wiki-sources.ts
+++ b/packages/article-contract/src/manifests/wiki-sources.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+/**
+ * A raw source document aggregated across the wiki for the home page's reading
+ * list. `citedBy` lists the article slugs whose `sources:` frontmatter cite this
+ * doc — it both ranks the desk and lets the blog pick a domain's lead source.
+ */
+export const WikiSourceSchema = z.object({
+  author: z.string().optional(),
+  citedBy: z.array(z.string()),
+  /** Coarse medium derived from the URL: Talk | Paper | Repo | Article | Note. */
+  kind: z.string(),
+  published: z.string().optional(),
+  title: z.string(),
+  url: z.string().optional(),
+});
+
+export type WikiSource = z.infer<typeof WikiSourceSchema>;
+
+export const WikiSourcesManifestSchema = z.object({
+  generatedOn: z.string(),
+  sources: z.array(WikiSourceSchema),
+});
+
+export type WikiSourcesManifest = z.infer<typeof WikiSourcesManifestSchema>;
+
+/** Parse + validate a raw wiki-sources manifest; throws on drift. */
+export const parseWikiSources = (data: unknown): WikiSourcesManifest =>
+  WikiSourcesManifestSchema.parse(data);


### PR DESCRIPTION
## Summary

- Adds five Zod schema modules under `packages/article-contract/src/manifests/` (one per CLI→blog JSON manifest) and wires them into the package's `exports` map — the foundation that makes the seam explicit.
- Refactors all five CLI emit points (`graph.ts`, `open-questions.ts`, `wiki-sources.ts`, `search-index.ts`, `projection.ts`) to import types and schemas from the shared package and run `Schema.parse(...)` immediately before every disk write (write-gate), replacing the previously inline interface declarations.
- Refactors the blog's build-time manifest readers (`articles/service.ts`, `search-data.ts`) to call `parse*` helpers from the shared package instead of casting JSON against local interfaces; `search-data.ts` avoids a runtime Zod parse for the ~800 KB search index to keep browser cost zero.
- Adds `CONTEXT.md` documenting the manifest concept, the contract rule, and the write-gate vs read-parse vs search-index carve-out distinctions.

## Commits

- `e1a9c6b2` ✨ feat(article-contract): add manifest schemas for all five build-time JSON files
- `c1525335` ♻️ refactor(cli): replace local interface defs with article-contract manifest schemas
- `5e77ba15` ♻️ refactor(blog): parse manifests via article-contract schemas on read
- `2e137be3` 📝 docs: add CONTEXT.md with manifest contract vocabulary

🤖 Generated with [Claude Code](https://claude.com/claude-code)