### PR TITLE
✨ feat(blog): history curation — remove + archived/deleted tombstones (#848)

### DIFF
--- a/apps/blog/src/__tests__/shelf/reading-store.test.ts
+++ b/apps/blog/src/__tests__/shelf/reading-store.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it, spyOn } from "bun:test";
 
-import { getHistory, perSlugKey, recordProgress } from "@/lib/reading-store";
+import {
+  getHistory,
+  perSlugKey,
+  recordProgress,
+  removeFromHistory,
+} from "@/lib/reading-store";
 
 afterEach(() => {
   localStorage.clear();
@@ -56,6 +61,20 @@ describe("reading-store", () => {
     expect(getHistory()).toEqual([]);
     localStorage.setItem(HISTORY_KEY, "{not-json");
     expect(getHistory()).toEqual([]);
+  });
+
+  it("removes one read and drops its per-slug resume state, leaving the rest", () => {
+    localStorage.setItem(
+      perSlugKey("beta"),
+      JSON.stringify({ headingId: "h", pct: 0.5 })
+    );
+    recordProgress("alpha", 0.3);
+    recordProgress("beta", 0.4);
+
+    removeFromHistory("beta");
+
+    expect(getHistory().map((entry) => entry.slug)).toEqual(["alpha"]);
+    expect(localStorage.getItem(perSlugKey("beta"))).toBeNull();
   });
 
   it("swallows storage write errors instead of throwing (private browsing)", () => {

--- a/apps/blog/src/__tests__/shelf/shelf-list.test.tsx
+++ b/apps/blog/src/__tests__/shelf/shelf-list.test.tsx
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 
 import { ShelfList } from "@/app/(blog)/shelf/shelf-list";
 import type { ShelfManifestEntry } from "@/lib/shelf-rows";
@@ -15,19 +21,38 @@ const manifest: ShelfManifestEntry[] = [
     title: "Alpha Article",
     label: "AI Engineering",
     href: "/articles/alpha",
+    archived: false,
+  },
+  {
+    slug: "gamma",
+    title: "Gamma Article",
+    label: "Entities",
+    href: "/articles/gamma",
+    archived: true,
   },
 ];
 
+const HISTORY_KEY = "howardism:reading-history";
 const ROW_TITLE = /Alpha Article/i;
+const ARCHIVED_TITLE = /Gamma Article/i;
 const EMPTY_STATE = /nothing on your shelf yet/i;
+const ARCHIVED_TAG = /archived/i;
+const TOMBSTONE = /no longer available/i;
+const REMOVE_ALPHA = /remove alpha article from shelf/i;
+const DISMISS_GHOST = /dismiss ghost-slug/i;
+
+function seedHistory(entries: { slug: string; pct: number }[]): void {
+  localStorage.setItem(
+    HISTORY_KEY,
+    JSON.stringify(
+      entries.map((entry) => ({ ...entry, lastReadAt: Date.now() }))
+    )
+  );
+}
 
 describe("ShelfList", () => {
   it("renders a history row linking to the top of the article", async () => {
-    localStorage.setItem(
-      "howardism:reading-history",
-      JSON.stringify([{ slug: "alpha", pct: 0.6, lastReadAt: Date.now() }])
-    );
-
+    seedHistory([{ slug: "alpha", pct: 0.6 }]);
     render(<ShelfList manifest={manifest} />);
 
     const link = await waitFor(() =>
@@ -40,5 +65,40 @@ describe("ShelfList", () => {
     render(<ShelfList manifest={manifest} />);
 
     await waitFor(() => expect(screen.getByText(EMPTY_STATE)).not.toBeNull());
+  });
+
+  it("removes a row when its remove control is clicked", async () => {
+    seedHistory([{ slug: "alpha", pct: 0.6 }]);
+    render(<ShelfList manifest={manifest} />);
+
+    const remove = await waitFor(() =>
+      screen.getByRole("button", { name: REMOVE_ALPHA })
+    );
+    fireEvent.click(remove);
+
+    await waitFor(() => expect(screen.queryByText(ROW_TITLE)).toBeNull());
+    expect(JSON.parse(localStorage.getItem(HISTORY_KEY) ?? "[]")).toEqual([]);
+  });
+
+  it("tags an archived read and still links it", async () => {
+    seedHistory([{ slug: "gamma", pct: 0.5 }]);
+    render(<ShelfList manifest={manifest} />);
+
+    await waitFor(() => expect(screen.getByText(ARCHIVED_TAG)).not.toBeNull());
+    expect(
+      screen.getByRole("link", { name: ARCHIVED_TITLE }).getAttribute("href")
+    ).toBe("/articles/gamma");
+  });
+
+  it("renders a dismissible tombstone for a slug that no longer resolves", async () => {
+    seedHistory([{ slug: "ghost-slug", pct: 0.7 }]);
+    render(<ShelfList manifest={manifest} />);
+
+    await waitFor(() => expect(screen.getByText(TOMBSTONE)).not.toBeNull());
+    // Not a link — there's no article to open.
+    expect(screen.queryByRole("link")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: DISMISS_GHOST }));
+    await waitFor(() => expect(screen.queryByText(TOMBSTONE)).toBeNull());
   });
 });

--- a/apps/blog/src/__tests__/shelf/shelf-rows.test.ts
+++ b/apps/blog/src/__tests__/shelf/shelf-rows.test.ts
@@ -9,12 +9,26 @@ const manifest: ShelfManifestEntry[] = [
     title: "Alpha",
     label: "AI Engineering",
     href: "/articles/alpha",
+    archived: false,
   },
-  { slug: "beta", title: "Beta", label: "Essay", href: "/articles/beta" },
+  {
+    slug: "beta",
+    title: "Beta",
+    label: "Essay",
+    href: "/articles/beta",
+    archived: false,
+  },
+  {
+    slug: "gamma",
+    title: "Gamma",
+    label: "Entities",
+    href: "/articles/gamma",
+    archived: true,
+  },
 ];
 
 describe("buildShelfRows", () => {
-  it("resolves history into rows, preserving newest-first order", () => {
+  it("resolves visible articles into rows, preserving newest-first order", () => {
     const history: ReadingEntry[] = [
       { slug: "beta", pct: 0.4, lastReadAt: 200 },
       { slug: "alpha", pct: 0.9, lastReadAt: 100 },
@@ -24,6 +38,7 @@ describe("buildShelfRows", () => {
 
     expect(rows.map((row) => row.slug)).toEqual(["beta", "alpha"]);
     expect(rows[0]).toMatchObject({
+      kind: "resolved",
       title: "Beta",
       label: "Essay",
       href: "/articles/beta",
@@ -32,7 +47,20 @@ describe("buildShelfRows", () => {
     });
   });
 
-  it("drops history entries with no matching manifest article", () => {
+  it("classifies an archived article as archived, still carrying its link", () => {
+    const rows = buildShelfRows(
+      [{ slug: "gamma", pct: 0.5, lastReadAt: 300 }],
+      manifest
+    );
+
+    expect(rows[0]).toMatchObject({
+      kind: "archived",
+      title: "Gamma",
+      href: "/articles/gamma",
+    });
+  });
+
+  it("classifies an unresolved slug as a deleted tombstone, not dropped", () => {
     const history: ReadingEntry[] = [
       { slug: "ghost", pct: 0.5, lastReadAt: 300 },
       { slug: "alpha", pct: 0.3, lastReadAt: 100 },
@@ -40,7 +68,10 @@ describe("buildShelfRows", () => {
 
     const rows = buildShelfRows(history, manifest);
 
-    expect(rows.map((row) => row.slug)).toEqual(["alpha"]);
+    expect(rows.map((row) => ({ slug: row.slug, kind: row.kind }))).toEqual([
+      { slug: "ghost", kind: "deleted" },
+      { slug: "alpha", kind: "resolved" },
+    ]);
   });
 
   it("returns an empty array for empty history", () => {

--- a/apps/blog/src/app/(blog)/shelf/page.tsx
+++ b/apps/blog/src/app/(blog)/shelf/page.tsx
@@ -37,6 +37,7 @@ export default async function ShelfPage() {
       title: meta.title,
       label: meta.domain ? DOMAIN_META[meta.domain].label : meta.tag,
       href: `/articles/${id}`,
+      archived: meta.archived === true,
     });
   }
 

--- a/apps/blog/src/app/(blog)/shelf/shelf-list.tsx
+++ b/apps/blog/src/app/(blog)/shelf/shelf-list.tsx
@@ -5,9 +5,10 @@ import relativeTime from "dayjs/plugin/relativeTime";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 
-import { getHistory } from "@/lib/reading-store";
+import { getHistory, removeFromHistory } from "@/lib/reading-store";
 import {
   buildShelfRows,
+  type LinkedShelfRow,
   type ShelfManifestEntry,
   type ShelfRow,
 } from "@/lib/shelf-rows";
@@ -16,19 +17,51 @@ dayjs.extend(relativeTime);
 
 const META_CLASS =
   "font-mono text-[10.5px] text-foreground-subtle uppercase tracking-[0.16em]";
+const REMOVE_CLASS =
+  "flex size-7 shrink-0 items-center justify-center rounded-full text-foreground-subtle transition-colors hover:bg-accent hover:text-foreground";
 
-function HistoryRow({ row }: { row: ShelfRow }) {
+function RemoveButton({
+  label,
+  onClick,
+}: {
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      aria-label={label}
+      className={REMOVE_CLASS}
+      onClick={onClick}
+      type="button"
+    >
+      <span aria-hidden="true">×</span>
+    </button>
+  );
+}
+
+function LinkedRow({
+  row,
+  onRemove,
+}: {
+  row: LinkedShelfRow;
+  onRemove: () => void;
+}) {
   const pct = Math.round(row.pct * 100);
 
   return (
-    <li className="border-border border-b border-dashed last:border-b-0">
+    <>
       <Link
-        className="group flex items-center gap-4 py-4 no-underline"
+        className="group flex min-w-0 flex-1 items-center gap-4 no-underline"
         href={row.href}
       >
         <div className="min-w-0 flex-1">
-          <span className="block font-display text-[16px] text-foreground leading-[1.3] transition-colors group-hover:text-brand">
-            {row.title}
+          <span className="flex items-center gap-2 font-display text-[16px] text-foreground leading-[1.3] transition-colors group-hover:text-brand">
+            <span className="truncate">{row.title}</span>
+            {row.kind === "archived" && (
+              <span className="shrink-0 rounded-sm border border-border px-1.5 py-0.5 font-mono text-[9px] text-foreground-subtle uppercase tracking-[0.14em]">
+                archived
+              </span>
+            )}
           </span>
           <span className={`mt-1 block ${META_CLASS}`}>
             {row.label} · {dayjs(row.lastReadAt).fromNow()}
@@ -47,6 +80,48 @@ function HistoryRow({ row }: { row: ShelfRow }) {
           <span className={`w-9 text-right ${META_CLASS}`}>{pct}%</span>
         </div>
       </Link>
+      <RemoveButton
+        label={`Remove ${row.title} from shelf`}
+        onClick={onRemove}
+      />
+    </>
+  );
+}
+
+function TombstoneRow({
+  slug,
+  onDismiss,
+}: {
+  slug: string;
+  onDismiss: () => void;
+}) {
+  return (
+    <>
+      <div className="min-w-0 flex-1">
+        <span className="flex items-center gap-2 font-display text-[16px] text-foreground-subtle italic leading-[1.3]">
+          <span className="truncate">{slug}</span>
+        </span>
+        <span className={`mt-1 block ${META_CLASS}`}>no longer available</span>
+      </div>
+      <RemoveButton label={`Dismiss ${slug}`} onClick={onDismiss} />
+    </>
+  );
+}
+
+function HistoryRow({
+  row,
+  onRemove,
+}: {
+  row: ShelfRow;
+  onRemove: (slug: string) => void;
+}) {
+  return (
+    <li className="flex items-center gap-2 border-border border-b border-dashed py-4 last:border-b-0">
+      {row.kind === "deleted" ? (
+        <TombstoneRow onDismiss={() => onRemove(row.slug)} slug={row.slug} />
+      ) : (
+        <LinkedRow onRemove={() => onRemove(row.slug)} row={row} />
+      )}
     </li>
   );
 }
@@ -55,7 +130,8 @@ function HistoryRow({ row }: { row: ShelfRow }) {
  * Reads the browser-local reading history on mount and resolves it against the
  * build-time article manifest. Renders nothing until the client read completes
  * (avoids an empty-state flash during hydration), then either the history rows
- * or a friendly empty state.
+ * — each removable, archived reads tagged, deleted reads shown as dismissible
+ * tombstones — or a friendly empty state.
  */
 export function ShelfList({ manifest }: { manifest: ShelfManifestEntry[] }) {
   const [rows, setRows] = useState<ShelfRow[] | null>(null);
@@ -77,10 +153,17 @@ export function ShelfList({ manifest }: { manifest: ShelfManifestEntry[] }) {
     );
   }
 
+  const handleRemove = (slug: string) => {
+    removeFromHistory(slug);
+    setRows((current) =>
+      current ? current.filter((row) => row.slug !== slug) : current
+    );
+  };
+
   return (
     <ul className="mt-6 flex list-none flex-col p-0">
       {rows.map((row) => (
-        <HistoryRow key={row.slug} row={row} />
+        <HistoryRow key={row.slug} onRemove={handleRemove} row={row} />
       ))}
     </ul>
   );

--- a/apps/blog/src/lib/reading-store.ts
+++ b/apps/blog/src/lib/reading-store.ts
@@ -87,3 +87,18 @@ export function recordProgress(slug: string, pct: number): void {
     // ignore storage errors (quota / private mode)
   }
 }
+
+/**
+ * Forget a single read: drop it from the history index and delete its per-slug
+ * resume state. Backs both the per-row "remove" control and the "dismiss" on a
+ * no-longer-available tombstone. Storage errors are silently ignored.
+ */
+export function removeFromHistory(slug: string): void {
+  try {
+    const next = getHistory().filter((entry) => entry.slug !== slug);
+    localStorage.setItem(HISTORY_KEY, JSON.stringify(next));
+    localStorage.removeItem(perSlugKey(slug));
+  } catch {
+    // ignore storage errors (quota / private mode)
+  }
+}

--- a/apps/blog/src/lib/shelf-rows.ts
+++ b/apps/blog/src/lib/shelf-rows.ts
@@ -1,7 +1,9 @@
 import type { ReadingEntry } from "./reading-store";
 
-/** Resolved article metadata the Shelf needs to render a history row. */
+/** Article metadata the Shelf needs to render a history row, from the manifest. */
 export interface ShelfManifestEntry {
+  /** Whether the article was archived after being read (still opens). */
+  archived: boolean;
   /** Link to the top of the article. */
   href: string;
   /** Domain display name, or the article kind when it has no domain. */
@@ -10,17 +12,41 @@ export interface ShelfManifestEntry {
   title: string;
 }
 
-/** A history entry resolved against the manifest into a renderable row. */
-export interface ShelfRow extends ShelfManifestEntry {
+/**
+ * How a stored read resolves against the current corpus:
+ * - `resolved` — a currently-visible article.
+ * - `archived` — read before it was archived; still opens, just tagged.
+ * - `deleted` — the slug no longer resolves at all; rendered as a tombstone.
+ */
+export type ShelfRowKind = "resolved" | "archived" | "deleted";
+
+interface ShelfRowBase {
+  kind: ShelfRowKind;
   lastReadAt: number;
   pct: number;
+  slug: string;
 }
 
+/** A read that still maps to an article (visible or archived). */
+export interface LinkedShelfRow extends ShelfRowBase {
+  href: string;
+  kind: "resolved" | "archived";
+  label: string;
+  title: string;
+}
+
+/** A read whose article no longer exists — a dismissible tombstone. */
+export interface DeletedShelfRow extends ShelfRowBase {
+  kind: "deleted";
+}
+
+export type ShelfRow = LinkedShelfRow | DeletedShelfRow;
+
 /**
- * Join reading history against the article manifest, preserving the history's
- * most-recent-first order. Entries whose slug is absent from the manifest (an
- * article that no longer exists) drop out silently — a later slice turns those
- * into tombstones; here they simply don't render.
+ * Join reading history against the full article manifest (visible + archived),
+ * preserving the history's most-recent-first order. Every stored read yields a
+ * row classified as resolved, archived, or deleted — nothing is dropped, so a
+ * deleted article surfaces as a tombstone the reader dismisses on their terms.
  */
 export function buildShelfRows(
   history: readonly ReadingEntry[],
@@ -29,9 +55,22 @@ export function buildShelfRows(
   const bySlug = new Map(manifest.map((entry) => [entry.slug, entry]));
   const rows: ShelfRow[] = [];
   for (const entry of history) {
+    const base = {
+      slug: entry.slug,
+      pct: entry.pct,
+      lastReadAt: entry.lastReadAt,
+    };
     const meta = bySlug.get(entry.slug);
     if (meta) {
-      rows.push({ ...meta, pct: entry.pct, lastReadAt: entry.lastReadAt });
+      rows.push({
+        ...base,
+        kind: meta.archived ? "archived" : "resolved",
+        title: meta.title,
+        label: meta.label,
+        href: meta.href,
+      });
+    } else {
+      rows.push({ ...base, kind: "deleted" });
     }
   }
   return rows;


### PR DESCRIPTION
Closes #848. Second slice of the reading-shelf chain (parent #845).

## What

Makes the `/shelf` reading history **curatable** and resilient to a changing corpus.

- **Remove a single read** — every history row gets a remove (×) control that forgets just that item (drops it from the history index and deletes its per-slug resume state).
- **Archived articles still appear** — a read you took before the article was archived stays on the shelf, tagged `archived`, and still links/opens.
- **Deleted articles become tombstones** — a slug that no longer resolves to any article renders as a clearly-marked "no longer available" row with its own dismiss control. It is **not** silently pruned; you decide when to clear it.
- All removes/dismisses persist immediately.

Surfaces touched: `reading-store` (new `removeFromHistory`), `shelf-rows` (three-way classification), `/shelf` page (passes the archived flag), and `shelf-list` (remove controls, archived tag, tombstone rows).

## Decisions

- **This PR is STACKED on #846's PR (base `feature/issue-846-reading-history`, PR #852).** Merge order: **merge #852 first**; GitHub will then auto-retarget this PR onto `main`. The diff here shows only the #848 delta on top of #846.
- **Classification model.** `shelf-rows`' `ShelfRow` became a discriminated union by `kind`: `resolved` | `archived` (both carry title/label/href and link) and `deleted` (slug only, no link). The builder now joins against the **full** article set and never drops a stored read — deleted slugs surface as tombstones rather than disappearing (the #846 behavior of silently dropping unknown slugs is intentionally replaced here, per the issue).
- **`archived` is sourced from `meta.archived`** in the page's manifest build (`getArticles()` already includes archived articles), so no manifest/contract change is needed — this remains browser-local only.
- **`removeFromHistory` also clears per-slug resume state**, matching the LRU-eviction semantics from #846: forgetting a read forgets where you were in it. The same primitive backs both "remove" (linked rows) and "dismiss" (tombstones).
- **Remove button is a sibling of the row link, not nested** — avoids invalid/inaccessible interactive nesting; the `<li>` is a flex row of [link-or-tombstone] + [remove button].
- **Anticipated shared-file conflicts with later slices** (note for merge ordering, not pre-resolved here):
  - `src/lib/reading-store.ts` — #850 (clear-all) will add a clear-everything function alongside `removeFromHistory`.
  - `src/app/(blog)/shelf/shelf-list.tsx` — #849 adds the Saved tab to this same list surface; expect to reconcile the tab/list structure there.

## Verification

Gates run this session, all green:
- `bun run lint` (ultracite/biome) — pass
- `bun run type-check` (tsc across all packages) — pass
- `bun run test` — pass (blog 132, cli 269). Shelf suite now 16 tests; **new/changed this slice**: `shelf-rows` archived classification + deleted-as-tombstone (replacing the old drop test) + order preserved; `reading-store` `removeFromHistory` (removes one, drops its resume state, leaves the rest); `ShelfList` remove-control removal + archived-tag + dismissible-tombstone.

No build run: this slice adds no route (only edits the existing `/shelf` page by one field), so per the chain's gate plan `bun run build` is not required here; type-check covers the page change.

**Not verified this session:** no browser / visual check, no manual click-through of remove/dismiss on the live page, no real archived/deleted article exercised end-to-end (classification is covered by unit tests with synthetic manifests), no cross-browser or private-browsing runtime check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
