### PR TITLE
✨ feat(blog): clear reading data via Tweaks panel (#850)

### DIFF
--- a/apps/blog/src/__tests__/shelf/reading-store.test.ts
+++ b/apps/blog/src/__tests__/shelf/reading-store.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, spyOn } from "bun:test";
 
 import {
+  clearReadingData,
   getHistory,
   getSaved,
   isSaved,
@@ -124,5 +125,30 @@ describe("reading-store save-for-later", () => {
     expect(getSaved()).toEqual([]);
     localStorage.setItem("howardism:reading-saved", "{not-json");
     expect(getSaved()).toEqual([]);
+  });
+});
+
+describe("reading-store clearReadingData", () => {
+  it("wipes history, the saved list, and every per-slug resume entry", () => {
+    recordProgress("alpha", 0.4);
+    toggleSave("beta");
+    localStorage.setItem(
+      perSlugKey("alpha"),
+      JSON.stringify({ headingId: "h", pct: 0.4 })
+    );
+    localStorage.setItem(
+      perSlugKey("gamma"),
+      JSON.stringify({ headingId: "h", pct: 0.5 })
+    );
+    // An unrelated namespace must survive the wipe.
+    localStorage.setItem("howardism:tweaks", "{}");
+
+    clearReadingData();
+
+    expect(getHistory()).toEqual([]);
+    expect(getSaved()).toEqual([]);
+    expect(localStorage.getItem(perSlugKey("alpha"))).toBeNull();
+    expect(localStorage.getItem(perSlugKey("gamma"))).toBeNull();
+    expect(localStorage.getItem("howardism:tweaks")).not.toBeNull();
   });
 });

--- a/apps/blog/src/__tests__/tweaks/tweaks.test.tsx
+++ b/apps/blog/src/__tests__/tweaks/tweaks.test.tsx
@@ -19,6 +19,7 @@ import { TWEAKS_STORAGE_KEY } from "@/components/tweaks/types";
 afterEach(cleanup);
 
 const READER_SETTINGS_LABEL = /reader settings/i;
+const CLEAR_DATA_LABEL = /clear reading data/i;
 
 // ── InitTweaksScript ────────────────────────────────────────────────────────
 
@@ -211,6 +212,38 @@ describe("reader-settings", () => {
     fireEvent.keyDown(input, { key: "t", target: input });
     await new Promise((r) => setTimeout(r, 50));
     expect(btn.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("clears all reading data from the panel", async () => {
+    localStorage.setItem(
+      "howardism:reading-history",
+      JSON.stringify([{ slug: "a", pct: 0.5, lastReadAt: 1 }])
+    );
+    localStorage.setItem(
+      "howardism:reading-saved",
+      JSON.stringify([{ slug: "b", savedAt: 1 }])
+    );
+    localStorage.setItem(
+      "howardism:reading:a",
+      JSON.stringify({ headingId: "h", pct: 0.5 })
+    );
+
+    render(
+      <TweaksProvider>
+        <ReaderSettings />
+      </TweaksProvider>
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: READER_SETTINGS_LABEL })
+    );
+    const clearButton = await screen.findByRole("button", {
+      name: CLEAR_DATA_LABEL,
+    });
+    fireEvent.click(clearButton);
+
+    expect(localStorage.getItem("howardism:reading-history")).toBeNull();
+    expect(localStorage.getItem("howardism:reading-saved")).toBeNull();
+    expect(localStorage.getItem("howardism:reading:a")).toBeNull();
   });
 });
 

--- a/apps/blog/src/components/tweaks/reader-settings.tsx
+++ b/apps/blog/src/components/tweaks/reader-settings.tsx
@@ -8,6 +8,8 @@ import {
 import { Toggle } from "@howardism/ui/components/toggle";
 import { useCallback, useEffect, useState } from "react";
 
+import { clearReadingData } from "@/lib/reading-store";
+
 import { useTweaks } from "./tweaks-provider";
 import type { TextSize } from "./types";
 
@@ -27,6 +29,20 @@ const PILL_TOGGLE =
 export function ReaderSettings() {
   const { state, setTapToScroll, setTextSize } = useTweaks();
   const [open, setOpen] = useState(false);
+  const [cleared, setCleared] = useState(false);
+
+  const handleClear = useCallback(() => {
+    clearReadingData();
+    setCleared(true);
+  }, []);
+
+  useEffect(() => {
+    if (!cleared) {
+      return;
+    }
+    const timer = setTimeout(() => setCleared(false), 2000);
+    return () => clearTimeout(timer);
+  }, [cleared]);
 
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
     if (e.key !== "t" && e.key !== "T") {
@@ -97,6 +113,23 @@ export function ReaderSettings() {
             </Toggle>
             <p className="mt-2 font-body text-[12px] text-foreground-subtle leading-snug">
               On touch devices, tap the top or bottom edge to scroll a screen.
+            </p>
+          </section>
+
+          <section aria-label="Reading data">
+            <div className="mb-2.5 font-mono text-[0.6875rem] text-foreground-subtle uppercase tracking-[0.16em]">
+              Reading data
+            </div>
+            <button
+              className="w-full rounded-full border border-border bg-background-2 px-3 py-1.5 font-body text-[13px] text-foreground-subtle transition-colors hover:bg-accent hover:text-foreground"
+              onClick={handleClear}
+              type="button"
+            >
+              {cleared ? "Cleared" : "Clear reading data"}
+            </button>
+            <p className="mt-2 font-body text-[12px] text-foreground-subtle leading-snug">
+              Erases your reading history, saved list, and in-article resume
+              positions from this browser.
             </p>
           </section>
         </div>

--- a/apps/blog/src/lib/reading-store.ts
+++ b/apps/blog/src/lib/reading-store.ts
@@ -166,3 +166,31 @@ export function toggleSave(slug: string): boolean {
   }
   return !wasSaved;
 }
+
+/* ── wipe everything (privacy / fresh start) ── */
+
+/**
+ * Erase all reading state from this browser: the history index, the saved
+ * list, and every per-slug resume entry. After this the Shelf is empty and
+ * in-article resume chips no longer appear (they read the same per-slug keys).
+ * Storage errors are silently ignored.
+ */
+export function clearReadingData(): void {
+  try {
+    localStorage.removeItem(HISTORY_KEY);
+    localStorage.removeItem(SAVED_KEY);
+    // Collect per-slug keys first — removing during iteration shifts indices.
+    const perSlugKeys: string[] = [];
+    for (let i = 0; i < localStorage.length; i += 1) {
+      const key = localStorage.key(i);
+      if (key?.startsWith(PER_SLUG_PREFIX)) {
+        perSlugKeys.push(key);
+      }
+    }
+    for (const key of perSlugKeys) {
+      localStorage.removeItem(key);
+    }
+  } catch {
+    // ignore storage errors (quota / private mode)
+  }
+}


### PR DESCRIPTION
Closes #850. Fourth slice of the reading-shelf chain (parent #845).

## What

A single control to wipe **all** reading data, for privacy or a fresh start.

- A **"Clear reading data"** control is added to the existing reader-settings (Tweaks) popover, in a new "Reading data" section beside text-size and tap-to-scroll.
- Activating it removes, in one action: the entire **reading history**, the **saved list**, and **all per-article resume state**. After clearing, the Shelf shows its empty states and in-article resume chips no longer appear (they read the same per-slug keys — this reset is intentional).
- A brief "Cleared" label confirms the action.

Store addition: `clearReadingData` — removes the history index, the saved list, and every `howardism:reading:<slug>` resume entry (scanned by prefix), while leaving unrelated namespaces (e.g. tweaks) intact.

## Decisions

- **This PR is STACKED on #849's PR (base `feature/issue-849-save-for-later`, PR #854).** Merge order: **#852 → #853 → #854 → this**; GitHub auto-retargets as each base merges. The diff shows only the #850 delta.
- **Per-slug keys are scanned by prefix** (`howardism:reading:`), collected before removal to avoid index-shift during iteration. The history (`reading-history`) and saved (`reading-saved`) keys don't share that prefix, so they're removed explicitly — a test asserts an unrelated `howardism:tweaks` key survives, guarding against an over-broad wipe.
- **No confirmation dialog.** The issue frames this as a single activating control; a one-tap clear with a transient "Cleared" acknowledgement keeps it simple. (If a confirm step is later wanted, it's a small follow-up.)
- **Per-row removal is untouched** — `removeFromHistory` (one-off deletions) and unsave still work exactly as before; this only adds the bulk wipe.
- **Anticipated shared-file conflict:** `src/lib/reading-store.ts` is the common growth point across the chain (#848 added `removeFromHistory`, #849 the save API, this adds `clearReadingData`); each is an independent additive export, so conflicts should be trivial textual ones at most.

## Verification

Gates run this session, all green:
- `bun run lint` (ultracite/biome) — pass
- `bun run type-check` (tsc across all packages) — pass
- `bun run test` — pass (blog 143, cli 269). **+2 new**: `reading-store` `clearReadingData` (wipes all three key families, preserves an unrelated namespace); a Tweaks-panel interaction test (open the reader-settings popover → click "Clear reading data" → history/saved/per-slug keys are gone).

No build run: this slice adds no route and only edits an existing client component (`reader-settings`) plus a store function, both covered by type-check; per the chain's gate plan `bun run build` is not required here.

**Not verified this session:** no browser / visual check, no manual click-through of the clear control on the live panel, no end-to-end check that the Shelf/resume chips visibly empty after clearing in a real browser, no cross-browser or private-browsing runtime check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
