### PR TITLE
✨ feat(blog): compare selection — cross-tab multi-select + Compare (N) bar (#851)

### DIFF
--- a/apps/blog/src/__tests__/compare/compare-ids.test.ts
+++ b/apps/blog/src/__tests__/compare/compare-ids.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 
-import { resolveCompareIds } from "@/lib/compare-ids";
+import { buildCompareHref, resolveCompareIds } from "@/lib/compare-ids";
 
 const known = new Set(["alpha", "beta", "gamma", "delta"]);
 
@@ -50,5 +50,17 @@ describe("resolveCompareIds", () => {
       "alpha",
       "beta",
     ]);
+  });
+});
+
+describe("buildCompareHref", () => {
+  it("builds the compare URL from a selection", () => {
+    expect(buildCompareHref(["alpha", "beta"])).toBe("/compare?ids=alpha,beta");
+  });
+
+  it("round-trips through resolveCompareIds", () => {
+    const href = buildCompareHref(["alpha", "beta"]);
+    const ids = href.split("ids=")[1];
+    expect(resolveCompareIds(ids, known)).toEqual(["alpha", "beta"]);
   });
 });

--- a/apps/blog/src/__tests__/shelf/shelf-selection.test.tsx
+++ b/apps/blog/src/__tests__/shelf/shelf-selection.test.tsx
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+
+const pushed: string[] = [];
+
+mock.module("next/navigation", () => ({
+  useRouter: () => ({
+    push: (href: string) => pushed.push(href),
+    replace: () => undefined,
+    back: () => undefined,
+    prefetch: () => undefined,
+  }),
+}));
+
+import { ShelfTabs } from "@/app/(blog)/shelf/shelf-tabs";
+import type { ShelfManifestEntry } from "@/lib/shelf-rows";
+
+const COMPARE_BUTTON = /compare \(\d+\)/i;
+
+const manifest: ShelfManifestEntry[] = [
+  {
+    slug: "a",
+    title: "Alpha",
+    label: "AI",
+    href: "/articles/a",
+    archived: false,
+  },
+  {
+    slug: "b",
+    title: "Beta",
+    label: "AI",
+    href: "/articles/b",
+    archived: false,
+  },
+  {
+    slug: "c",
+    title: "Gamma",
+    label: "AI",
+    href: "/articles/c",
+    archived: false,
+  },
+  {
+    slug: "d",
+    title: "Delta",
+    label: "AI",
+    href: "/articles/d",
+    archived: false,
+  },
+  {
+    slug: "e",
+    title: "Echo",
+    label: "AI",
+    href: "/articles/e",
+    archived: false,
+  },
+];
+
+function seedHistory(slugs: string[]): void {
+  localStorage.setItem(
+    "howardism:reading-history",
+    JSON.stringify(
+      slugs.map((slug, index) => ({ slug, pct: 0.5, lastReadAt: 1000 - index }))
+    )
+  );
+}
+
+function seedSaved(slugs: string[]): void {
+  localStorage.setItem(
+    "howardism:reading-saved",
+    JSON.stringify(
+      slugs.map((slug, index) => ({ slug, savedAt: 1000 - index }))
+    )
+  );
+}
+
+const checkbox = (title: string) =>
+  screen.getByRole("checkbox", { name: `Select ${title} to compare` });
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+  pushed.length = 0;
+});
+
+describe("Shelf compare selection", () => {
+  it("keeps a selection across switching between History and Saved tabs", async () => {
+    seedHistory(["a"]);
+    seedSaved(["e"]);
+    render(<ShelfTabs manifest={manifest} />);
+
+    fireEvent.click(
+      await screen.findByRole("checkbox", { name: "Select Alpha to compare" })
+    );
+    expect(screen.getByText("1 selected")).not.toBeNull();
+
+    // Radix tabs activate on focus, not click.
+    fireEvent.focusIn(screen.getByRole("tab", { name: "Saved" }));
+    fireEvent.click(
+      await screen.findByRole("checkbox", { name: "Select Echo to compare" })
+    );
+    expect(screen.getByText("2 selected")).not.toBeNull();
+
+    fireEvent.focusIn(screen.getByRole("tab", { name: "History" }));
+    await waitFor(() =>
+      expect((checkbox("Alpha") as HTMLInputElement).checked).toBe(true)
+    );
+  });
+
+  it("caps the selection at three and prevents a fourth", async () => {
+    seedHistory(["a", "b", "c", "d"]);
+    render(<ShelfTabs manifest={manifest} />);
+
+    fireEvent.click(
+      await screen.findByRole("checkbox", { name: "Select Alpha to compare" })
+    );
+    fireEvent.click(checkbox("Beta"));
+    fireEvent.click(checkbox("Gamma"));
+    expect(screen.getByText("3 selected")).not.toBeNull();
+
+    const fourth = checkbox("Delta") as HTMLInputElement;
+    expect(fourth.disabled).toBe(true);
+    fireEvent.click(fourth);
+    expect(screen.getByText("3 selected")).not.toBeNull();
+  });
+
+  it("navigates to the compare route built from the selection", async () => {
+    seedHistory(["a", "b"]);
+    render(<ShelfTabs manifest={manifest} />);
+
+    fireEvent.click(
+      await screen.findByRole("checkbox", { name: "Select Alpha to compare" })
+    );
+    fireEvent.click(checkbox("Beta"));
+    fireEvent.click(screen.getByRole("button", { name: COMPARE_BUTTON }));
+
+    expect(pushed).toEqual(["/compare?ids=a,b"]);
+  });
+});

--- a/apps/blog/src/app/(blog)/shelf/saved-list.tsx
+++ b/apps/blog/src/app/(blog)/shelf/saved-list.tsx
@@ -8,7 +8,12 @@ import { SaveButton } from "@/components/save-button";
 import { getSaved, type SavedEntry } from "@/lib/reading-store";
 import type { ShelfManifestEntry } from "@/lib/shelf-rows";
 
-import { ArchivedBadge, ShelfArticleRow } from "./shelf-article-row";
+import {
+  ArchivedBadge,
+  type ListSelection,
+  ShelfArticleRow,
+  toRowSelection,
+} from "./shelf-article-row";
 
 dayjs.extend(relativeTime);
 
@@ -17,7 +22,13 @@ dayjs.extend(relativeTime);
  * against the article manifest. Unsaving a row drops it from the list. Saves of
  * a now-missing article are simply not shown (the stored list is untouched).
  */
-export function SavedList({ manifest }: { manifest: ShelfManifestEntry[] }) {
+export function SavedList({
+  manifest,
+  selection,
+}: {
+  manifest: ShelfManifestEntry[];
+  selection?: ListSelection;
+}) {
   const [saved, setSaved] = useState<SavedEntry[] | null>(null);
 
   useEffect(() => {
@@ -67,6 +78,7 @@ export function SavedList({ manifest }: { manifest: ShelfManifestEntry[] }) {
           href={meta.href}
           key={meta.slug}
           label={meta.label}
+          selection={toRowSelection(selection, meta.slug, meta.title)}
           timeText={`saved ${dayjs(entry.savedAt).fromNow()}`}
           title={meta.title}
         />

--- a/apps/blog/src/app/(blog)/shelf/shelf-article-row.tsx
+++ b/apps/blog/src/app/(blog)/shelf/shelf-article-row.tsx
@@ -4,6 +4,42 @@ import type { ReactNode } from "react";
 const META_CLASS =
   "font-mono text-[10.5px] text-foreground-subtle uppercase tracking-[0.16em]";
 
+/** Compare-selection state for a single row; omit to hide the checkbox. */
+export interface RowSelection {
+  /** True when the selection cap is reached and this row isn't selected. */
+  disabled: boolean;
+  /** Accessible label for the checkbox. */
+  label: string;
+  onToggle: () => void;
+  selected: boolean;
+}
+
+/** List-level compare selection shared by both Shelf tabs; omit to disable it. */
+export interface ListSelection {
+  /** True once the selection cap (3) is reached. */
+  atLimit: boolean;
+  onToggleSelect: (slug: string) => void;
+  selectedSlugs: ReadonlySet<string>;
+}
+
+/** Build a row's checkbox state from the shared list selection. */
+export function toRowSelection(
+  selection: ListSelection | undefined,
+  slug: string,
+  title: string
+): RowSelection | undefined {
+  if (!selection) {
+    return;
+  }
+  const selected = selection.selectedSlugs.has(slug);
+  return {
+    selected,
+    disabled: selection.atLimit && !selected,
+    onToggle: () => selection.onToggleSelect(slug),
+    label: `Select ${title} to compare`,
+  };
+}
+
 interface ShelfArticleRowProps {
   /** Optional inline tag after the title (e.g. "archived"). */
   badge?: ReactNode;
@@ -14,6 +50,8 @@ interface ShelfArticleRowProps {
   label: string;
   /** When set (0–1), renders the reading-progress bar and percentage. */
   progress?: number;
+  /** Compare-selection checkbox; omitted when selection is off. */
+  selection?: RowSelection;
   timeText: string;
   title: string;
 }
@@ -31,11 +69,22 @@ export function ShelfArticleRow({
   badge,
   progress,
   control,
+  selection,
 }: ShelfArticleRowProps) {
   const pct = progress === undefined ? null : Math.round(progress * 100);
 
   return (
     <li className="flex items-center gap-2 border-border border-b border-dashed py-4 last:border-b-0">
+      {selection && (
+        <input
+          aria-label={selection.label}
+          checked={selection.selected}
+          className="size-4 shrink-0 accent-brand disabled:opacity-40"
+          disabled={selection.disabled}
+          onChange={selection.onToggle}
+          type="checkbox"
+        />
+      )}
       <Link
         className="group flex min-w-0 flex-1 items-center gap-4 no-underline"
         href={href}

--- a/apps/blog/src/app/(blog)/shelf/shelf-list.tsx
+++ b/apps/blog/src/app/(blog)/shelf/shelf-list.tsx
@@ -11,7 +11,12 @@ import {
   type ShelfRow,
 } from "@/lib/shelf-rows";
 
-import { ArchivedBadge, ShelfArticleRow } from "./shelf-article-row";
+import {
+  ArchivedBadge,
+  type ListSelection,
+  ShelfArticleRow,
+  toRowSelection,
+} from "./shelf-article-row";
 
 dayjs.extend(relativeTime);
 
@@ -62,9 +67,11 @@ function TombstoneRow({
 function HistoryRow({
   row,
   onRemove,
+  selection,
 }: {
   row: ShelfRow;
   onRemove: (slug: string) => void;
+  selection?: ListSelection;
 }) {
   if (row.kind === "deleted") {
     return (
@@ -83,6 +90,7 @@ function HistoryRow({
       href={row.href}
       label={row.label}
       progress={row.pct}
+      selection={toRowSelection(selection, row.slug, row.title)}
       timeText={dayjs(row.lastReadAt).fromNow()}
       title={row.title}
     />
@@ -96,7 +104,13 @@ function HistoryRow({
  * archived reads tagged, deleted reads shown as dismissible tombstones — or a
  * friendly empty state.
  */
-export function ShelfList({ manifest }: { manifest: ShelfManifestEntry[] }) {
+export function ShelfList({
+  manifest,
+  selection,
+}: {
+  manifest: ShelfManifestEntry[];
+  selection?: ListSelection;
+}) {
   const [rows, setRows] = useState<ShelfRow[] | null>(null);
 
   useEffect(() => {
@@ -126,7 +140,12 @@ export function ShelfList({ manifest }: { manifest: ShelfManifestEntry[] }) {
   return (
     <ul className="mt-2 flex list-none flex-col p-0">
       {rows.map((row) => (
-        <HistoryRow key={row.slug} onRemove={handleRemove} row={row} />
+        <HistoryRow
+          key={row.slug}
+          onRemove={handleRemove}
+          row={row}
+          selection={selection}
+        />
       ))}
     </ul>
   );

--- a/apps/blog/src/app/(blog)/shelf/shelf-tabs.tsx
+++ b/apps/blog/src/app/(blog)/shelf/shelf-tabs.tsx
@@ -6,29 +6,110 @@ import {
   TabsList,
   TabsTrigger,
 } from "@howardism/ui/components/tabs";
+import { useRouter } from "next/navigation";
+import { useMemo, useState } from "react";
 
+import { buildCompareHref, MAX_COMPARE } from "@/lib/compare-ids";
 import type { ShelfManifestEntry } from "@/lib/shelf-rows";
 
 import { SavedList } from "./saved-list";
 import { ShelfList } from "./shelf-list";
 
+/** Minimum selection that makes a comparison meaningful. */
+const MIN_COMPARE = 2;
+
+function CompareBar({
+  count,
+  onCompare,
+  onClear,
+}: {
+  count: number;
+  onCompare: () => void;
+  onClear: () => void;
+}) {
+  return (
+    <div className="fixed inset-x-0 bottom-0 z-40 border-border border-t bg-card/95 px-4 py-3 shadow-paper-lg backdrop-blur-sm">
+      <div className="mx-auto flex max-w-wide items-center justify-between gap-4">
+        <span className="font-mono text-[11px] text-foreground-subtle uppercase tracking-[0.16em]">
+          {count} selected
+        </span>
+        <div className="flex items-center gap-2">
+          <button
+            className="rounded-full px-3 py-1.5 font-mono text-[11px] text-foreground-subtle uppercase tracking-[0.16em] transition-colors hover:text-foreground"
+            onClick={onClear}
+            type="button"
+          >
+            Clear
+          </button>
+          <button
+            className="rounded-full bg-brand px-4 py-1.5 font-mono text-[11px] text-white uppercase tracking-[0.16em] transition-opacity hover:opacity-90 disabled:opacity-40"
+            disabled={count < MIN_COMPARE}
+            onClick={onCompare}
+            type="button"
+          >
+            Compare ({count}) →
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 /**
  * The Shelf's tabbed shell: automatic reading History and deliberate Saved
- * lists, both resolved against the same build-time article manifest.
+ * lists, both resolved against the same build-time article manifest. Owns the
+ * cross-tab compare selection (so a History pick and a Saved pick combine),
+ * caps it at three, and launches the comparison via a persistent bar.
  */
 export function ShelfTabs({ manifest }: { manifest: ShelfManifestEntry[] }) {
+  const router = useRouter();
+  const [selected, setSelected] = useState<string[]>([]);
+
+  const selection = useMemo(
+    () => ({
+      selectedSlugs: new Set(selected),
+      atLimit: selected.length >= MAX_COMPARE,
+      onToggleSelect: (slug: string) =>
+        setSelected((current) => {
+          if (current.includes(slug)) {
+            return current.filter((entry) => entry !== slug);
+          }
+          if (current.length >= MAX_COMPARE) {
+            return current;
+          }
+          return [...current, slug];
+        }),
+    }),
+    [selected]
+  );
+
+  const startCompare = () => {
+    if (selected.length >= MIN_COMPARE) {
+      router.push(buildCompareHref(selected));
+    }
+  };
+
   return (
-    <Tabs className="mt-8" defaultValue="history">
-      <TabsList>
-        <TabsTrigger value="history">History</TabsTrigger>
-        <TabsTrigger value="saved">Saved</TabsTrigger>
-      </TabsList>
-      <TabsContent value="history">
-        <ShelfList manifest={manifest} />
-      </TabsContent>
-      <TabsContent value="saved">
-        <SavedList manifest={manifest} />
-      </TabsContent>
-    </Tabs>
+    <>
+      <Tabs className="mt-8" defaultValue="history">
+        <TabsList>
+          <TabsTrigger value="history">History</TabsTrigger>
+          <TabsTrigger value="saved">Saved</TabsTrigger>
+        </TabsList>
+        <TabsContent value="history">
+          <ShelfList manifest={manifest} selection={selection} />
+        </TabsContent>
+        <TabsContent value="saved">
+          <SavedList manifest={manifest} selection={selection} />
+        </TabsContent>
+      </Tabs>
+      {selected.length > 0 && (
+        <CompareBar
+          count={selected.length}
+          onClear={() => setSelected([])}
+          onCompare={startCompare}
+        />
+      )}
+    </>
   );
 }

--- a/apps/blog/src/lib/compare-ids.ts
+++ b/apps/blog/src/lib/compare-ids.ts
@@ -1,6 +1,11 @@
 /** Most articles a single comparison can hold. */
 export const MAX_COMPARE = 3;
 
+/** Build the compare route URL for a selection of slugs. */
+export function buildCompareHref(slugs: readonly string[]): string {
+  return `/compare?ids=${slugs.join(",")}`;
+}
+
 /**
  * Resolve the `?ids=` query value into a clean, ordered slug list for the
  * compare view. Parses the comma-separated value, keeps only currently-known


### PR DESCRIPTION
Closes #851. Sixth and final slice of the reading-shelf chain (parent #845).

## What

Assemble a comparison from the Shelf and launch it — wiring the Shelf to the `/compare` route from #847.

- Each **History and Saved row** gains a **selection checkbox**.
- The selection **spans both tabs**: a history pick and a saved pick combine into one comparison.
- A persistent **"Compare (N) →" bar** reflects the live count of selected items.
- Selection is **capped at 3** in the UI — a 4th checkbox is disabled.
- Activating **Compare** builds `/compare?ids=…` from the selection and navigates to it.

Module addition: `buildCompareHref(slugs) → /compare?ids=…` in the compare module.

## Decisions

- **This PR is STACKED on #847's PR (base `feature/issue-847-compare-route`, PR #856).** Merge order — the full bottom-up chain: **#852 → #853 → #854 → #855 → #856 → this**; GitHub auto-retargets as each base merges. The diff shows only the #851 delta.
- **Selection state is lifted into `ShelfTabs`** (the tabbed shell that owns both lists), which is what makes it survive tab switches — radix `Tabs` unmounts the inactive tab, but the parent's state persists and flows back into each list as props. Both `ShelfList` and `SavedList` take an optional `selection` prop, so they still render standalone (no checkboxes) when it's omitted — existing tests for them are untouched.
- **Cap enforced in the toggle**: once 3 are selected, `onToggleSelect` ignores new slugs and unselected checkboxes render `disabled`. The cap reuses `MAX_COMPARE` from #847's module (no magic number).
- **Tombstone (deleted) rows are not selectable** — there's no body to compare — so the checkbox lives only on the shared `ShelfArticleRow`, not the tombstone row.
- **Compare button activates at ≥2** (a single article isn't a comparison); the bar still shows the live count from 1 so the user sees the selection build.
- **Checkbox is a sibling of the row link**, not nested, keeping the anchor clean (same pattern as the remove/save controls).
- This completes the chain — no further shared-file conflicts to flag downstream.

## Verification

Gates run this session, all green:
- `bun run lint` (ultracite/biome) — pass
- `bun run type-check` (tsc across all packages) — pass
- `bun run test` — pass (blog 157, cli 269). **+5 new**: `buildCompareHref` (builds the URL, round-trips through `resolveCompareIds`); Shelf selection (cross-tab persistence across a History↔Saved switch, cap at 3 with the 4th disabled, navigates to `/compare?ids=…` built from the selection via a mocked router).
- `bun run build` — pass; `/compare` still compiles (dynamic `ƒ`), `/shelf` still static (`○`). **Required for this route slice** — pre-push does not run build.

Note on the selection test: radix `Tabs` activate on focus, not click, so the cross-tab test switches tabs with `fireEvent.focusIn` (no new test dependency added).

**Not verified this session:** no browser / visual check, no manual click-through of selecting across tabs and launching compare in a real browser, no visual review of the fixed Compare bar over content, no cross-browser/responsive QA, no real end-to-end run of select → compare → rendered columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
