### PR TITLE
✨ feat(blog): save-for-later — SaveButton on 3 surfaces + Saved tab (#849)

### DIFF
--- a/apps/blog/src/__tests__/shelf/reading-store.test.ts
+++ b/apps/blog/src/__tests__/shelf/reading-store.test.ts
@@ -2,9 +2,12 @@ import { afterEach, describe, expect, it, spyOn } from "bun:test";
 
 import {
   getHistory,
+  getSaved,
+  isSaved,
   perSlugKey,
   recordProgress,
   removeFromHistory,
+  toggleSave,
 } from "@/lib/reading-store";
 
 afterEach(() => {
@@ -83,5 +86,43 @@ describe("reading-store", () => {
     });
     expect(() => recordProgress("gamma", 0.6)).not.toThrow();
     spy.mockRestore();
+  });
+});
+
+describe("reading-store save-for-later", () => {
+  it("toggles a save on and off, persisting and reporting the new state", () => {
+    expect(isSaved("alpha")).toBe(false);
+
+    expect(toggleSave("alpha")).toBe(true);
+    expect(isSaved("alpha")).toBe(true);
+    expect(getSaved().map((entry) => entry.slug)).toEqual(["alpha"]);
+
+    expect(toggleSave("alpha")).toBe(false);
+    expect(isSaved("alpha")).toBe(false);
+    expect(getSaved()).toEqual([]);
+  });
+
+  it("orders saves newest-first", () => {
+    toggleSave("alpha");
+    toggleSave("beta");
+    toggleSave("gamma");
+    expect(getSaved().map((entry) => entry.slug)).toEqual([
+      "gamma",
+      "beta",
+      "alpha",
+    ]);
+  });
+
+  it("never caps the saved list", () => {
+    for (let i = 0; i < 60; i += 1) {
+      toggleSave(`slug-${i}`);
+    }
+    expect(getSaved()).toHaveLength(60);
+  });
+
+  it("returns an empty saved list when storage is empty or corrupt", () => {
+    expect(getSaved()).toEqual([]);
+    localStorage.setItem("howardism:reading-saved", "{not-json");
+    expect(getSaved()).toEqual([]);
   });
 });

--- a/apps/blog/src/__tests__/shelf/save-button.test.tsx
+++ b/apps/blog/src/__tests__/shelf/save-button.test.tsx
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { SavedList } from "@/app/(blog)/shelf/saved-list";
+import { ShelfList } from "@/app/(blog)/shelf/shelf-list";
+import { SaveButton } from "@/components/save-button";
+import { isSaved } from "@/lib/reading-store";
+import type { ShelfManifestEntry } from "@/lib/shelf-rows";
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
+
+const SAVE = /save for later/i;
+const SAVED = /saved for later/i;
+const ALPHA_TITLE = /Alpha Article/i;
+const EMPTY_SAVED = /nothing saved yet/i;
+
+const manifest: ShelfManifestEntry[] = [
+  {
+    slug: "alpha",
+    title: "Alpha Article",
+    label: "AI Engineering",
+    href: "/articles/alpha",
+    archived: false,
+  },
+];
+
+describe("SaveButton", () => {
+  it("toggles saved state on click and persists it", async () => {
+    render(<SaveButton slug="alpha" />);
+
+    const button = screen.getByRole("button", { name: SAVE });
+    expect(button.getAttribute("aria-pressed")).toBe("false");
+
+    fireEvent.click(button);
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: SAVED }).getAttribute("aria-pressed")
+      ).toBe("true")
+    );
+    expect(isSaved("alpha")).toBe(true);
+  });
+
+  it("reflects an already-saved article on mount", async () => {
+    localStorage.setItem(
+      "howardism:reading-saved",
+      JSON.stringify([{ slug: "alpha", savedAt: Date.now() }])
+    );
+    render(<SaveButton slug="alpha" />);
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: SAVED })).not.toBeNull()
+    );
+  });
+});
+
+describe("SavedList", () => {
+  it("lists saved articles and drops a row when unsaved", async () => {
+    localStorage.setItem(
+      "howardism:reading-saved",
+      JSON.stringify([{ slug: "alpha", savedAt: Date.now() }])
+    );
+    render(<SavedList manifest={manifest} />);
+
+    const link = await waitFor(() =>
+      screen.getByRole("link", { name: ALPHA_TITLE })
+    );
+    expect(link.getAttribute("href")).toBe("/articles/alpha");
+
+    fireEvent.click(screen.getByRole("button", { name: SAVED }));
+    await waitFor(() => expect(screen.queryByText(ALPHA_TITLE)).toBeNull());
+  });
+
+  it("shows the empty state when nothing is saved", async () => {
+    render(<SavedList manifest={manifest} />);
+    await waitFor(() => expect(screen.getByText(EMPTY_SAVED)).not.toBeNull());
+  });
+});
+
+describe("ShelfList still renders history rows", () => {
+  it("renders a saved-independent history row", async () => {
+    localStorage.setItem(
+      "howardism:reading-history",
+      JSON.stringify([{ slug: "alpha", pct: 0.6, lastReadAt: Date.now() }])
+    );
+    render(<ShelfList manifest={manifest} />);
+    await waitFor(() =>
+      expect(screen.getByRole("link", { name: ALPHA_TITLE })).not.toBeNull()
+    );
+  });
+});

--- a/apps/blog/src/app/(blog)/articles/[slug]/article-layout.tsx
+++ b/apps/blog/src/app/(blog)/articles/[slug]/article-layout.tsx
@@ -9,6 +9,7 @@ import { DataGrid } from "@/components/howardism/data-grid";
 import { DomainLabel } from "@/components/howardism/domain-label";
 import { HalfDisc } from "@/components/howardism/half-disc";
 import { SubjectChipList } from "@/components/howardism/subject-chip-list";
+import { SaveButton } from "@/components/save-button";
 import { formatDate } from "@/utils/time";
 import { DOMAIN_META } from "../domain-meta";
 import type {
@@ -136,6 +137,9 @@ export function ArticleLayout({
                   {meta.title}
                 </h1>
                 <DataGrid maxWidth={280} rows={metaRows} stack />
+                <div className="mt-5">
+                  <SaveButton showLabel slug={slug} />
+                </div>
               </div>
 
               <div

--- a/apps/blog/src/app/(blog)/articles/articles-table.tsx
+++ b/apps/blog/src/app/(blog)/articles/articles-table.tsx
@@ -1,4 +1,5 @@
 import { InternalLink } from "@/components/internal-link";
+import { SaveButton } from "@/components/save-button";
 import { formatDateShort } from "@/utils/time";
 
 import type { ArticleEntity } from "./service";
@@ -39,6 +40,7 @@ export function ArticlesTable({
             <th scope="col">Title</th>
             <th scope="col">Summary</th>
             <th scope="col">Date</th>
+            <th scope="col">Save</th>
           </tr>
         </thead>
         <tbody>
@@ -63,6 +65,9 @@ export function ArticlesTable({
                 <time dateTime={article.meta.date}>
                   {formatDateShort(article.meta.date)}
                 </time>
+              </td>
+              <td className="w-[36px] py-3.5 pl-1 text-right align-baseline">
+                <SaveButton slug={article.slug} />
               </td>
             </tr>
           ))}

--- a/apps/blog/src/app/(blog)/articles/kind-plate.tsx
+++ b/apps/blog/src/app/(blog)/articles/kind-plate.tsx
@@ -1,6 +1,7 @@
 import { DomainLabel } from "@/components/howardism/domain-label";
 import { SubjectChipList } from "@/components/howardism/subject-chip-list";
 import { InternalLink } from "@/components/internal-link";
+import { SaveButton } from "@/components/save-button";
 import { formatDateShort } from "@/utils/time";
 
 import { KIND_META } from "./kind-meta";
@@ -86,6 +87,7 @@ export function KindPlate({
                 <th scope="col">Title</th>
                 <th scope="col">Domain</th>
                 <th scope="col">Date</th>
+                <th scope="col">Save</th>
               </tr>
             </thead>
             <tbody>
@@ -139,6 +141,9 @@ export function KindPlate({
                       {formatDateShort(article.meta.date)}
                     </time>{" "}
                     · {article.meta.readingTime}′
+                  </td>
+                  <td className="w-[36px] py-3.5 pl-1 text-right align-baseline">
+                    <SaveButton slug={article.slug} />
                   </td>
                 </tr>
               ))}

--- a/apps/blog/src/app/(blog)/shelf/page.tsx
+++ b/apps/blog/src/app/(blog)/shelf/page.tsx
@@ -5,7 +5,7 @@ import type { ShelfManifestEntry } from "@/lib/shelf-rows";
 
 import { DOMAIN_META } from "../articles/domain-meta";
 import { getArticles } from "../articles/service";
-import { ShelfList } from "./shelf-list";
+import { ShelfTabs } from "./shelf-tabs";
 
 const SHELF_URL = `${env.NEXT_PUBLIC_DOMAIN_NAME}/shelf`;
 
@@ -56,7 +56,7 @@ export default async function ShelfPage() {
         </p>
       </header>
 
-      <ShelfList manifest={manifest} />
+      <ShelfTabs manifest={manifest} />
     </div>
   );
 }

--- a/apps/blog/src/app/(blog)/shelf/saved-list.tsx
+++ b/apps/blog/src/app/(blog)/shelf/saved-list.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import dayjs from "dayjs";
+import relativeTime from "dayjs/plugin/relativeTime";
+import { useEffect, useState } from "react";
+
+import { SaveButton } from "@/components/save-button";
+import { getSaved, type SavedEntry } from "@/lib/reading-store";
+import type { ShelfManifestEntry } from "@/lib/shelf-rows";
+
+import { ArchivedBadge, ShelfArticleRow } from "./shelf-article-row";
+
+dayjs.extend(relativeTime);
+
+/**
+ * Saved tab: lists deliberately saved articles, newest-saved first, resolved
+ * against the article manifest. Unsaving a row drops it from the list. Saves of
+ * a now-missing article are simply not shown (the stored list is untouched).
+ */
+export function SavedList({ manifest }: { manifest: ShelfManifestEntry[] }) {
+  const [saved, setSaved] = useState<SavedEntry[] | null>(null);
+
+  useEffect(() => {
+    setSaved(getSaved());
+  }, []);
+
+  if (saved === null) {
+    return null;
+  }
+
+  const bySlug = new Map(manifest.map((entry) => [entry.slug, entry]));
+  const rows = saved
+    .map((entry) => ({ entry, meta: bySlug.get(entry.slug) }))
+    .filter(
+      (row): row is { entry: SavedEntry; meta: ShelfManifestEntry } =>
+        row.meta !== undefined
+    );
+
+  if (rows.length === 0) {
+    return (
+      <p className="mt-6 font-body text-[15px] text-muted-foreground leading-[1.6]">
+        Nothing saved yet. Use the bookmark control on any article or listing to
+        keep it here for later.
+      </p>
+    );
+  }
+
+  const handleToggle = (slug: string, nowSaved: boolean) => {
+    if (!nowSaved) {
+      setSaved((current) =>
+        current ? current.filter((entry) => entry.slug !== slug) : current
+      );
+    }
+  };
+
+  return (
+    <ul className="mt-2 flex list-none flex-col p-0">
+      {rows.map(({ entry, meta }) => (
+        <ShelfArticleRow
+          badge={meta.archived ? <ArchivedBadge /> : undefined}
+          control={
+            <SaveButton
+              onToggle={(nowSaved) => handleToggle(meta.slug, nowSaved)}
+              slug={meta.slug}
+            />
+          }
+          href={meta.href}
+          key={meta.slug}
+          label={meta.label}
+          timeText={`saved ${dayjs(entry.savedAt).fromNow()}`}
+          title={meta.title}
+        />
+      ))}
+    </ul>
+  );
+}

--- a/apps/blog/src/app/(blog)/shelf/shelf-article-row.tsx
+++ b/apps/blog/src/app/(blog)/shelf/shelf-article-row.tsx
@@ -1,0 +1,79 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+const META_CLASS =
+  "font-mono text-[10.5px] text-foreground-subtle uppercase tracking-[0.16em]";
+
+interface ShelfArticleRowProps {
+  /** Optional inline tag after the title (e.g. "archived"). */
+  badge?: ReactNode;
+  /** Trailing control rendered outside the link (remove or save). */
+  control: ReactNode;
+  href: string;
+  /** Meta line: the domain/kind label plus a time phrase. */
+  label: string;
+  /** When set (0–1), renders the reading-progress bar and percentage. */
+  progress?: number;
+  timeText: string;
+  title: string;
+}
+
+/**
+ * The Shelf's compact article row — a single link presentation shared by the
+ * History and Saved lists. The trailing `control` sits outside the link so the
+ * remove/save button never nests inside the anchor.
+ */
+export function ShelfArticleRow({
+  href,
+  title,
+  label,
+  timeText,
+  badge,
+  progress,
+  control,
+}: ShelfArticleRowProps) {
+  const pct = progress === undefined ? null : Math.round(progress * 100);
+
+  return (
+    <li className="flex items-center gap-2 border-border border-b border-dashed py-4 last:border-b-0">
+      <Link
+        className="group flex min-w-0 flex-1 items-center gap-4 no-underline"
+        href={href}
+      >
+        <div className="min-w-0 flex-1">
+          <span className="flex items-center gap-2 font-display text-[16px] text-foreground leading-[1.3] transition-colors group-hover:text-brand">
+            <span className="truncate">{title}</span>
+            {badge}
+          </span>
+          <span className={`mt-1 block ${META_CLASS}`}>
+            {label} · {timeText}
+          </span>
+        </div>
+        {pct !== null && (
+          <div className="flex shrink-0 items-center gap-2">
+            <span
+              aria-hidden="true"
+              className="h-1 w-16 overflow-hidden rounded-full bg-border"
+            >
+              <span
+                className="block h-full rounded-full bg-brand/70"
+                style={{ width: `${pct}%` }}
+              />
+            </span>
+            <span className={`w-9 text-right ${META_CLASS}`}>{pct}%</span>
+          </div>
+        )}
+      </Link>
+      {control}
+    </li>
+  );
+}
+
+/** Shared "archived" tag for rows whose article was archived after reading. */
+export function ArchivedBadge() {
+  return (
+    <span className="shrink-0 rounded-sm border border-border px-1.5 py-0.5 font-mono text-[9px] text-foreground-subtle uppercase tracking-[0.14em]">
+      archived
+    </span>
+  );
+}

--- a/apps/blog/src/app/(blog)/shelf/shelf-list.tsx
+++ b/apps/blog/src/app/(blog)/shelf/shelf-list.tsx
@@ -2,16 +2,16 @@
 
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
-import Link from "next/link";
 import { useEffect, useState } from "react";
 
 import { getHistory, removeFromHistory } from "@/lib/reading-store";
 import {
   buildShelfRows,
-  type LinkedShelfRow,
   type ShelfManifestEntry,
   type ShelfRow,
 } from "@/lib/shelf-rows";
+
+import { ArchivedBadge, ShelfArticleRow } from "./shelf-article-row";
 
 dayjs.extend(relativeTime);
 
@@ -39,55 +39,6 @@ function RemoveButton({
   );
 }
 
-function LinkedRow({
-  row,
-  onRemove,
-}: {
-  row: LinkedShelfRow;
-  onRemove: () => void;
-}) {
-  const pct = Math.round(row.pct * 100);
-
-  return (
-    <>
-      <Link
-        className="group flex min-w-0 flex-1 items-center gap-4 no-underline"
-        href={row.href}
-      >
-        <div className="min-w-0 flex-1">
-          <span className="flex items-center gap-2 font-display text-[16px] text-foreground leading-[1.3] transition-colors group-hover:text-brand">
-            <span className="truncate">{row.title}</span>
-            {row.kind === "archived" && (
-              <span className="shrink-0 rounded-sm border border-border px-1.5 py-0.5 font-mono text-[9px] text-foreground-subtle uppercase tracking-[0.14em]">
-                archived
-              </span>
-            )}
-          </span>
-          <span className={`mt-1 block ${META_CLASS}`}>
-            {row.label} · {dayjs(row.lastReadAt).fromNow()}
-          </span>
-        </div>
-        <div className="flex shrink-0 items-center gap-2">
-          <span
-            aria-hidden="true"
-            className="h-1 w-16 overflow-hidden rounded-full bg-border"
-          >
-            <span
-              className="block h-full rounded-full bg-brand/70"
-              style={{ width: `${pct}%` }}
-            />
-          </span>
-          <span className={`w-9 text-right ${META_CLASS}`}>{pct}%</span>
-        </div>
-      </Link>
-      <RemoveButton
-        label={`Remove ${row.title} from shelf`}
-        onClick={onRemove}
-      />
-    </>
-  );
-}
-
 function TombstoneRow({
   slug,
   onDismiss,
@@ -96,15 +47,15 @@ function TombstoneRow({
   onDismiss: () => void;
 }) {
   return (
-    <>
+    <li className="flex items-center gap-2 border-border border-b border-dashed py-4 last:border-b-0">
       <div className="min-w-0 flex-1">
-        <span className="flex items-center gap-2 font-display text-[16px] text-foreground-subtle italic leading-[1.3]">
-          <span className="truncate">{slug}</span>
+        <span className="block truncate font-display text-[16px] text-foreground-subtle italic leading-[1.3]">
+          {slug}
         </span>
         <span className={`mt-1 block ${META_CLASS}`}>no longer available</span>
       </div>
       <RemoveButton label={`Dismiss ${slug}`} onClick={onDismiss} />
-    </>
+    </li>
   );
 }
 
@@ -115,23 +66,35 @@ function HistoryRow({
   row: ShelfRow;
   onRemove: (slug: string) => void;
 }) {
+  if (row.kind === "deleted") {
+    return (
+      <TombstoneRow onDismiss={() => onRemove(row.slug)} slug={row.slug} />
+    );
+  }
   return (
-    <li className="flex items-center gap-2 border-border border-b border-dashed py-4 last:border-b-0">
-      {row.kind === "deleted" ? (
-        <TombstoneRow onDismiss={() => onRemove(row.slug)} slug={row.slug} />
-      ) : (
-        <LinkedRow onRemove={() => onRemove(row.slug)} row={row} />
-      )}
-    </li>
+    <ShelfArticleRow
+      badge={row.kind === "archived" ? <ArchivedBadge /> : undefined}
+      control={
+        <RemoveButton
+          label={`Remove ${row.title} from shelf`}
+          onClick={() => onRemove(row.slug)}
+        />
+      }
+      href={row.href}
+      label={row.label}
+      progress={row.pct}
+      timeText={dayjs(row.lastReadAt).fromNow()}
+      title={row.title}
+    />
   );
 }
 
 /**
- * Reads the browser-local reading history on mount and resolves it against the
- * build-time article manifest. Renders nothing until the client read completes
- * (avoids an empty-state flash during hydration), then either the history rows
- * — each removable, archived reads tagged, deleted reads shown as dismissible
- * tombstones — or a friendly empty state.
+ * History tab: reads the browser-local reading history on mount and resolves
+ * it against the build-time article manifest. Renders nothing until the client
+ * read completes (avoids an empty-state flash), then the rows — each removable,
+ * archived reads tagged, deleted reads shown as dismissible tombstones — or a
+ * friendly empty state.
  */
 export function ShelfList({ manifest }: { manifest: ShelfManifestEntry[] }) {
   const [rows, setRows] = useState<ShelfRow[] | null>(null);
@@ -146,7 +109,7 @@ export function ShelfList({ manifest }: { manifest: ShelfManifestEntry[] }) {
 
   if (rows.length === 0) {
     return (
-      <p className="mt-8 font-body text-[15px] text-muted-foreground leading-[1.6]">
+      <p className="mt-6 font-body text-[15px] text-muted-foreground leading-[1.6]">
         Nothing on your shelf yet. Read past the opening of any article and it
         lands here automatically — saved only in this browser.
       </p>
@@ -161,7 +124,7 @@ export function ShelfList({ manifest }: { manifest: ShelfManifestEntry[] }) {
   };
 
   return (
-    <ul className="mt-6 flex list-none flex-col p-0">
+    <ul className="mt-2 flex list-none flex-col p-0">
       {rows.map((row) => (
         <HistoryRow key={row.slug} onRemove={handleRemove} row={row} />
       ))}

--- a/apps/blog/src/app/(blog)/shelf/shelf-tabs.tsx
+++ b/apps/blog/src/app/(blog)/shelf/shelf-tabs.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@howardism/ui/components/tabs";
+
+import type { ShelfManifestEntry } from "@/lib/shelf-rows";
+
+import { SavedList } from "./saved-list";
+import { ShelfList } from "./shelf-list";
+
+/**
+ * The Shelf's tabbed shell: automatic reading History and deliberate Saved
+ * lists, both resolved against the same build-time article manifest.
+ */
+export function ShelfTabs({ manifest }: { manifest: ShelfManifestEntry[] }) {
+  return (
+    <Tabs className="mt-8" defaultValue="history">
+      <TabsList>
+        <TabsTrigger value="history">History</TabsTrigger>
+        <TabsTrigger value="saved">Saved</TabsTrigger>
+      </TabsList>
+      <TabsContent value="history">
+        <ShelfList manifest={manifest} />
+      </TabsContent>
+      <TabsContent value="saved">
+        <SavedList manifest={manifest} />
+      </TabsContent>
+    </Tabs>
+  );
+}

--- a/apps/blog/src/components/save-button.tsx
+++ b/apps/blog/src/components/save-button.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { cn } from "@howardism/ui/lib/utils";
+import {
+  BookmarkAdd01Icon,
+  BookmarkCheck01Icon,
+} from "@hugeicons/core-free-icons";
+import { HugeiconsIcon } from "@hugeicons/react";
+import { useEffect, useState } from "react";
+
+import { isSaved, toggleSave } from "@/lib/reading-store";
+
+interface SaveButtonProps {
+  className?: string;
+  /** Notified with the new saved state after a toggle. */
+  onToggle?: (saved: boolean) => void;
+  /** Render the state word ("Save" / "Saved") next to the icon. */
+  showLabel?: boolean;
+  slug: string;
+}
+
+/**
+ * Reusable save-for-later toggle. Reflects the persisted saved state (read on
+ * mount to avoid a hydration mismatch — the server always renders the unsaved
+ * state) and flips it on click. Used on the article page, listing rows, and
+ * the Shelf.
+ */
+export function SaveButton({
+  slug,
+  className,
+  showLabel = false,
+  onToggle,
+}: SaveButtonProps) {
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    setSaved(isSaved(slug));
+  }, [slug]);
+
+  const handleClick = () => {
+    const next = toggleSave(slug);
+    setSaved(next);
+    onToggle?.(next);
+  };
+
+  return (
+    <button
+      aria-label={saved ? "Saved for later — remove" : "Save for later"}
+      aria-pressed={saved}
+      className={cn(
+        "inline-flex shrink-0 items-center gap-1.5 rounded-full text-foreground-subtle transition-colors hover:text-brand aria-pressed:text-brand",
+        showLabel
+          ? "border border-border px-3 py-1.5 font-mono text-[10.5px] uppercase tracking-[0.16em] aria-pressed:border-brand/40"
+          : "size-7 justify-center",
+        className
+      )}
+      onClick={handleClick}
+      type="button"
+    >
+      <HugeiconsIcon
+        className="size-[18px]"
+        icon={saved ? BookmarkCheck01Icon : BookmarkAdd01Icon}
+      />
+      {showLabel && <span>{saved ? "Saved" : "Save"}</span>}
+    </button>
+  );
+}

--- a/apps/blog/src/lib/reading-store.ts
+++ b/apps/blog/src/lib/reading-store.ts
@@ -11,6 +11,8 @@
 const PER_SLUG_PREFIX = "howardism:reading:";
 /** History index key. Distinct from the per-slug prefix (no trailing colon). */
 const HISTORY_KEY = "howardism:reading-history";
+/** Save-for-later index key. Uncapped, newest-saved first. */
+const SAVED_KEY = "howardism:reading-saved";
 /** Below this scroll fraction a read isn't worth remembering. */
 const MIN_RECORD_PCT = 0.25;
 /** Most-recent reads to keep; older reads are evicted LRU-style. */
@@ -101,4 +103,66 @@ export function removeFromHistory(slug: string): void {
   } catch {
     // ignore storage errors (quota / private mode)
   }
+}
+
+/* ── save-for-later (deliberate, uncapped, separate from history) ── */
+
+export interface SavedEntry {
+  /** Epoch ms when the article was saved, for newest-first ordering. */
+  savedAt: number;
+  /** Article slug; the join key against the article manifest. */
+  slug: string;
+}
+
+function isSavedEntry(value: unknown): value is SavedEntry {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const entry = value as Record<string, unknown>;
+  return typeof entry.slug === "string" && typeof entry.savedAt === "number";
+}
+
+/**
+ * The save-for-later list, newest-saved first. Uncapped — only the reader
+ * trims it by unsaving. Returns `[]` when storage is unavailable or corrupt.
+ */
+export function getSaved(): SavedEntry[] {
+  try {
+    const raw = localStorage.getItem(SAVED_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed.filter(isSavedEntry);
+  } catch {
+    return [];
+  }
+}
+
+/** Whether `slug` is currently saved for later. */
+export function isSaved(slug: string): boolean {
+  return getSaved().some((entry) => entry.slug === slug);
+}
+
+/**
+ * Toggle `slug`'s saved state, persisting the change, and return the new state
+ * (`true` if it is now saved). Saving moves it to the front; the list is never
+ * auto-trimmed. Storage errors are swallowed; the returned state still
+ * reflects the intended toggle so the control stays responsive.
+ */
+export function toggleSave(slug: string): boolean {
+  const saved = getSaved();
+  const wasSaved = saved.some((entry) => entry.slug === slug);
+  const next = wasSaved
+    ? saved.filter((entry) => entry.slug !== slug)
+    : [{ slug, savedAt: Date.now() }, ...saved];
+  try {
+    localStorage.setItem(SAVED_KEY, JSON.stringify(next));
+  } catch {
+    // ignore storage errors (quota / private mode)
+  }
+  return !wasSaved;
 }


### PR DESCRIPTION
Closes #849. Third slice of the reading-shelf chain (parent #845).

## What

Deliberate **save-for-later**, separate from automatic history.

- **Reusable `SaveButton`** — a bookmark toggle that reflects the persisted saved state and flips it on click. Placed on three surfaces:
  - the **article page** (labelled Save/Saved control under the title),
  - **listing rows** — the index plates (`kind-plate`) and the domain/tag/tagged listing tables (`articles-table`), so an article can be saved without opening it,
  - **Shelf** history/saved rows.
- **`/shelf` gains tabs** — **History | Saved** (radix `Tabs`). The Saved tab lists everything saved, **newest-saved first**.
- **Uncapped saved list** — it only changes when you save/unsave; nothing is auto-trimmed.
- Saved rows **reuse the compact row treatment** (the new shared `shelf-article-row`) and link to the article.

Store additions: `getSaved` / `isSaved` / `toggleSave` (entries `{ slug, savedAt }`, uncapped, newest-first) under `howardism:reading-saved`.

## Decisions

- **This PR is STACKED on #848's PR (base `feature/issue-848-history-curation`, PR #853).** Merge order: **merge #852 → #853 → this**. GitHub auto-retargets as each base merges. The diff shows only the #849 delta.
- **Shared compact row.** Extracted `shelf-article-row.tsx` from the #848 history list so History and Saved render the same row treatment — honoring the "reuse, don't duplicate" mandate. The History tombstone (deleted) row stays list-specific (it has no link). This is a refactor of the #848 `ShelfList` internals; its public behavior/tests are unchanged.
- **Saved state read on mount** (`useEffect`), so the server always renders the unsaved state and there's no hydration mismatch — same pattern as the rest of the Shelf. Listing/article pages stay statically generated.
- **`toggleSave` returns the new state** so the optimistic control update is correct even when the persist write is swallowed (private browsing).
- **Saves of a now-missing article** are simply not rendered in the Saved tab; the stored list is left intact (uncapped, user-curated) — no tombstone treatment for saved (that concept is history-only, per #848).
- **Icons**: `BookmarkAdd01Icon` (unsaved) / `BookmarkCheck01Icon` (saved) from the existing `@hugeicons/core-free-icons`, matching the header's icon usage.
- **Anticipated shared-file conflicts with later slices** (note for merge ordering, not pre-resolved here):
  - `src/lib/reading-store.ts` — #850 (clear-all) adds a clear-everything function alongside the save API.
  - `src/app/(blog)/shelf/*` and `shelf-article-row.tsx` — #851 (compare selection) adds multi-select affordances onto these same rows/tabs.

## Verification

Gates run this session, all green:
- `bun run lint` (ultracite/biome) — pass
- `bun run type-check` (tsc across all packages) — pass
- `bun run test` — pass (blog 141, cli 269). Shelf suite +9: `reading-store` save API (toggle round-trip + persistence, newest-first ordering, uncapped at 60, corrupt-storage); `SaveButton` (click toggles `aria-pressed` + persists, reflects already-saved on mount); `SavedList` (lists + unsave drops the row, empty state); plus a guard that `ShelfList` history rendering still works after the shared-row refactor.
- `bun run build` — pass; `/shelf` still prerenders static (`○`), and the listing/article pages still build with the new client controls. Run as insurance (this slice adds client boundaries — radix Tabs + SaveButton — onto several statically-generated pages) even though the chain's gate plan lists build optional here.

**Not verified this session:** no browser / visual check, no manual click-through of save/unsave on the live pages, no tab-switch interaction in a real browser, no cross-browser or private-browsing runtime check, no visual review of the listing-table save column at narrow widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
