### PR TITLE
🔧 chore: fix invalid Renovate matchPackageNames wildcard (#843)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,13 +18,7 @@
     {
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["minor", "patch"],
-      "matchPackageNames": [
-        "**",
-        "!next",
-        "!react",
-        "!react-dom",
-        "!typescript"
-      ],
+      "matchPackageNames": ["!next", "!react", "!react-dom", "!typescript"],
       "automerge": true
     },
     {


### PR DESCRIPTION
## What

Removes the `"**"` wildcard from `packageRules[1].matchPackageNames` in `renovate.json`, leaving the negation-only list `["!next", "!react", "!react-dom", "!typescript"]`.

## Why

Renovate stopped opening PRs and filed #843 with:

> `packageRules[1].matchPackageNames`: Your input contains `*` or `**` along with other patterns. Please remove them, as `*` or `**` matches all patterns.

A negation-only `matchPackageNames` list already implicitly matches **every** package except the listed exclusions, so the leading `"**"` was redundant *and* now rejected by Renovate's validator. Removing it preserves the original intent — automerge devDependency `minor`/`patch` updates for everything except `next`, `react`, `react-dom`, and `typescript`.

## Verification

`renovate-config-validator` now passes:

```
INFO: Validating renovate.json
INFO: Config validated successfully
```

Closes #843