### PR TITLE
✨ feat(blog): compare route — bare-body columns/tabs + compare-ids (#847)

### DIFF
--- a/apps/blog/src/__tests__/compare/compare-ids.test.ts
+++ b/apps/blog/src/__tests__/compare/compare-ids.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "bun:test";
+
+import { resolveCompareIds } from "@/lib/compare-ids";
+
+const known = new Set(["alpha", "beta", "gamma", "delta"]);
+
+describe("resolveCompareIds", () => {
+  it("keeps known slugs in their given order", () => {
+    expect(resolveCompareIds("beta,alpha", known)).toEqual(["beta", "alpha"]);
+  });
+
+  it("drops unknown slugs", () => {
+    expect(resolveCompareIds("alpha,ghost,beta", known)).toEqual([
+      "alpha",
+      "beta",
+    ]);
+  });
+
+  it("collapses duplicates to first occurrence", () => {
+    expect(resolveCompareIds("alpha,alpha,beta,alpha", known)).toEqual([
+      "alpha",
+      "beta",
+    ]);
+  });
+
+  it("caps the set at three", () => {
+    expect(resolveCompareIds("alpha,beta,gamma,delta", known)).toEqual([
+      "alpha",
+      "beta",
+      "gamma",
+    ]);
+  });
+
+  it("trims whitespace around slugs", () => {
+    expect(resolveCompareIds(" alpha , beta ", known)).toEqual([
+      "alpha",
+      "beta",
+    ]);
+  });
+
+  it("returns an empty list for empty, missing, or garbage input", () => {
+    expect(resolveCompareIds("", known)).toEqual([]);
+    expect(resolveCompareIds(undefined, known)).toEqual([]);
+    expect(resolveCompareIds("  , ,", known)).toEqual([]);
+    expect(resolveCompareIds("ghost,phantom", known)).toEqual([]);
+  });
+
+  it("flattens a repeated query param array before resolving", () => {
+    expect(resolveCompareIds(["alpha", "beta"], known)).toEqual([
+      "alpha",
+      "beta",
+    ]);
+  });
+});

--- a/apps/blog/src/__tests__/compare/compare-view.test.tsx
+++ b/apps/blog/src/__tests__/compare/compare-view.test.tsx
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import {
+  type ComparePanel,
+  CompareView,
+} from "@/app/(blog)/compare/compare-view";
+
+afterEach(cleanup);
+
+const panels: ComparePanel[] = [
+  {
+    slug: "alpha",
+    title: "Alpha",
+    href: "/articles/alpha",
+    body: <p>Alpha body</p>,
+  },
+  {
+    slug: "beta",
+    title: "Beta",
+    href: "/articles/beta",
+    body: <p>Beta body</p>,
+  },
+];
+
+describe("CompareView", () => {
+  it("renders every panel body and a tab per article", () => {
+    render(<CompareView panels={panels} />);
+
+    expect(screen.getByText("Alpha body")).not.toBeNull();
+    expect(screen.getByText("Beta body")).not.toBeNull();
+    // Each article title appears as both a tab and a panel heading link.
+    expect(screen.getAllByRole("button", { name: "Alpha" })).toHaveLength(1);
+  });
+
+  it("marks the first tab active and switches on click", () => {
+    render(<CompareView panels={panels} />);
+
+    const alphaTab = screen.getByRole("button", { name: "Alpha" });
+    const betaTab = screen.getByRole("button", { name: "Beta" });
+    expect(alphaTab.getAttribute("aria-pressed")).toBe("true");
+    expect(betaTab.getAttribute("aria-pressed")).toBe("false");
+
+    fireEvent.click(betaTab);
+
+    expect(alphaTab.getAttribute("aria-pressed")).toBe("false");
+    expect(betaTab.getAttribute("aria-pressed")).toBe("true");
+  });
+});

--- a/apps/blog/src/app/(blog)/compare/compare-view.tsx
+++ b/apps/blog/src/app/(blog)/compare/compare-view.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { cn } from "@howardism/ui/lib/utils";
+import Link from "next/link";
+import { type ReactNode, useState } from "react";
+
+export interface ComparePanel {
+  body: ReactNode;
+  href: string;
+  slug: string;
+  title: string;
+}
+
+/** Static column-count classes so Tailwind keeps them (no interpolation). */
+const COLUMN_CLASS: Record<number, string> = {
+  1: "lg:grid-cols-1",
+  2: "lg:grid-cols-2",
+  3: "lg:grid-cols-3",
+};
+
+const PANEL_CLASS =
+  "max-h-[calc(100dvh-9rem)] overflow-y-auto rounded-md border border-border bg-card/40 p-5";
+
+/**
+ * Side-by-side reader for up to three article bodies. On wide screens the
+ * panels sit in parallel, each scrolling on its own. Below `lg` they collapse
+ * to a tab bar that flips one panel into view at a time; all panels stay
+ * mounted, so each keeps its scroll position across tab switches.
+ */
+export function CompareView({ panels }: { panels: ComparePanel[] }) {
+  const [active, setActive] = useState(0);
+
+  return (
+    <div className="mx-auto max-w-wide px-4 py-6">
+      <div className="mb-4 flex items-center justify-between gap-4">
+        <h1 className="font-mono text-[11px] text-foreground-subtle uppercase tracking-[0.2em]">
+          Comparing {panels.length}{" "}
+          {panels.length === 1 ? "article" : "articles"}
+        </h1>
+        <Link
+          className="font-mono text-[11px] text-foreground-subtle uppercase tracking-[0.16em] no-underline transition-colors hover:text-brand"
+          href="/articles"
+        >
+          All articles →
+        </Link>
+      </div>
+
+      {/* Mobile/tablet tab bar */}
+      <fieldset
+        aria-label="Choose an article to read"
+        className="m-0 flex flex-wrap gap-1.5 border-0 p-0 lg:hidden"
+      >
+        {panels.map((panel, index) => (
+          <button
+            aria-pressed={index === active}
+            className="rounded-full border border-border px-3 py-1.5 font-body text-[13px] text-foreground-subtle transition-colors aria-pressed:border-brand/40 aria-pressed:bg-brand/10 aria-pressed:text-brand"
+            key={panel.slug}
+            onClick={() => setActive(index)}
+            type="button"
+          >
+            {panel.title}
+          </button>
+        ))}
+      </fieldset>
+
+      <div
+        className={cn(
+          "grid grid-cols-1 gap-6",
+          COLUMN_CLASS[panels.length] ?? COLUMN_CLASS[3]
+        )}
+      >
+        {panels.map((panel, index) => (
+          <section
+            aria-label={panel.title}
+            className={cn(
+              PANEL_CLASS,
+              index === active ? "block" : "hidden",
+              "lg:block"
+            )}
+            key={panel.slug}
+          >
+            <header className="mb-5 border-border border-b border-dashed pb-3">
+              <Link
+                className="font-display text-[18px] text-foreground leading-[1.25] no-underline transition-colors hover:text-brand"
+                href={panel.href}
+              >
+                {panel.title}
+              </Link>
+            </header>
+            {panel.body}
+          </section>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/blog/src/app/(blog)/compare/page.tsx
+++ b/apps/blog/src/app/(blog)/compare/page.tsx
@@ -1,0 +1,83 @@
+import { cn } from "@howardism/ui/lib/utils";
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { env } from "@/config/env";
+import { resolveCompareIds } from "@/lib/compare-ids";
+
+import { importArticleModule } from "../articles/render-article";
+import { getArticles } from "../articles/service";
+import { CompareView } from "./compare-view";
+
+export const metadata: Metadata = {
+  title: "Compare — Howardism",
+  description:
+    "Read up to three articles side by side to cross-reference them.",
+  alternates: { canonical: `${env.NEXT_PUBLIC_DOMAIN_NAME}/compare` },
+  // URL-driven tool view, not indexable content.
+  robots: { index: false, follow: true },
+};
+
+interface ComparePageProps {
+  searchParams: Promise<{ ids?: string | string[] }>;
+}
+
+function CompareEmpty() {
+  return (
+    <div className="mx-auto max-w-read px-4 py-20 text-center">
+      <h1 className="font-display font-normal text-[22px] text-foreground tracking-[-0.015em]">
+        Nothing to compare.
+      </h1>
+      <p className="mt-3 font-body text-[15px] text-muted-foreground leading-[1.6]">
+        Add up to three article slugs to the URL — e.g.{" "}
+        <code className="rounded-sm bg-muted px-1.5 py-0.5 font-mono text-[13px]">
+          /compare?ids=slug-a,slug-b
+        </code>
+        .
+      </p>
+      <Link
+        className={cn(
+          "mt-6 inline-block font-mono text-[11px] uppercase tracking-[0.16em]",
+          "text-brand no-underline transition-colors hover:text-foreground"
+        )}
+        href="/articles"
+      >
+        Browse all articles →
+      </Link>
+    </div>
+  );
+}
+
+export default async function ComparePage({ searchParams }: ComparePageProps) {
+  const { ids } = await searchParams;
+  const { ids: knownIds } = await getArticles();
+  const slugs = resolveCompareIds(ids, new Set(knownIds));
+
+  if (slugs.length === 0) {
+    return <CompareEmpty />;
+  }
+
+  const panels = await Promise.all(
+    slugs.map(async (slug) => {
+      const mod = await importArticleModule(slug, "en");
+      const Body = mod.default;
+      return {
+        slug,
+        title: mod.meta.title,
+        href: `/articles/${slug}`,
+        body: (
+          <div
+            className={cn(
+              "prose max-w-none",
+              mod.meta.dropCap && "prose-drop-cap"
+            )}
+          >
+            <Body />
+          </div>
+        ),
+      };
+    })
+  );
+
+  return <CompareView panels={panels} />;
+}

--- a/apps/blog/src/lib/compare-ids.ts
+++ b/apps/blog/src/lib/compare-ids.ts
@@ -1,0 +1,31 @@
+/** Most articles a single comparison can hold. */
+export const MAX_COMPARE = 3;
+
+/**
+ * Resolve the `?ids=` query value into a clean, ordered slug list for the
+ * compare view. Parses the comma-separated value, keeps only currently-known
+ * slugs in first-seen order, collapses duplicates, and caps the set at
+ * {@link MAX_COMPARE}. Empty or garbage input yields an empty list, so the
+ * route never errors on bad input.
+ */
+export function resolveCompareIds(
+  rawIds: string | string[] | undefined,
+  knownSlugs: ReadonlySet<string>
+): string[] {
+  if (!rawIds) {
+    return [];
+  }
+  const raw = Array.isArray(rawIds) ? rawIds.join(",") : rawIds;
+  const result: string[] = [];
+  for (const part of raw.split(",")) {
+    const slug = part.trim();
+    if (slug.length === 0 || !knownSlugs.has(slug) || result.includes(slug)) {
+      continue;
+    }
+    result.push(slug);
+    if (result.length === MAX_COMPARE) {
+      break;
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
Closes #847. Fifth slice of the reading-shelf chain (parent #845) — first of Phase 2 (compare).

## What

A standalone comparison view: a URL naming up to 3 articles renders their bodies together for cross-referencing. Independent of the Shelf; demoable by hand-typing a URL.

- **`/compare?ids=a,b,c`** reads the comma-separated slugs, resolves them against the article manifest, and renders each article's body as **bare prose** — reading content only, with no per-article header/resume/footer chrome.
- **Desktop**: parallel scrollable columns (each scrolls on its own). **Mobile/tablet (< lg)**: a tab bar that flips one article into view at a time; all panels stay mounted, so each keeps its scroll position for the session.
- **Graceful degradation**: unknown slugs dropped, duplicates collapsed, set capped at 3; empty or garbage `ids` renders a friendly empty state, never an error.
- The selection lives entirely in the URL → a comparison is shareable and bookmarkable.

New modules: pure `compare-ids` (`resolveCompareIds(rawIds, knownSlugs) → string[]`), the `/compare` route (`page.tsx`), and the client `CompareView` (columns/tabs).

## Decisions

- **This PR is STACKED on #850's PR (base `feature/issue-850-clear-reading-data`, PR #855).** Merge order: **#852 → #853 → #854 → #855 → this**; GitHub auto-retargets as each base merges. The diff shows only the #847 delta. (Note: #847 is logically independent of the Shelf — it only depends on the manifest — but is stacked linearly per the chain plan; #851 will build on it.)
- **Bare-body render path.** Reuses `importArticleModule(slug, "en").default` (the compiled MDX body) wrapped in the same `prose` container the article page uses (`prose max-w-none`, plus `prose-drop-cap` when the article sets it) — but **without** `ArticleLayout`, so none of the per-article chrome renders. The server page builds the bodies (RSC) and passes them as `ReactNode` props into the client `CompareView`, which only arranges columns/tabs.
- **Columns vs tabs at `lg`.** Desktop uses a static grid (`lg:grid-cols-{1,2,3}` chosen from a literal lookup so Tailwind keeps the classes); below `lg` the panels become `hidden` except the active one, with a button group switching them. Keeping all panels mounted (display-toggled) is what preserves each panel's scroll position across tab switches — no manual scroll bookkeeping.
- **Resolution order**: parse → trim → keep known, first-seen, deduped → cap at 3. Accepts a repeated `?ids=` array param (Next can hand `string[]`) by flattening first.
- **`/compare` is dynamic** (`ƒ`) because it reads `searchParams` — expected for a URL-driven tool view; set `noindex`.
- **Lives under `(blog)`** so it inherits the root layout (html/body/fonts/providers) and site nav; the "bare" requirement is about per-article chrome, not the site shell.
- **Anticipated shared-file conflict:** `src/app/(blog)/compare/*` and `src/lib/compare-ids.ts` are the seams #851 (compare selection) builds on — it will add the cross-tab multi-select + "Compare (N)" bar that links into this route.

## Verification

Gates run this session, all green:
- `bun run lint` (ultracite/biome) — pass
- `bun run type-check` (tsc across all packages) — pass
- `bun run test` — pass (blog 152, cli 269). **+9 new**: `compare-ids` (order kept, unknown dropped, duplicates collapsed, capped at 3, whitespace trimmed, empty/missing/garbage → empty, array param flattened) and `CompareView` (renders every body + a tab per article; first tab active, switches on click).
- `bun run build` — pass; `/compare` compiles and is emitted as a dynamic route (`ƒ`), `/shelf` still static (`○`). **Required for this route slice** — the pre-push hook does not run build, so this is the only gate that catches a broken route.

**Not verified this session:** no browser / visual check, no manual hand-typed-URL run, no real multi-article side-by-side scroll test, no verification of per-tab scroll retention in a real browser, no check of duplicate heading-id behavior across columns, no cross-browser/responsive QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
