### PR TITLE
✨ feat(blog): reading history capture + /shelf view (#846)

### DIFF
--- a/apps/blog/src/__tests__/articles/article-layout.test.tsx
+++ b/apps/blog/src/__tests__/articles/article-layout.test.tsx
@@ -2,13 +2,28 @@ import { afterEach, describe, expect, it, mock } from "bun:test";
 import { cleanup, render } from "@testing-library/react";
 import type { ReactNode } from "react";
 
+import {
+  BacklinksDisclosureView,
+  formatBacklinkLabel,
+} from "@/app/(blog)/articles/[slug]/backlinks-disclosure";
 import { ArticleNavProvider } from "@/components/article-nav-context";
 import { TweaksProvider } from "@/components/tweaks/tweaks-provider";
+
+// Value copy of the real backlinks-disclosure exports, taken before the stub
+// below replaces the module. mock.module is process-wide, so the stub leaks
+// into other suites; preserving BacklinksDisclosureView and formatBacklinkLabel
+// (the latter used by the real ArticleRail) keeps them intact for those suites,
+// while only the async <BacklinksDisclosure> wrapper is neutralised here.
+const realBacklinksDisclosure = {
+  BacklinksDisclosureView,
+  formatBacklinkLabel,
+};
 
 // `<BacklinksDisclosure>` and `<ArticleRail>` are async server components;
 // happy-dom + RTL's sync render tree can't await them. Both have their own
 // dedicated tests — neutralise them here so layout-only assertions can run.
 mock.module("@/app/(blog)/articles/[slug]/backlinks-disclosure", () => ({
+  ...realBacklinksDisclosure,
   BacklinksDisclosure: () => null,
 }));
 mock.module("@/app/(blog)/articles/[slug]/article-rail", () => ({

--- a/apps/blog/src/__tests__/articles/article-rail.test.tsx
+++ b/apps/blog/src/__tests__/articles/article-rail.test.tsx
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "bun:test";
 
-import { ArticleRail } from "@/app/(blog)/articles/[slug]/article-rail";
 import type { ArticleHeading } from "@/app/(blog)/articles/service";
+// Imported via the preload-linked support module rather than the module under
+// test directly: article-layout.test stubs "@/app/(blog)/articles/[slug]/
+// article-rail" with a process-wide mock, so importing it here would yield that
+// stub depending on file order. The support module holds the real binding (#780).
+import { ArticleRail } from "@/test-support/real-article-modules";
 
 // A slug absent from the article graph: getArticleConnections resolves to
 // empty arrays, so `headings` is the rail's only content source.

--- a/apps/blog/src/__tests__/components/internal-link.test.tsx
+++ b/apps/blog/src/__tests__/components/internal-link.test.tsx
@@ -5,6 +5,7 @@ import {
   InternalLink,
   InternalLinkPreviewBody,
 } from "@/components/internal-link";
+import { createNextNavigationMock } from "@/test-support/next-navigation-mock";
 
 afterEach(() => {
   cleanup();
@@ -44,9 +45,9 @@ describe("InternalLink — fallback paths", () => {
   });
 
   it("renders a plain anchor when the href matches the current page", async () => {
-    mock.module("next/navigation", () => ({
-      usePathname: () => "/articles/claude-code",
-    }));
+    mock.module("next/navigation", () =>
+      createNextNavigationMock({ usePathname: () => "/articles/claude-code" })
+    );
 
     // Re-import after the mock takes effect so the component picks it up.
     const { InternalLink: ScopedInternalLink } = await import(
@@ -67,9 +68,9 @@ describe("InternalLink — fallback paths", () => {
     expect(anchors[0].hasAttribute("aria-describedby")).toBe(false);
 
     // Restore the default mock for subsequent tests.
-    mock.module("next/navigation", () => ({
-      usePathname: () => "/",
-    }));
+    mock.module("next/navigation", () =>
+      createNextNavigationMock({ usePathname: () => "/" })
+    );
   });
 });
 

--- a/apps/blog/src/__tests__/search/search-palette.test.tsx
+++ b/apps/blog/src/__tests__/search/search-palette.test.tsx
@@ -6,17 +6,20 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
+import { createNextNavigationMock } from "@/test-support/next-navigation-mock";
 
 const pushed: string[] = [];
 
-mock.module("next/navigation", () => ({
-  useRouter: () => ({
-    push: (href: string) => pushed.push(href),
-    replace: () => undefined,
-    back: () => undefined,
-    prefetch: () => undefined,
-  }),
-}));
+mock.module("next/navigation", () =>
+  createNextNavigationMock({
+    useRouter: () => ({
+      push: (href: string) => pushed.push(href),
+      replace: () => undefined,
+      back: () => undefined,
+      prefetch: () => undefined,
+    }),
+  })
+);
 
 mock.module("@/data/search-index.json", () => ({
   default: {

--- a/apps/blog/src/__tests__/shelf/reading-store.test.ts
+++ b/apps/blog/src/__tests__/shelf/reading-store.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
+
+import { getHistory, perSlugKey, recordProgress } from "@/lib/reading-store";
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+const HISTORY_KEY = "howardism:reading-history";
+const CAP = 50;
+
+describe("reading-store", () => {
+  it("records a read once it crosses the 25% threshold", () => {
+    recordProgress("alpha", 0.3);
+    const history = getHistory();
+    expect(history).toHaveLength(1);
+    expect(history[0]?.slug).toBe("alpha");
+    expect(history[0]?.pct).toBe(0.3);
+  });
+
+  it("ignores scrolls below the 25% threshold", () => {
+    recordProgress("barely", 0.1);
+    expect(getHistory()).toHaveLength(0);
+  });
+
+  it("moves a re-read slug to the front and refreshes its progress", () => {
+    recordProgress("alpha", 0.3);
+    recordProgress("beta", 0.4);
+    recordProgress("alpha", 0.9);
+    const history = getHistory();
+    expect(history.map((entry) => entry.slug)).toEqual(["alpha", "beta"]);
+    expect(history[0]?.pct).toBe(0.9);
+  });
+
+  it("caps history at 50, evicting the oldest read and its resume state", () => {
+    for (let i = 0; i <= CAP; i += 1) {
+      localStorage.setItem(
+        perSlugKey(`slug-${i}`),
+        JSON.stringify({ headingId: "h", pct: 0.5 })
+      );
+      recordProgress(`slug-${i}`, 0.5);
+    }
+
+    const history = getHistory();
+    expect(history).toHaveLength(CAP);
+    // slug-0 was the oldest read — evicted past the cap...
+    expect(history.some((entry) => entry.slug === "slug-0")).toBe(false);
+    // ...and its per-slug resume state is dropped with it.
+    expect(localStorage.getItem(perSlugKey("slug-0"))).toBeNull();
+    // The newest read survives, resume state intact.
+    expect(history[0]?.slug).toBe(`slug-${CAP}`);
+    expect(localStorage.getItem(perSlugKey(`slug-${CAP}`))).not.toBeNull();
+  });
+
+  it("returns an empty history when storage is empty or corrupt", () => {
+    expect(getHistory()).toEqual([]);
+    localStorage.setItem(HISTORY_KEY, "{not-json");
+    expect(getHistory()).toEqual([]);
+  });
+
+  it("swallows storage write errors instead of throwing (private browsing)", () => {
+    const spy = spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("quota exceeded");
+    });
+    expect(() => recordProgress("gamma", 0.6)).not.toThrow();
+    spy.mockRestore();
+  });
+});

--- a/apps/blog/src/__tests__/shelf/shelf-list.test.tsx
+++ b/apps/blog/src/__tests__/shelf/shelf-list.test.tsx
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+
+import { ShelfList } from "@/app/(blog)/shelf/shelf-list";
+import type { ShelfManifestEntry } from "@/lib/shelf-rows";
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
+
+const manifest: ShelfManifestEntry[] = [
+  {
+    slug: "alpha",
+    title: "Alpha Article",
+    label: "AI Engineering",
+    href: "/articles/alpha",
+  },
+];
+
+const ROW_TITLE = /Alpha Article/i;
+const EMPTY_STATE = /nothing on your shelf yet/i;
+
+describe("ShelfList", () => {
+  it("renders a history row linking to the top of the article", async () => {
+    localStorage.setItem(
+      "howardism:reading-history",
+      JSON.stringify([{ slug: "alpha", pct: 0.6, lastReadAt: Date.now() }])
+    );
+
+    render(<ShelfList manifest={manifest} />);
+
+    const link = await waitFor(() =>
+      screen.getByRole("link", { name: ROW_TITLE })
+    );
+    expect(link.getAttribute("href")).toBe("/articles/alpha");
+  });
+
+  it("shows the empty state when there is no reading history", async () => {
+    render(<ShelfList manifest={manifest} />);
+
+    await waitFor(() => expect(screen.getByText(EMPTY_STATE)).not.toBeNull());
+  });
+});

--- a/apps/blog/src/__tests__/shelf/shelf-rows.test.ts
+++ b/apps/blog/src/__tests__/shelf/shelf-rows.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "bun:test";
+
+import type { ReadingEntry } from "@/lib/reading-store";
+import { buildShelfRows, type ShelfManifestEntry } from "@/lib/shelf-rows";
+
+const manifest: ShelfManifestEntry[] = [
+  {
+    slug: "alpha",
+    title: "Alpha",
+    label: "AI Engineering",
+    href: "/articles/alpha",
+  },
+  { slug: "beta", title: "Beta", label: "Essay", href: "/articles/beta" },
+];
+
+describe("buildShelfRows", () => {
+  it("resolves history into rows, preserving newest-first order", () => {
+    const history: ReadingEntry[] = [
+      { slug: "beta", pct: 0.4, lastReadAt: 200 },
+      { slug: "alpha", pct: 0.9, lastReadAt: 100 },
+    ];
+
+    const rows = buildShelfRows(history, manifest);
+
+    expect(rows.map((row) => row.slug)).toEqual(["beta", "alpha"]);
+    expect(rows[0]).toMatchObject({
+      title: "Beta",
+      label: "Essay",
+      href: "/articles/beta",
+      pct: 0.4,
+      lastReadAt: 200,
+    });
+  });
+
+  it("drops history entries with no matching manifest article", () => {
+    const history: ReadingEntry[] = [
+      { slug: "ghost", pct: 0.5, lastReadAt: 300 },
+      { slug: "alpha", pct: 0.3, lastReadAt: 100 },
+    ];
+
+    const rows = buildShelfRows(history, manifest);
+
+    expect(rows.map((row) => row.slug)).toEqual(["alpha"]);
+  });
+
+  it("returns an empty array for empty history", () => {
+    expect(buildShelfRows([], manifest)).toEqual([]);
+  });
+});

--- a/apps/blog/src/app/(blog)/(layout)/constants.ts
+++ b/apps/blog/src/app/(blog)/(layout)/constants.ts
@@ -2,6 +2,7 @@ export const NavSection = {
   Home: "/",
   Articles: "/articles",
   Questions: "/questions",
+  Shelf: "/shelf",
 } as const;
 export type NavSection = (typeof NavSection)[keyof typeof NavSection];
 
@@ -13,5 +14,6 @@ export const FOOTER_NAV: { label: string; href: string }[] = [
   { label: "Home", href: "/" },
   { label: "Articles", href: "/articles" },
   { label: "Questions", href: "/questions" },
+  { label: "Shelf", href: "/shelf" },
   { label: "RSS", href: "/rss/feed.xml" },
 ];

--- a/apps/blog/src/app/(blog)/articles/[slug]/resume-reading.tsx
+++ b/apps/blog/src/app/(blog)/articles/[slug]/resume-reading.tsx
@@ -2,12 +2,11 @@
 
 import throttle from "lodash.throttle";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-
 import useScrollSpy from "@/hooks/use-scroll-spy";
+import { perSlugKey, recordProgress } from "@/lib/reading-store";
 
 import type { ArticleHeading } from "../service";
 
-const STORAGE_PREFIX = "howardism:reading:";
 const MIN_PCT = 0.25; // below this, "resume" isn't worth offering
 const MAX_PCT = 0.9; // above this, the reader has effectively finished
 const AUTO_DISMISS_MS = 6000;
@@ -19,7 +18,7 @@ interface SavedProgress {
 
 function readSaved(slug: string): SavedProgress | null {
   try {
-    const raw = localStorage.getItem(STORAGE_PREFIX + slug);
+    const raw = localStorage.getItem(perSlugKey(slug));
     if (!raw) {
       return null;
     }
@@ -83,14 +82,16 @@ export function ResumeReading({ headings, slug }: ResumeReadingProps) {
       if (scrollable <= 0 || window.scrollY <= 0) {
         return;
       }
+      const pct = Math.min(1, Math.max(0, window.scrollY / scrollable));
+      // Remember this read on the Shelf once it crosses the resume threshold.
+      recordProgress(slug, pct);
       const headingId = activeIdRef.current;
       if (!headingId) {
         return;
       }
-      const pct = Math.min(1, Math.max(0, window.scrollY / scrollable));
       try {
         localStorage.setItem(
-          STORAGE_PREFIX + slug,
+          perSlugKey(slug),
           JSON.stringify({ headingId, pct })
         );
       } catch {

--- a/apps/blog/src/app/(blog)/shelf/page.tsx
+++ b/apps/blog/src/app/(blog)/shelf/page.tsx
@@ -1,0 +1,61 @@
+import type { Metadata } from "next";
+
+import { env } from "@/config/env";
+import type { ShelfManifestEntry } from "@/lib/shelf-rows";
+
+import { DOMAIN_META } from "../articles/domain-meta";
+import { getArticles } from "../articles/service";
+import { ShelfList } from "./shelf-list";
+
+const SHELF_URL = `${env.NEXT_PUBLIC_DOMAIN_NAME}/shelf`;
+
+export const dynamic = "error";
+
+export const metadata: Metadata = {
+  title: "Shelf — Howardism",
+  description:
+    "Your reading history: the articles you've read, newest first, kept locally in your browser.",
+  alternates: { canonical: SHELF_URL },
+  openGraph: { url: SHELF_URL },
+  // Personal, browser-local view — empty for everyone server-side, so keep it
+  // out of the search index.
+  robots: { index: false, follow: true },
+};
+
+export default async function ShelfPage() {
+  const { ids, entities } = await getArticles();
+
+  const manifest: ShelfManifestEntry[] = [];
+  for (const id of ids) {
+    const entity = entities[id];
+    if (!entity) {
+      continue;
+    }
+    const { meta } = entity;
+    manifest.push({
+      slug: id,
+      title: meta.title,
+      label: meta.domain ? DOMAIN_META[meta.domain].label : meta.tag,
+      href: `/articles/${id}`,
+    });
+  }
+
+  return (
+    <div className="hw-page-enter mx-auto max-w-read px-4 pb-20">
+      <header className="border-border border-b border-dashed pt-8 pb-6">
+        <span className="font-mono text-[10.5px] text-foreground-subtle uppercase tracking-[0.22em]">
+          Howardism · Vol. 03
+        </span>
+        <h1 className="mt-3 font-display font-normal text-[27px] text-foreground leading-[1.2] tracking-[-0.015em]">
+          Your shelf, <span className="text-brand">read &amp; remembered.</span>
+        </h1>
+        <p className="mt-4 max-w-[560px] font-body text-[15px] text-muted-foreground leading-[1.6]">
+          Articles you&apos;ve meaningfully read, newest first. This list lives
+          only in your browser — nothing is sent anywhere.
+        </p>
+      </header>
+
+      <ShelfList manifest={manifest} />
+    </div>
+  );
+}

--- a/apps/blog/src/app/(blog)/shelf/shelf-list.tsx
+++ b/apps/blog/src/app/(blog)/shelf/shelf-list.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import dayjs from "dayjs";
+import relativeTime from "dayjs/plugin/relativeTime";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import { getHistory } from "@/lib/reading-store";
+import {
+  buildShelfRows,
+  type ShelfManifestEntry,
+  type ShelfRow,
+} from "@/lib/shelf-rows";
+
+dayjs.extend(relativeTime);
+
+const META_CLASS =
+  "font-mono text-[10.5px] text-foreground-subtle uppercase tracking-[0.16em]";
+
+function HistoryRow({ row }: { row: ShelfRow }) {
+  const pct = Math.round(row.pct * 100);
+
+  return (
+    <li className="border-border border-b border-dashed last:border-b-0">
+      <Link
+        className="group flex items-center gap-4 py-4 no-underline"
+        href={row.href}
+      >
+        <div className="min-w-0 flex-1">
+          <span className="block font-display text-[16px] text-foreground leading-[1.3] transition-colors group-hover:text-brand">
+            {row.title}
+          </span>
+          <span className={`mt-1 block ${META_CLASS}`}>
+            {row.label} · {dayjs(row.lastReadAt).fromNow()}
+          </span>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <span
+            aria-hidden="true"
+            className="h-1 w-16 overflow-hidden rounded-full bg-border"
+          >
+            <span
+              className="block h-full rounded-full bg-brand/70"
+              style={{ width: `${pct}%` }}
+            />
+          </span>
+          <span className={`w-9 text-right ${META_CLASS}`}>{pct}%</span>
+        </div>
+      </Link>
+    </li>
+  );
+}
+
+/**
+ * Reads the browser-local reading history on mount and resolves it against the
+ * build-time article manifest. Renders nothing until the client read completes
+ * (avoids an empty-state flash during hydration), then either the history rows
+ * or a friendly empty state.
+ */
+export function ShelfList({ manifest }: { manifest: ShelfManifestEntry[] }) {
+  const [rows, setRows] = useState<ShelfRow[] | null>(null);
+
+  useEffect(() => {
+    setRows(buildShelfRows(getHistory(), manifest));
+  }, [manifest]);
+
+  if (rows === null) {
+    return null;
+  }
+
+  if (rows.length === 0) {
+    return (
+      <p className="mt-8 font-body text-[15px] text-muted-foreground leading-[1.6]">
+        Nothing on your shelf yet. Read past the opening of any article and it
+        lands here automatically — saved only in this browser.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="mt-6 flex list-none flex-col p-0">
+      {rows.map((row) => (
+        <HistoryRow key={row.slug} row={row} />
+      ))}
+    </ul>
+  );
+}

--- a/apps/blog/src/lib/reading-store.ts
+++ b/apps/blog/src/lib/reading-store.ts
@@ -1,0 +1,89 @@
+/**
+ * Browser-local reading history for the Shelf. Owns the `howardism:reading*`
+ * localStorage namespace: the most-recent-first history index plus the
+ * per-slug resume state written by the article reader. A pure client module
+ * (no React) so later Shelf slices can reuse it without re-implementing the
+ * storage contract. None of this is a build manifest — it never enters
+ * `@howardism/article-contract`.
+ */
+
+/** Per-slug resume-progress key prefix (shared with the resume chip). */
+const PER_SLUG_PREFIX = "howardism:reading:";
+/** History index key. Distinct from the per-slug prefix (no trailing colon). */
+const HISTORY_KEY = "howardism:reading-history";
+/** Below this scroll fraction a read isn't worth remembering. */
+const MIN_RECORD_PCT = 0.25;
+/** Most-recent reads to keep; older reads are evicted LRU-style. */
+const MAX_HISTORY = 50;
+
+export interface ReadingEntry {
+  /** Epoch ms of the most recent read, for the relative "last read" time. */
+  lastReadAt: number;
+  /** Latest scroll fraction (0–1), for the row's progress indicator. */
+  pct: number;
+  /** Article slug; the join key against the article manifest. */
+  slug: string;
+}
+
+/** localStorage key holding the resume state for a single article. */
+export const perSlugKey = (slug: string): string => PER_SLUG_PREFIX + slug;
+
+function isReadingEntry(value: unknown): value is ReadingEntry {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const entry = value as Record<string, unknown>;
+  return (
+    typeof entry.slug === "string" &&
+    typeof entry.pct === "number" &&
+    typeof entry.lastReadAt === "number"
+  );
+}
+
+/**
+ * Reading history, most-recent-first. Returns `[]` when storage is
+ * unavailable (private browsing) or the stored value is missing/corrupt.
+ */
+export function getHistory(): ReadingEntry[] {
+  try {
+    const raw = localStorage.getItem(HISTORY_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed.filter(isReadingEntry);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Record (or refresh) a read once it crosses the meaningful-read threshold:
+ * moves the slug to the front, updates its last-read time and progress, and
+ * caps the list at the 50 most recent — evicting older entries and dropping
+ * their per-slug resume state along with them. Below-threshold scrolls and any
+ * storage error are silently ignored, so a reader in private browsing sees no
+ * failure.
+ */
+export function recordProgress(slug: string, pct: number): void {
+  if (pct < MIN_RECORD_PCT) {
+    return;
+  }
+  try {
+    const withoutSlug = getHistory().filter((entry) => entry.slug !== slug);
+    const next: ReadingEntry[] = [
+      { slug, pct, lastReadAt: Date.now() },
+      ...withoutSlug,
+    ];
+    const kept = next.slice(0, MAX_HISTORY);
+    for (const evicted of next.slice(MAX_HISTORY)) {
+      localStorage.removeItem(perSlugKey(evicted.slug));
+    }
+    localStorage.setItem(HISTORY_KEY, JSON.stringify(kept));
+  } catch {
+    // ignore storage errors (quota / private mode)
+  }
+}

--- a/apps/blog/src/lib/shelf-rows.ts
+++ b/apps/blog/src/lib/shelf-rows.ts
@@ -1,0 +1,38 @@
+import type { ReadingEntry } from "./reading-store";
+
+/** Resolved article metadata the Shelf needs to render a history row. */
+export interface ShelfManifestEntry {
+  /** Link to the top of the article. */
+  href: string;
+  /** Domain display name, or the article kind when it has no domain. */
+  label: string;
+  slug: string;
+  title: string;
+}
+
+/** A history entry resolved against the manifest into a renderable row. */
+export interface ShelfRow extends ShelfManifestEntry {
+  lastReadAt: number;
+  pct: number;
+}
+
+/**
+ * Join reading history against the article manifest, preserving the history's
+ * most-recent-first order. Entries whose slug is absent from the manifest (an
+ * article that no longer exists) drop out silently — a later slice turns those
+ * into tombstones; here they simply don't render.
+ */
+export function buildShelfRows(
+  history: readonly ReadingEntry[],
+  manifest: readonly ShelfManifestEntry[]
+): ShelfRow[] {
+  const bySlug = new Map(manifest.map((entry) => [entry.slug, entry]));
+  const rows: ShelfRow[] = [];
+  for (const entry of history) {
+    const meta = bySlug.get(entry.slug);
+    if (meta) {
+      rows.push({ ...meta, pct: entry.pct, lastReadAt: entry.lastReadAt });
+    }
+  }
+  return rows;
+}

--- a/apps/blog/src/test-support/next-navigation-mock.ts
+++ b/apps/blog/src/test-support/next-navigation-mock.ts
@@ -1,0 +1,53 @@
+interface NextNavigationMock {
+  notFound: () => never;
+  permanentRedirect: () => never;
+  redirect: () => never;
+  useParams: () => Record<string, string>;
+  usePathname: () => string;
+  useRouter: () => {
+    push: (href: string) => void;
+    replace: () => void;
+    back: () => void;
+    prefetch: () => void;
+  };
+  useSearchParams: () => URLSearchParams;
+}
+
+// Canonical next/navigation mock with the full named-export set. Every
+// `mock.module("next/navigation", ...)` call — the preload and any test that
+// needs custom behaviour — must go through this so the module's export shape
+// stays complete. Bun locks the named-export set to whichever mock factory was
+// analysed when a consumer is linked; a factory that omits, say, `usePathname`
+// makes later `import { usePathname }` fail with "Export named ... not found".
+// Passing overrides keeps the full shape while swapping individual hooks.
+export function createNextNavigationMock(
+  overrides: Partial<NextNavigationMock> = {}
+): NextNavigationMock {
+  return {
+    useRouter: () => ({
+      push: () => undefined,
+      replace: () => undefined,
+      back: () => undefined,
+      prefetch: () => undefined,
+    }),
+    usePathname: () => "/",
+    useSearchParams: () => new URLSearchParams(),
+    useParams: () => ({}),
+    notFound: () => {
+      throw Object.assign(new Error("NEXT_NOT_FOUND"), {
+        digest: "NEXT_NOT_FOUND",
+      });
+    },
+    redirect: () => {
+      throw Object.assign(new Error("NEXT_REDIRECT"), {
+        digest: "NEXT_REDIRECT",
+      });
+    },
+    permanentRedirect: () => {
+      throw Object.assign(new Error("NEXT_REDIRECT"), {
+        digest: "NEXT_REDIRECT",
+      });
+    },
+    ...overrides,
+  };
+}

--- a/apps/blog/src/test-support/real-article-modules.ts
+++ b/apps/blog/src/test-support/real-article-modules.ts
@@ -1,0 +1,10 @@
+import { ArticleRail as RealArticleRail } from "@/app/(blog)/articles/[slug]/article-rail";
+
+// Value copy of the genuine ArticleRail, captured the moment this module is
+// evaluated. The test preload imports this file, so the capture happens before
+// article-layout.test registers its process-wide `mock.module(..., () => null)`
+// stub. Re-exporting with `export { ArticleRail } from ...` would NOT work: that
+// is an indirect binding that follows mock.module's later registry swap to the
+// stub. Binding the value to a const freezes the real implementation so the
+// dedicated article-rail suite gets it regardless of test-file order (see #780).
+export const ArticleRail = RealArticleRail;

--- a/apps/blog/test-preload.ts
+++ b/apps/blog/test-preload.ts
@@ -1,4 +1,5 @@
 import { mock } from "bun:test";
+import { createNextNavigationMock } from "./src/test-support/next-navigation-mock";
 
 // Mock next/navigation with all hooks before any test file registers a subset mock.
 // Without this, Bun's ESM/CJS interop analysis runs on whichever test file's mock
@@ -7,29 +8,4 @@ import { mock } from "bun:test";
 // "Export named 'useRouter' not found" even though its own mock.module provides it.
 // Preloading with the full export set ensures Bun's analysis cache is populated
 // correctly before parallel test files start overriding with narrower subsets.
-mock.module("next/navigation", () => ({
-  useRouter: () => ({
-    push: () => undefined,
-    replace: () => undefined,
-    back: () => undefined,
-    prefetch: () => undefined,
-  }),
-  usePathname: () => "/",
-  useSearchParams: () => new URLSearchParams(),
-  useParams: () => ({}),
-  notFound: (): never => {
-    throw Object.assign(new Error("NEXT_NOT_FOUND"), {
-      digest: "NEXT_NOT_FOUND",
-    });
-  },
-  redirect: (): never => {
-    throw Object.assign(new Error("NEXT_REDIRECT"), {
-      digest: "NEXT_REDIRECT",
-    });
-  },
-  permanentRedirect: (): never => {
-    throw Object.assign(new Error("NEXT_REDIRECT"), {
-      digest: "NEXT_REDIRECT",
-    });
-  },
-}));
+mock.module("next/navigation", () => createNextNavigationMock());

--- a/apps/blog/test-preload.ts
+++ b/apps/blog/test-preload.ts
@@ -1,5 +1,9 @@
 import { mock } from "bun:test";
 import { createNextNavigationMock } from "./src/test-support/next-navigation-mock";
+// Link the genuine async server-component modules now, before article-layout.test
+// stubs them with mock.module, so article-rail / backlinks-disclosure suites can
+// import the real implementations regardless of test-file order (see #780).
+import "./src/test-support/real-article-modules";
 
 // Mock next/navigation with all hooks before any test file registers a subset mock.
 // Without this, Bun's ESM/CJS interop analysis runs on whichever test file's mock


### PR DESCRIPTION
Closes #846. First slice of the reading-shelf chain (parent #845).

## What

The tracer bullet for the **Shelf**: articles you meaningfully read are remembered automatically and listed at a page you can reach and reopen.

- **Capture** — while reading, once scroll crosses the existing **25% resume threshold**, the article is recorded into a browser-local reading history (most-recent-first) and its last-read time stays current as you keep scrolling. This reuses the resume reader's existing scroll listener and per-slug storage key — no second listener, and the resume chip's behavior is unchanged.
- **`/shelf` page** — lists the reading history newest-first as compact rows: title, domain (or article kind), a progress bar + percentage, and a relative "last read" time. Each row links to the **top** of the article; the existing resume chip still offers to jump to where you left off.
- **50-cap LRU** — history is capped at the 50 most recent reads; exceeding it evicts the oldest entry **and** deletes that article's per-slug resume state along with it.
- **Empty + resilient** — a friendly empty state before anything is read; all reads/writes swallow storage errors so private browsing / quota never throws.
- **Navigation** — "Shelf" added to both the header (desktop + mobile) and footer nav.

New surfaces: `/shelf` route (`page.tsx` + client `shelf-list.tsx`), the `reading-store` client module and the pure `shelf-rows` builder under `src/lib/`, and a one-line capture hook inside the existing `resume-reading` reader.

## Decisions

- **This PR is STACKED on the base of the chain (base `main`).** It is the first slice, so there is no predecessor PR — merge order: this merges first; #848/#849 (which branch from here) follow. GitHub will auto-retarget the downstream PRs when this merges.
- **Storage ownership.** `reading-store` now owns the entire `howardism:reading*` localStorage namespace — the new `howardism:reading-history` index plus the existing per-slug `howardism:reading:<slug>` resume keys (via the exported `perSlugKey` helper). Centralizing the key is what lets eviction correctly drop a forgotten article's resume state. This is browser-local only and is intentionally **not** added to `@howardism/article-contract`.
- **Capture lives in `resume-reading`.** Rather than add a second scroll listener, history capture streams from the reader's existing throttled scroll handler, which already computes exactly the resume percentage the 25% threshold is defined against. The 0.25 gate now lives in `reading-store` (`recordProgress`) so the store enforces the policy.
- **Progress value = latest scroll fraction** (matching resume semantics), not max-ever — simplest and consistent with the resume chip.
- **Resolve against all articles** (`getArticles`), so a read that later gets archived still resolves to a row; history entries with no matching slug drop out silently. The archived/deleted **tombstone** treatment is explicitly deferred to #848.
- **`/shelf` is `noindex`** (but `follow`): it renders empty for everyone server-side (the data is browser-local), so there's nothing worth indexing. Static-generated via `dynamic = "error"`, same as `/questions`.
- **Anticipated shared-file conflicts with sibling slices** (note for merge ordering, not pre-resolved here):
  - `src/lib/reading-store.ts` — #848 (curation: `remove`/tombstones) and #850 (clear-all) will extend this module.
  - `src/app/(blog)/shelf/shelf-list.tsx` — #848 adds remove controls + tombstone rendering; #849 adds the Saved tab.
  - `src/app/(blog)/(layout)/constants.ts` — only touched here for the Shelf nav entry; unlikely to reconflict.

## Verification

Gates run this session, all green:
- `bun run lint` (ultracite/biome) — pass
- `bun run type-check` (tsc across all packages) — pass
- `bun run test` — pass (127 tests; **11 new**: `reading-store` capture + below-threshold + re-read-to-front + 50-cap/evict + corrupt-storage + error-swallow; `shelf-rows` resolve/order + drop-unknown + empty; `ShelfList` row-with-href + empty-state)
- `bun run build` — pass; `/shelf` prerenders as static content (`○`). Run even though the slice table lists it optional for #846, since this adds a route and pre-push does not run build.

**Not verified this session:** no browser / visual check, no manual click-through of the live page, no real-device scroll-capture test (capture is covered by the store's unit tests, not an end-to-end scroll), no cross-browser or private-browsing runtime check, no performance/lighthouse pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
