### PR TITLE
💄 feat(blog): mobile reader gap-fill (menu, ergonomics, resume %)

### DIFF
--- a/apps/blog/src/__tests__/articles/resume-reading.test.tsx
+++ b/apps/blog/src/__tests__/articles/resume-reading.test.tsx
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import { ResumeReading } from "@/app/(blog)/articles/[slug]/resume-reading";
+import type { ArticleHeading } from "@/app/(blog)/articles/service";
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+  document.body.innerHTML = "";
+});
+
+const RESUME_WITH_PCT = /Resume · 58%/;
+
+const headings: ArticleHeading[] = [
+  { depth: 2, id: "intro", text: "Intro" },
+  { depth: 2, id: "middle", text: "Middle" },
+  { depth: 2, id: "end", text: "End" },
+];
+
+function anchorInDom(id: string): void {
+  const el = document.createElement("div");
+  el.id = id;
+  document.body.appendChild(el);
+}
+
+describe("ResumeReading offer chip", () => {
+  it("offers resume with the saved percentage when reopening partway through", () => {
+    anchorInDom("middle");
+    localStorage.setItem(
+      "howardism:reading:my-slug",
+      JSON.stringify({ headingId: "middle", pct: 0.58 })
+    );
+
+    render(<ResumeReading headings={headings} slug="my-slug" />);
+
+    expect(screen.getByText(RESUME_WITH_PCT)).not.toBeNull();
+  });
+
+  it("stays quiet when there is no saved progress", () => {
+    const { container } = render(
+      <ResumeReading headings={headings} slug="unread" />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("stays quiet when saved progress is below the resume threshold", () => {
+    anchorInDom("intro");
+    localStorage.setItem(
+      "howardism:reading:barely",
+      JSON.stringify({ headingId: "intro", pct: 0.1 })
+    );
+
+    const { container } = render(
+      <ResumeReading headings={headings} slug="barely" />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/apps/blog/src/__tests__/howardism/primitives.test.tsx
+++ b/apps/blog/src/__tests__/howardism/primitives.test.tsx
@@ -67,6 +67,20 @@ describe("data-grid", () => {
     render(<DataGrid className="extra" rows={[["k", "v"]]} />);
     expect(screen.getByTestId("data-grid").className).toContain("extra");
   });
+
+  it("uses the two-column split by default", () => {
+    render(<DataGrid rows={[["k", "v"]]} />);
+    const grid = screen.getByTestId("data-grid");
+    expect(grid.className).toContain("grid-cols-[auto_1fr]");
+    expect(grid.className).not.toContain("grid-cols-1");
+  });
+
+  it("stacks label over value below 480px when stack is set", () => {
+    render(<DataGrid rows={[["k", "v"]]} stack />);
+    const grid = screen.getByTestId("data-grid");
+    expect(grid.className).toContain("grid-cols-1");
+    expect(grid.className).toContain("min-[480px]:grid-cols-[auto_1fr]");
+  });
 });
 
 describe("ph", () => {

--- a/apps/blog/src/app/(blog)/(layout)/header.tsx
+++ b/apps/blog/src/app/(blog)/(layout)/header.tsx
@@ -1,15 +1,15 @@
 "use client";
 
-import { Badge } from "@howardism/ui/components/badge";
 import {
   Sheet,
+  SheetClose,
   SheetContent,
   SheetHeader,
   SheetTitle,
   SheetTrigger,
 } from "@howardism/ui/components/sheet";
 import { cn } from "@howardism/ui/lib/utils";
-import { Moon02Icon, Sun03Icon } from "@hugeicons/core-free-icons";
+import { Menu01Icon, Moon02Icon, Sun03Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -25,13 +25,18 @@ import { useTweaks } from "@/components/tweaks/tweaks-provider";
 import useHasScrolled from "@/hooks/use-has-scrolled";
 
 import { Avatar } from "./avatar";
-import { NAV_SECTION_KEYS, NavSection } from "./constants";
+import { FOOTER_NAV, NAV_SECTION_KEYS, NavSection } from "./constants";
+
+function isRouteActive(pathname: string | null, href: string): boolean {
+  return (
+    pathname !== null &&
+    (pathname === href || (href !== "/" && pathname.startsWith(href)))
+  );
+}
 
 function NavLink({ href, label }: { href: string; label: string }) {
   const pathname = usePathname();
-  const isActive =
-    pathname !== null &&
-    (pathname === href || (href !== "/" && pathname.startsWith(href)));
+  const isActive = isRouteActive(pathname, href);
 
   return (
     <Link
@@ -58,38 +63,56 @@ function DesktopNav() {
 }
 
 function MobileNav() {
+  const pathname = usePathname();
+
   return (
     <div className="md:hidden">
       <Sheet>
-        <SheetTrigger asChild>
-          <button type="button">
-            <Badge variant="chip">Menu</Badge>
-          </button>
+        <SheetTrigger
+          aria-label="Menu"
+          className="flex size-9 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+        >
+          <HugeiconsIcon className="size-[18px]" icon={Menu01Icon} />
         </SheetTrigger>
         <SheetContent
           className="mx-4 mt-4 rounded-3xl p-8"
           showCloseButton={false}
           side="top"
         >
-          <SheetHeader className="p-0">
-            <SheetTitle className="font-medium font-mono text-[0.6875rem] text-foreground-subtle uppercase tracking-[0.16em]">
-              Navigation
-            </SheetTitle>
+          <SheetHeader className="flex-row items-center gap-3 p-0">
+            <Avatar label="Home" size={36} />
+            <div className="flex flex-col gap-px">
+              <SheetTitle className="font-display font-medium text-[15px] text-foreground leading-none tracking-[-0.015em]">
+                Howardism
+              </SheetTitle>
+              <span className="font-mono text-[10px] text-foreground-subtle uppercase leading-none tracking-[0.14em]">
+                vol. 03 · quiet corner of the web
+              </span>
+            </div>
           </SheetHeader>
           <nav aria-label="Mobile primary" className="mt-6">
             <ul className="m-0 flex list-none flex-col gap-0 border-border border-t p-0">
-              {NAV_SECTION_KEYS.map((key) => (
-                <li className="border-border border-b" key={key}>
-                  <Link
-                    className="block py-3 font-body text-[15px] text-foreground"
-                    href={NavSection[key]}
-                  >
-                    {key}
-                  </Link>
+              {FOOTER_NAV.map(({ label, href }) => (
+                <li className="border-border border-b" key={label}>
+                  <SheetClose asChild>
+                    <Link
+                      aria-current={
+                        isRouteActive(pathname, href) ? "page" : undefined
+                      }
+                      className="flex min-h-12 items-center rounded-lg px-2 font-body text-[15px] text-foreground transition-colors aria-[current=page]:bg-brand/10 aria-[current=page]:text-brand"
+                      href={href}
+                    >
+                      {label}
+                    </Link>
+                  </SheetClose>
                 </li>
               ))}
             </ul>
           </nav>
+          <span className="mt-6 block font-mono text-[10px] text-foreground-subtle tracking-[0.02em]">
+            Set in Fraunces, Newsreader &amp; JetBrains Mono. The text is the
+            work; the design is the chrome.
+          </span>
         </SheetContent>
       </Sheet>
     </div>
@@ -157,15 +180,23 @@ export function SiteBar() {
           <DesktopNav />
 
           {/* Reader controls — article pages only. The TOC button is hidden at
-              the rail breakpoint, where the sticky rail already shows the TOC. */}
+              the rail breakpoint, where the sticky rail already shows the TOC. A
+              hairline divider sets this reader cluster apart from the global
+              search/theme/menu cluster. */}
           {isArticle && (
-            <div className="flex items-center gap-0.5">
-              <span className="inline-flex rail:hidden">
-                <TocSheet />
-              </span>
-              <ArticleFind />
-              <ReaderSettings />
-            </div>
+            <>
+              <div className="flex items-center gap-0.5">
+                <span className="inline-flex rail:hidden">
+                  <TocSheet />
+                </span>
+                <ArticleFind />
+                <ReaderSettings />
+              </div>
+              <span
+                aria-hidden="true"
+                className="h-5 w-px shrink-0 bg-border"
+              />
+            </>
           )}
 
           <SearchTrigger />

--- a/apps/blog/src/app/(blog)/articles/[slug]/article-layout.tsx
+++ b/apps/blog/src/app/(blog)/articles/[slug]/article-layout.tsx
@@ -135,7 +135,7 @@ export function ArticleLayout({
                 <h1 className="mb-5 font-display font-normal text-[27px] text-foreground leading-[1.25] tracking-[-0.015em]">
                   {meta.title}
                 </h1>
-                <DataGrid maxWidth={280} rows={metaRows} />
+                <DataGrid maxWidth={280} rows={metaRows} stack />
               </div>
 
               <div

--- a/apps/blog/src/app/(blog)/articles/[slug]/article-toc.tsx
+++ b/apps/blog/src/app/(blog)/articles/[slug]/article-toc.tsx
@@ -44,7 +44,7 @@ export function ArticleToc({ headings }: ArticleTocProps) {
               <a
                 aria-current={isActive ? "location" : undefined}
                 className={cn(
-                  "no-underline transition-colors hover:text-foreground",
+                  "no-underline transition-colors hover:text-foreground [@media(pointer:coarse)]:flex [@media(pointer:coarse)]:min-h-11 [@media(pointer:coarse)]:items-center",
                   isActive ? "text-foreground" : "text-foreground-subtle"
                 )}
                 href={`#${heading.id}`}

--- a/apps/blog/src/app/(blog)/articles/[slug]/resume-reading.tsx
+++ b/apps/blog/src/app/(blog)/articles/[slug]/resume-reading.tsx
@@ -55,7 +55,7 @@ export function ResumeReading({ headings, slug }: ResumeReadingProps) {
   const activeIdRef = useRef(activeId);
   activeIdRef.current = activeId;
 
-  const [resumeId, setResumeId] = useState<string | null>(null);
+  const [resume, setResume] = useState<SavedProgress | null>(null);
 
   // Read the saved position once on mount and decide whether to offer resume.
   useEffect(() => {
@@ -69,8 +69,8 @@ export function ResumeReading({ headings, slug }: ResumeReadingProps) {
     if (!document.getElementById(saved.headingId)) {
       return;
     }
-    setResumeId(saved.headingId);
-    const timer = setTimeout(() => setResumeId(null), AUTO_DISMISS_MS);
+    setResume(saved);
+    const timer = setTimeout(() => setResume(null), AUTO_DISMISS_MS);
     return () => clearTimeout(timer);
   }, [headings.length, slug]);
 
@@ -106,15 +106,15 @@ export function ResumeReading({ headings, slug }: ResumeReadingProps) {
   }, [slug]);
 
   const handleResume = useCallback(() => {
-    if (resumeId) {
+    if (resume) {
       document
-        .getElementById(resumeId)
+        .getElementById(resume.headingId)
         ?.scrollIntoView({ behavior: "smooth", block: "start" });
     }
-    setResumeId(null);
-  }, [resumeId]);
+    setResume(null);
+  }, [resume]);
 
-  if (!resumeId) {
+  if (!resume) {
     return null;
   }
 
@@ -125,12 +125,13 @@ export function ResumeReading({ headings, slug }: ResumeReadingProps) {
         onClick={handleResume}
         type="button"
       >
-        Resume <span aria-hidden="true">↓</span>
+        Resume · {Math.round(resume.pct * 100)}%{" "}
+        <span aria-hidden="true">↓</span>
       </button>
       <button
         aria-label="Dismiss resume"
         className="flex size-6 items-center justify-center rounded-full text-foreground-subtle transition-colors hover:text-foreground"
-        onClick={() => setResumeId(null)}
+        onClick={() => setResume(null)}
         type="button"
       >
         <span aria-hidden="true">×</span>

--- a/apps/blog/src/components/howardism/data-grid.tsx
+++ b/apps/blog/src/components/howardism/data-grid.tsx
@@ -5,13 +5,23 @@ interface DataGridProps {
   className?: string;
   maxWidth?: number;
   rows: [string, ReactNode][];
+  /** Stack label over value below 480px — for the narrow article column. */
+  stack?: boolean;
 }
 
-export function DataGrid({ rows, maxWidth = 360, className }: DataGridProps) {
+export function DataGrid({
+  rows,
+  maxWidth = 360,
+  className,
+  stack = false,
+}: DataGridProps) {
   return (
     <div
       className={cn(
-        "grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5 font-mono text-[11px] text-foreground-subtle uppercase tracking-[0.18em]",
+        "grid gap-x-4 gap-y-1.5 font-mono text-[11px] text-foreground-subtle uppercase tracking-[0.18em]",
+        stack
+          ? "grid-cols-1 min-[480px]:grid-cols-[auto_1fr]"
+          : "grid-cols-[auto_1fr]",
         className
       )}
       data-testid="data-grid"

--- a/apps/blog/src/components/toc-sheet.tsx
+++ b/apps/blog/src/components/toc-sheet.tsx
@@ -7,7 +7,7 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "@howardism/ui/components/sheet";
-import { Menu01Icon } from "@hugeicons/core-free-icons";
+import { LeftToRightListBulletIcon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 
 import { ArticleToc } from "@/app/(blog)/articles/[slug]/article-toc";
@@ -33,7 +33,7 @@ export function TocSheet() {
         aria-label="On this page"
         className="flex size-9 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
       >
-        <HugeiconsIcon className="size-4" icon={Menu01Icon} />
+        <HugeiconsIcon className="size-4" icon={LeftToRightListBulletIcon} />
       </SheetTrigger>
       <SheetContent className="w-72" side="left">
         <SheetHeader>

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -314,6 +314,13 @@
   color: var(--brand);
 }
 
+/* Step the drop-cap down on a narrow column so it doesn't crowd the first line. */
+@media (max-width: 480px) {
+  .prose-drop-cap::first-letter {
+    font-size: 3.3em;
+  }
+}
+
 /* NOTE: the in-article "find on page" `::highlight(article-find)` styling is
    injected at runtime by useFindHighlights — Turbopack's build-time CSS parser
    does not yet recognise the `::highlight()` pseudo-element and would silently


### PR DESCRIPTION
## What & why

Implements the agreed scope of the **Mobile Reader — Improvement Plan** design handoff. The plan was authored against a prototype and marked "not yet built," but the live blog had already implemented most of it via a **top site-bar** architecture rather than the plan's bottom-reader-bar paradigm. After grilling, we chose to **gap-fill on the existing architecture** rather than rebuild — so this PR fills the genuine gaps and adopts the plan's polish where it improves what exists, without tearing out working, tested UI.

The rail breakpoint stays at `--breakpoint-rail: 80rem` (1280px); the plan's "1080px" is the prototype's number and can't fit the real 720+320 two-column layout.

## Changes

**Wayfinding (P0)**
- Mobile nav: replaced the "Menu" text chip with a 36px **hamburger glyph** matching the search/theme buttons. The sheet now lists Home · Articles · Questions · **RSS** (shared `FOOTER_NAV`) with the **avatar + colophon**, ≥48px rows, **active-route** brand wash, and `SheetClose` to dismiss on navigate.
- Retargeted the `TocSheet` trigger to a `LeftToRightListBullet` glyph so it no longer collides with the nav hamburger in a phone article header.
- Added a hairline divider grouping the reader controls (TOC/find/Aa) apart from the global controls (search/theme/menu).

**Ergonomics (P1)**
- Drop-cap steps down 4.2em → 3.3em below 480px.
- TOC links get a ≥44px hit area on coarse pointers (the contents sheet); desktop rail density unchanged.
- New opt-in `stack` prop on `DataGrid` stacks the article meta grid label-over-value below 480px (disc-page-header unaffected).

**Comfort (P2)**
- Resume chip now shows the stored position — "Resume · 58% ↓" — keeping the unobtrusive offer model (no auto-scroll).

## Not built (already satisfied / out of scope)
- **Bottom reader bar / contents sheet** — kept the existing top progress bar + left-drawer TOC.
- **Inline lead source (P1a)** — no-op: provenance already reaches mobile via the body `## Sources` section, the "About this piece" card, and the meta row; Related + Backlinks already surface inline via `BacklinksDisclosure`.
- **Type size + find (P2a)** — already built and already match the plan's brand-soft highlight + mono count.

## Verification
Run from the worktree (Bun + Turborepo):
- `bun run type-check` — ✅ all packages
- `bun run lint` — ✅ (ultracite/biome)
- `bun test` (apps/blog) — ✅ 116 pass / 0 fail, incl. new DataGrid `stack` + resume `%` tests
- `bun run build` (apps/blog) — ✅ 92 static pages

Not done: no in-browser / device visual check (handoff README advises against screenshots; values were read from source). Worth an eyeball on a real phone before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)