### PR TITLE
✨ feat(blog): unify the page layout system (5-phase)

### DIFF
--- a/apps/blog/src/__tests__/articles/article-layout.test.tsx
+++ b/apps/blog/src/__tests__/articles/article-layout.test.tsx
@@ -42,42 +42,34 @@ const BASE_META: ArticleMeta = {
   title: "Test Article",
 };
 
+function hasDropCap(meta: ArticleMeta): boolean {
+  const { container } = render(
+    <ArticleLayout meta={meta} slug="test-article">
+      <p>Article content</p>
+    </ArticleLayout>,
+    { wrapper: Providers }
+  );
+  return Boolean(
+    container.querySelector(".prose")?.classList.contains("prose-drop-cap")
+  );
+}
+
 describe("ArticleLayout drop-cap", () => {
-  it("applies prose-drop-cap class when meta.dropCap === true", () => {
-    const { container } = render(
-      <ArticleLayout meta={{ ...BASE_META, dropCap: true }} slug="test-article">
-        <p>Article content</p>
-      </ArticleLayout>,
-      { wrapper: Providers }
-    );
-    const proseDiv = container.querySelector(".prose");
-    expect(proseDiv).toBeDefined();
-    expect(proseDiv?.classList.contains("prose-drop-cap")).toBe(true);
+  it("applies prose-drop-cap for Essay articles", () => {
+    expect(hasDropCap({ ...BASE_META, tag: "Essay" })).toBe(true);
   });
 
-  it("does not apply prose-drop-cap when meta.dropCap is undefined", () => {
-    const { container } = render(
-      <ArticleLayout meta={BASE_META} slug="test-article">
-        <p>Article content</p>
-      </ArticleLayout>,
-      { wrapper: Providers }
-    );
-    const proseDiv = container.querySelector(".prose");
-    expect(proseDiv).toBeDefined();
-    expect(proseDiv?.classList.contains("prose-drop-cap")).toBe(false);
+  it("does not apply prose-drop-cap for Concept articles", () => {
+    expect(hasDropCap({ ...BASE_META, tag: "Concept" })).toBe(false);
   });
 
-  it("does not apply prose-drop-cap when meta.dropCap === false", () => {
-    const { container } = render(
-      <ArticleLayout
-        meta={{ ...BASE_META, dropCap: false }}
-        slug="test-article"
-      >
-        <p>Article content</p>
-      </ArticleLayout>,
-      { wrapper: Providers }
+  it("does not apply prose-drop-cap for Entity articles", () => {
+    expect(hasDropCap({ ...BASE_META, tag: "Entity" })).toBe(false);
+  });
+
+  it("ignores the legacy meta.dropCap flag (kind decides)", () => {
+    expect(hasDropCap({ ...BASE_META, tag: "Concept", dropCap: true })).toBe(
+      false
     );
-    const proseDiv = container.querySelector(".prose");
-    expect(proseDiv?.classList.contains("prose-drop-cap")).toBe(false);
   });
 });

--- a/apps/blog/src/__tests__/articles/index-row.test.tsx
+++ b/apps/blog/src/__tests__/articles/index-row.test.tsx
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { cleanup, render, screen, within } from "@testing-library/react";
+
+import { IndexRow } from "@/app/(blog)/articles/index-row";
+import type { ArticleEntity, ArticleMeta } from "@/app/(blog)/articles/service";
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
+
+const META: ArticleMeta = {
+  date: "2026-05-06",
+  description: "A description",
+  domain: "ai-engineering",
+  imageAlt: "alt",
+  readingTime: 7,
+  tag: "Concept",
+  tags: ["agents", "loops", "orchestration", "extra"],
+  title: "Alpha Article",
+};
+
+const ARTICLE: ArticleEntity = {
+  heroImage: { src: "/x.png", height: 100, width: 100 },
+  meta: META,
+  position: 0,
+  slug: "alpha",
+};
+
+const TITLE = /Alpha Article/i;
+const SAVE = /save for later/i;
+
+function renderRow(props: Partial<Parameters<typeof IndexRow>[0]> = {}) {
+  return render(
+    <ul>
+      <IndexRow
+        accent="var(--brand)"
+        article={ARTICLE}
+        ordinal={3}
+        {...props}
+      />
+    </ul>
+  );
+}
+
+describe("IndexRow", () => {
+  it("renders the kind-prefixed numeral marker and a link to the article", () => {
+    renderRow({ prefix: "C" });
+    expect(screen.getByText("C03")).toBeDefined();
+    const link = screen.getByRole("link", { name: TITLE });
+    expect(link.getAttribute("href")).toBe("/articles/alpha");
+  });
+
+  it("renders a bare numeral when no prefix is given", () => {
+    renderRow();
+    expect(screen.getByText("03")).toBeDefined();
+  });
+
+  it("shows the date and reading time", () => {
+    const { container } = renderRow();
+    expect(container.textContent).toContain("7′");
+  });
+
+  it("shows subject chips up to the limit with an overflow marker", () => {
+    renderRow();
+    expect(screen.getByText("Agents")).toBeDefined();
+    expect(screen.getByText("Orchestration")).toBeDefined();
+    expect(screen.queryByText("Extra")).toBeNull();
+    expect(screen.getByText("+1")).toBeDefined();
+  });
+
+  it("hides chips when showChips is false", () => {
+    renderRow({ showChips: false });
+    expect(screen.queryByText("Agents")).toBeNull();
+  });
+
+  it("shows the domain label by default and hides it when showDomain is false", () => {
+    const { rerender } = renderRow();
+    expect(screen.getByText("AI Engineering")).toBeDefined();
+
+    rerender(
+      <ul>
+        <IndexRow
+          accent="var(--brand)"
+          article={ARTICLE}
+          ordinal={3}
+          showDomain={false}
+        />
+      </ul>
+    );
+    expect(screen.queryByText("AI Engineering")).toBeNull();
+  });
+
+  it("renders the save button by default and omits it when showSave is false", () => {
+    const { container, rerender } = renderRow();
+    expect(within(container).getByRole("button", { name: SAVE })).toBeDefined();
+
+    rerender(
+      <ul>
+        <IndexRow
+          accent="var(--brand)"
+          article={ARTICLE}
+          ordinal={3}
+          showSave={false}
+        />
+      </ul>
+    );
+    expect(within(container).queryByRole("button", { name: SAVE })).toBeNull();
+  });
+});

--- a/apps/blog/src/__tests__/howardism/page-frame.test.ts
+++ b/apps/blog/src/__tests__/howardism/page-frame.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Phase 5 of the layout unification — the CI guard that keeps the system from
+ * drifting: every public page must take its frame from <PlatePage> (width via
+ * the max-w-read/index/wide tokens, gutter via px-gutter) rather than
+ * hand-rolling it.
+ *
+ * This is deliberately narrower than the handoff's literal grep
+ * (`max-w-[…px]|px-4|px-8`). That pattern also matches legitimate things the
+ * design relies on — content-measure caps like `max-w-[680px]` on a paragraph,
+ * button padding like `px-4` on the header nav, and the global frame's
+ * `sm:px-8` in (blog)/layout.tsx — so it would fail on correct code. Instead we
+ * forbid the two things that actually signal a hand-rolled page frame: a raw
+ * page-container width anywhere, and a raw page gutter on a route entry.
+ */
+
+const BLOG_APP_DIR = join(import.meta.dir, "../../app/(blog)");
+
+/** The former page-container widths — now the read/index/wide tokens. */
+const RAW_PAGE_WIDTH = /max-w-\[(?:720|1120|1280|1320)px\]/;
+/** A raw horizontal page gutter (bare or responsive-prefixed). */
+const RAW_GUTTER = /\bpx-[48]\b/;
+
+function blogFiles(predicate: (path: string) => boolean): string[] {
+  return readdirSync(BLOG_APP_DIR, { recursive: true })
+    .map(String)
+    .filter((rel) => rel.endsWith(".tsx") || rel.endsWith(".ts"))
+    .filter(predicate)
+    .map((rel) => join(BLOG_APP_DIR, rel));
+}
+
+describe("page frame guard", () => {
+  it("never sets a raw page-container width — use max-w-read/index/wide", () => {
+    const offenders = blogFiles(() => true).filter((file) =>
+      RAW_PAGE_WIDTH.test(readFileSync(file, "utf8"))
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  it("never sets a raw gutter on a route entry — render <PlatePage>", () => {
+    const offenders = blogFiles((rel) => rel.endsWith("page.tsx")).filter(
+      (file) => RAW_GUTTER.test(readFileSync(file, "utf8"))
+    );
+    expect(offenders).toEqual([]);
+  });
+});

--- a/apps/blog/src/__tests__/howardism/page-frame.test.ts
+++ b/apps/blog/src/__tests__/howardism/page-frame.test.ts
@@ -23,6 +23,8 @@ const BLOG_APP_DIR = join(import.meta.dir, "../../app/(blog)");
 const RAW_PAGE_WIDTH = /max-w-\[(?:720|1120|1280|1320)px\]/;
 /** A raw horizontal page gutter (bare or responsive-prefixed). */
 const RAW_GUTTER = /\bpx-[48]\b/;
+/** The gutter token's literal value inlined instead of `px-gutter`. */
+const INLINED_GUTTER = /px-\[clamp\(20px,\s*5vw,\s*56px\)\]/;
 
 function blogFiles(predicate: (path: string) => boolean): string[] {
   return readdirSync(BLOG_APP_DIR, { recursive: true })
@@ -43,6 +45,13 @@ describe("page frame guard", () => {
   it("never sets a raw gutter on a route entry — render <PlatePage>", () => {
     const offenders = blogFiles((rel) => rel.endsWith("page.tsx")).filter(
       (file) => RAW_GUTTER.test(readFileSync(file, "utf8"))
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  it("never inlines the gutter token's value — use px-gutter", () => {
+    const offenders = blogFiles(() => true).filter((file) =>
+      INLINED_GUTTER.test(readFileSync(file, "utf8"))
     );
     expect(offenders).toEqual([]);
   });

--- a/apps/blog/src/__tests__/howardism/page-frame.test.ts
+++ b/apps/blog/src/__tests__/howardism/page-frame.test.ts
@@ -24,7 +24,7 @@ const RAW_PAGE_WIDTH = /max-w-\[(?:720|1120|1280|1320)px\]/;
 /** A raw horizontal page gutter (bare or responsive-prefixed). */
 const RAW_GUTTER = /\bpx-[48]\b/;
 /** The gutter token's literal value inlined instead of `px-gutter`. */
-const INLINED_GUTTER = /px-\[clamp\(20px,\s*5vw,\s*56px\)\]/;
+const INLINED_GUTTER = /px-\[clamp\(20px,\s*5vw,\s*72px\)\]/;
 
 function blogFiles(predicate: (path: string) => boolean): string[] {
   return readdirSync(BLOG_APP_DIR, { recursive: true })

--- a/apps/blog/src/app/(blog)/(layout)/footer.tsx
+++ b/apps/blog/src/app/(blog)/(layout)/footer.tsx
@@ -18,7 +18,7 @@ const SOCIAL_LABEL: Record<string, string> = {
 
 export function Footer() {
   return (
-    <footer className="mt-auto border-border border-t border-dashed px-4 pt-6 pb-8">
+    <footer className="mt-auto border-border border-t border-dashed px-gutter pt-6 pb-8">
       <div className="mx-auto flex max-w-[960px] flex-col gap-4">
         {/* Nav row */}
         <nav aria-label="footer">

--- a/apps/blog/src/app/(blog)/[locale]/articles/page.tsx
+++ b/apps/blog/src/app/(blog)/[locale]/articles/page.tsx
@@ -21,7 +21,7 @@ export const metadata: Metadata = {
 export default async function ZhArticlesIndex() {
   const links = await getTranslatedArticleLinks();
   return (
-    <div className="hw-page-enter mx-auto max-w-[720px] px-4 py-16">
+    <div className="hw-page-enter mx-auto max-w-read px-gutter py-16">
       <header className="mb-10 border-border border-b pb-6">
         <p className="font-mono text-[10.5px] text-foreground-subtle uppercase tracking-[0.22em]">
           機器翻譯 · machine-translated

--- a/apps/blog/src/app/(blog)/_shell/plate-page.tsx
+++ b/apps/blog/src/app/(blog)/_shell/plate-page.tsx
@@ -1,0 +1,120 @@
+import { cn } from "@howardism/ui/lib/utils";
+import type { CSSProperties, ReactNode } from "react";
+
+import { DiscPageHeader } from "@/components/howardism/disc-page-header";
+import { DomainLabel } from "@/components/howardism/domain-label";
+
+import type { ArticleDomain } from "../articles/service";
+import { PLATE_META, type PlateKey } from "../plate-meta";
+
+const VOLUME = "Howardism · Vol. 03";
+
+const WIDTH_CLASS = {
+  read: "max-w-read",
+  index: "max-w-index",
+  wide: "max-w-wide",
+} as const;
+
+interface PlatePageProps {
+  /** Domain/kind tint for the compact header. */
+  accent?: string;
+  /** Body owns its own horizontal gutter (full-bleed banded sections). */
+  bleed?: boolean;
+  children: ReactNode;
+  /** Plate II leaf — surfaces "Plate II · {domain}" in the compact eyebrow. */
+  domain?: ArticleDomain;
+  /** Override the right eyebrow (reader badges + brand). */
+  eyebrowEnd?: ReactNode;
+  /** "none" lets the page render its own header (e.g. the article reader). */
+  header?: "full" | "compact" | "none";
+  /** Rendered under the header DataGrid (intro copy, save button). */
+  headerChildren?: ReactNode;
+  headerData?: [string, ReactNode][];
+  plate: PlateKey;
+  /** Reading column: `max-w-read` widening to `max-w-index` at the rail bp. */
+  rail?: boolean;
+  stackData?: boolean;
+  /** Merged onto the outer container (e.g. the reader's --article-accent). */
+  style?: CSSProperties;
+  /** Defaults to the plate's canonical title. */
+  title?: string;
+  titleAccent?: ReactNode;
+  /** Semantic content width; ignored when `rail` is set. */
+  width: "read" | "index" | "wide";
+}
+
+/**
+ * The single page shell every public blog route renders through. It owns the
+ * content width (one of three semantic stops), the responsive page gutter, the
+ * page-enter animation, and — unless `header="none"` — the shared
+ * `DiscPageHeader`, numbered from the plate taxonomy.
+ */
+export function PlatePage({
+  width,
+  plate,
+  domain,
+  header = "full",
+  title,
+  titleAccent,
+  accent,
+  headerData,
+  headerChildren,
+  eyebrowEnd,
+  stackData,
+  rail = false,
+  bleed = false,
+  style,
+  children,
+}: PlatePageProps) {
+  const meta = PLATE_META[plate];
+  const widthClass = rail ? "max-w-read rail:max-w-index" : WIDTH_CLASS[width];
+
+  let headerNode: ReactNode = null;
+  if (header !== "none") {
+    const eyebrowStart =
+      header === "compact" && domain ? (
+        <>
+          {meta.label}
+          <span aria-hidden="true" className="mx-1.5">
+            ·
+          </span>
+          <DomainLabel domain={domain} />
+        </>
+      ) : (
+        VOLUME
+      );
+    headerNode = (
+      <DiscPageHeader
+        accent={accent}
+        data={headerData}
+        eyebrowEnd={eyebrowEnd ?? `${meta.label} · No. ${meta.number}`}
+        eyebrowStart={eyebrowStart}
+        stackData={stackData}
+        title={title ?? meta.title}
+        titleAccent={titleAccent}
+        variant={header}
+      >
+        {headerChildren}
+      </DiscPageHeader>
+    );
+  }
+
+  if (bleed) {
+    return (
+      <div className={cn("hw-page-enter mx-auto", widthClass)} style={style}>
+        {headerNode && <div className="px-gutter">{headerNode}</div>}
+        {children}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn("hw-page-enter mx-auto px-gutter pb-20", widthClass)}
+      style={style}
+    >
+      {headerNode}
+      {children}
+    </div>
+  );
+}

--- a/apps/blog/src/app/(blog)/articles/[slug]/article-layout.tsx
+++ b/apps/blog/src/app/(blog)/articles/[slug]/article-layout.tsx
@@ -11,7 +11,9 @@ import { SubjectChipList } from "@/components/howardism/subject-chip-list";
 import { SaveButton } from "@/components/save-button";
 import { formatDate } from "@/utils/time";
 import { PlatePage } from "../../_shell/plate-page";
+import { PLATE_META } from "../../plate-meta";
 import { DOMAIN_META } from "../domain-meta";
+import { kindHasDropCap } from "../kind-meta";
 import type {
   ArticleHeading,
   ArticleMeta,
@@ -126,7 +128,7 @@ export function ArticleLayout({
             }
             eyebrowStart={
               <>
-                Plate II
+                {PLATE_META.domains.label}
                 {meta.domain && (
                   <>
                     <span aria-hidden="true" className="mx-1.5">
@@ -162,7 +164,7 @@ export function ArticleLayout({
             <div
               className={cn(
                 "prose max-w-none",
-                meta.dropCap && "prose-drop-cap"
+                kindHasDropCap(meta.tag) && "prose-drop-cap"
               )}
               data-article-body
             >

--- a/apps/blog/src/app/(blog)/articles/[slug]/article-layout.tsx
+++ b/apps/blog/src/app/(blog)/articles/[slug]/article-layout.tsx
@@ -5,12 +5,12 @@ import Link from "next/link";
 import type { CSSProperties, ReactNode } from "react";
 
 import { PublishArticleNav } from "@/components/article-nav-context";
-import { DataGrid } from "@/components/howardism/data-grid";
+import { DiscPageHeader } from "@/components/howardism/disc-page-header";
 import { DomainLabel } from "@/components/howardism/domain-label";
-import { HalfDisc } from "@/components/howardism/half-disc";
 import { SubjectChipList } from "@/components/howardism/subject-chip-list";
 import { SaveButton } from "@/components/save-button";
 import { formatDate } from "@/utils/time";
+import { PlatePage } from "../../_shell/plate-page";
 import { DOMAIN_META } from "../domain-meta";
 import type {
   ArticleHeading,
@@ -83,29 +83,23 @@ export function ArticleLayout({
   ];
 
   return (
-    <div
-      className="hw-page-enter mx-auto max-w-read rail:max-w-wide px-4 pb-20"
+    <PlatePage
+      header="none"
+      plate="domains"
+      rail
       style={{ "--article-accent": accent } as CSSProperties}
+      width="index"
     >
       <PublishArticleNav headings={headings} slug={slug} />
       <TapScrollZones />
       <ResumeReading headings={headings} slug={slug} />
       <div className="grid rail:grid-cols-[minmax(0,720px)_320px] gap-12">
         <div className="min-w-0">
-          <div className="relative mb-10 overflow-hidden border-t-[3px] border-t-[var(--article-accent)] border-b border-b-border border-double pt-2.5 pb-10">
-            <div className="mb-7 flex items-baseline justify-between gap-4">
-              <span className={cn(EYEBROW_CLASS, "inline-flex items-center")}>
-                Plate II
-                {meta.domain && (
-                  <>
-                    <span aria-hidden="true" className="mx-1.5">
-                      ·
-                    </span>
-                    <DomainLabel domain={meta.domain} />
-                  </>
-                )}
-              </span>
-              <span className="inline-flex items-center gap-2">
+          <DiscPageHeader
+            accent={accent}
+            data={metaRows}
+            eyebrowEnd={
+              <>
                 {locale === "zh-TW" && (
                   <span className="rounded-sm border border-border px-1.5 py-0.5 font-mono text-[9.5px] text-foreground-subtle uppercase tracking-[0.18em]">
                     機器翻譯 · machine-translated
@@ -127,31 +121,30 @@ export function ArticleLayout({
                     {locale === "zh-TW" ? "EN" : "中文"}
                   </Link>
                 )}
-                <span className={EYEBROW_CLASS}>HOWARDISM</span>
-              </span>
-            </div>
+                HOWARDISM
+              </>
+            }
+            eyebrowStart={
+              <>
+                Plate II
+                {meta.domain && (
+                  <>
+                    <span aria-hidden="true" className="mx-1.5">
+                      ·
+                    </span>
+                    <DomainLabel domain={meta.domain} />
+                  </>
+                )}
+              </>
+            }
+            stackData
+            title={meta.title}
+            variant="compact"
+          >
+            <SaveButton showLabel slug={slug} />
+          </DiscPageHeader>
 
-            <div className="grid grid-cols-[1fr_auto] items-start gap-x-8">
-              <div>
-                <h1 className="mb-5 font-display font-normal text-[27px] text-foreground leading-[1.25] tracking-[-0.015em]">
-                  {meta.title}
-                </h1>
-                <DataGrid maxWidth={280} rows={metaRows} stack />
-                <div className="mt-5">
-                  <SaveButton showLabel slug={slug} />
-                </div>
-              </div>
-
-              <div
-                aria-hidden="true"
-                className="relative -mt-2.5 -mr-4 shrink-0"
-              >
-                <HalfDisc align="right" size={140} />
-              </div>
-            </div>
-          </div>
-
-          <p className="mb-8 border-[var(--article-accent)] border-l-2 pl-4 font-body text-base text-muted-foreground italic leading-[1.65]">
+          <p className="mt-10 mb-8 border-[var(--article-accent)] border-l-2 pl-4 font-body text-base text-muted-foreground italic leading-[1.65]">
             {meta.description}
           </p>
 
@@ -242,6 +235,6 @@ export function ArticleLayout({
 
         <ArticleRail headings={headings} slug={slug} />
       </div>
-    </div>
+    </PlatePage>
   );
 }

--- a/apps/blog/src/app/(blog)/articles/articles-table.tsx
+++ b/apps/blog/src/app/(blog)/articles/articles-table.tsx
@@ -1,11 +1,17 @@
-import { InternalLink } from "@/components/internal-link";
-import { SaveButton } from "@/components/save-button";
-import { formatDateShort } from "@/utils/time";
-
+import { IndexRow } from "./index-row";
+import { kindMetaFor } from "./kind-meta";
 import type { ArticleEntity } from "./service";
 
+const NO_NAVIGABLE: ReadonlySet<string> = new Set();
+
 interface ArticlesTableProps {
+  /** Uniform numeral tint (e.g. a domain color); defaults to per-row kind. */
+  accent?: string;
   articles: ArticleEntity[];
+  /** Subject tags with their own page — decides which chips link. */
+  navigable?: ReadonlySet<string>;
+  /** Show the domain column — false on single-domain (domain) pages. */
+  showDomain?: boolean;
   /**
    * Caption rendered for screen readers describing the rows. Defaults to a
    * generic article-listing caption.
@@ -20,6 +26,9 @@ export function ArticlesTable({
   articles,
   srCaption = DEFAULT_SR_CAPTION,
   title,
+  accent,
+  showDomain = true,
+  navigable = NO_NAVIGABLE,
 }: ArticlesTableProps) {
   return (
     <section>
@@ -33,46 +42,23 @@ export function ArticlesTable({
           </span>
         </header>
       ) : null}
-      <table className="w-full border-collapse">
-        <caption className="sr-only">{srCaption}</caption>
-        <thead className="sr-only">
-          <tr>
-            <th scope="col">Title</th>
-            <th scope="col">Summary</th>
-            <th scope="col">Date</th>
-            <th scope="col">Save</th>
-          </tr>
-        </thead>
-        <tbody>
-          {articles.map((article) => (
-            <tr
-              className="border-border border-b align-baseline last:border-b-0"
+      <ol aria-label={srCaption} className="m-0 list-none p-0">
+        {articles.map((article, i) => {
+          const kind = kindMetaFor(article.meta.tag);
+          return (
+            <IndexRow
+              accent={accent ?? kind.color}
+              article={article}
+              first={i === 0}
               key={article.slug}
-            >
-              <td className="w-[34%] py-3.5 pr-6 align-baseline">
-                <InternalLink
-                  className="font-display font-medium text-[16px] text-foreground no-underline transition-colors hover:text-brand"
-                  href={`/articles/${article.slug}`}
-                  previewMeta={article.meta}
-                >
-                  {article.meta.title}
-                </InternalLink>
-              </td>
-              <td className="py-3.5 pr-6 align-baseline font-body text-[14px] text-muted-foreground leading-[1.45]">
-                {article.meta.description}
-              </td>
-              <td className="w-[110px] whitespace-nowrap py-3.5 text-right align-baseline font-mono text-[11px] text-foreground-subtle uppercase tracking-[0.14em]">
-                <time dateTime={article.meta.date}>
-                  {formatDateShort(article.meta.date)}
-                </time>
-              </td>
-              <td className="w-[36px] py-3.5 pl-1 text-right align-baseline">
-                <SaveButton slug={article.slug} />
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+              navigable={navigable}
+              ordinal={i + 1}
+              prefix={kind.prefix}
+              showDomain={showDomain}
+            />
+          );
+        })}
+      </ol>
     </section>
   );
 }

--- a/apps/blog/src/app/(blog)/articles/domain/[domain]/page.tsx
+++ b/apps/blog/src/app/(blog)/articles/domain/[domain]/page.tsx
@@ -12,6 +12,7 @@ import { importArticleModule } from "../../render-article";
 import {
   articleExists,
   getArticlesByDomain,
+  getNavigableTagSet,
   getOpenQuestionsByDomain,
 } from "../../service";
 
@@ -57,10 +58,11 @@ export default async function DomainPage({ params }: DomainPageProps) {
 
   const meta = DOMAIN_META[resolved];
   const mocSlug = `moc-${resolved}`;
-  const [articles, openQuestions, hasMoc] = await Promise.all([
+  const [articles, openQuestions, hasMoc, navigable] = await Promise.all([
     getArticlesByDomain(resolved),
     Promise.resolve(getOpenQuestionsByDomain(resolved)),
     articleExists(mocSlug),
+    getNavigableTagSet(),
   ]);
   // Render the curated Map of Content inline when one exists; the `syntheses`
   // domain has no MOC, so it falls back to the date-sorted notes table.
@@ -98,7 +100,10 @@ export default async function DomainPage({ params }: DomainPageProps) {
         </div>
       ) : (
         <ArticlesTable
+          accent={meta.color}
           articles={articles}
+          navigable={navigable}
+          showDomain={false}
           srCaption={`${meta.label} articles, sorted by date, newest first.`}
         />
       )}

--- a/apps/blog/src/app/(blog)/articles/domain/[domain]/page.tsx
+++ b/apps/blog/src/app/(blog)/articles/domain/[domain]/page.tsx
@@ -88,7 +88,7 @@ export default async function DomainPage({ params }: DomainPageProps) {
       plate="domains"
       title={`${meta.label},`}
       titleAccent="in order."
-      width="index"
+      width="wide"
     >
       <p className="mt-10 mb-12 max-w-[60ch] font-body text-[15px] text-muted-foreground leading-[1.6]">
         {meta.blurb}

--- a/apps/blog/src/app/(blog)/articles/domain/[domain]/page.tsx
+++ b/apps/blog/src/app/(blog)/articles/domain/[domain]/page.tsx
@@ -1,10 +1,10 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
-import { DiscPageHeader } from "@/components/howardism/disc-page-header";
 import { env } from "@/config/env";
 import { formatDateShort } from "@/utils/time";
 
+import { PlatePage } from "../../../_shell/plate-page";
 import { ArticlesTable } from "../../articles-table";
 import { DOMAIN_META, DOMAIN_ORDER, resolveDomain } from "../../domain-meta";
 import { OpenQuestionsSection } from "../../open-questions-section";
@@ -75,22 +75,19 @@ export default async function DomainPage({ params }: DomainPageProps) {
   );
 
   return (
-    <div className="hw-page-enter mx-auto max-w-[1120px] px-8 pb-20">
-      <DiscPageHeader
-        data={[
-          ["Notes", String(articles.length)],
-          ["Domain", meta.label],
-          ["Open Qs", String(openCount)],
-          ["Newest", newestDate ? formatDateShort(newestDate) : "—"],
-          ["Oldest", oldestDate ? formatDateShort(oldestDate) : "—"],
-        ]}
-        number="02"
-        plate="Plate II"
-        title={`${meta.label},`}
-        titleAccent="in order."
-        volume="Howardism · Vol. 03"
-      />
-
+    <PlatePage
+      headerData={[
+        ["Notes", String(articles.length)],
+        ["Domain", meta.label],
+        ["Open Qs", String(openCount)],
+        ["Newest", newestDate ? formatDateShort(newestDate) : "—"],
+        ["Oldest", oldestDate ? formatDateShort(oldestDate) : "—"],
+      ]}
+      plate="domains"
+      title={`${meta.label},`}
+      titleAccent="in order."
+      width="index"
+    >
       <p className="mt-10 mb-12 max-w-[60ch] font-body text-[15px] text-muted-foreground leading-[1.6]">
         {meta.blurb}
       </p>
@@ -111,6 +108,6 @@ export default async function DomainPage({ params }: DomainPageProps) {
         concepts={openQuestions}
         heading="Open questions"
       />
-    </div>
+    </PlatePage>
   );
 }

--- a/apps/blog/src/app/(blog)/articles/filter-bar.tsx
+++ b/apps/blog/src/app/(blog)/articles/filter-bar.tsx
@@ -19,7 +19,7 @@ const ACTIVE = "border-current border-b pb-0.5 text-brand italic";
  */
 export function FilterBar({ sectionSlugs }: FilterBarProps) {
   return (
-    <div className="border-border border-b bg-card/40 px-[clamp(20px,5vw,56px)] py-5">
+    <div className="border-border border-b bg-card/40 px-gutter py-5">
       <div className="grid grid-cols-[88px_1fr] items-baseline gap-x-6 gap-y-2.5">
         <span className={ROW_LABEL}>Filed under</span>
         <div className="flex flex-wrap gap-x-6 gap-y-1.5">

--- a/apps/blog/src/app/(blog)/articles/index-row.tsx
+++ b/apps/blog/src/app/(blog)/articles/index-row.tsx
@@ -1,0 +1,116 @@
+import { cn } from "@howardism/ui/lib/utils";
+
+import { DomainLabel } from "@/components/howardism/domain-label";
+import { SubjectChipList } from "@/components/howardism/subject-chip-list";
+import { InternalLink } from "@/components/internal-link";
+import { SaveButton } from "@/components/save-button";
+import { formatDateShort } from "@/utils/time";
+
+import type { ArticleEntity } from "./service";
+
+const NO_NAVIGABLE: ReadonlySet<string> = new Set();
+
+interface IndexRowProps {
+  /** Numeral tint (domain or kind color). */
+  accent: string;
+  article: ArticleEntity;
+  density?: "comfortable" | "compact";
+  /** First row in its list — gets the accent top rule instead of a hairline. */
+  first?: boolean;
+  /** Subject tags with their own page — decides which chips link. */
+  navigable?: ReadonlySet<string>;
+  /** 1-based position within its list — rendered as the numeral marker. */
+  ordinal: number;
+  /** Kind letter before the ordinal (C / E / S / I); omit for a bare numeral. */
+  prefix?: string;
+  /** Show subject chips under the title. */
+  showChips?: boolean;
+  /** Show the domain label column (hide on single-domain pages). */
+  showDomain?: boolean;
+  /** Show the trailing save button. */
+  showSave?: boolean;
+}
+
+const META_CLASS =
+  "whitespace-nowrap font-mono text-[10.5px] text-foreground-subtle uppercase tracking-[0.12em]";
+
+/**
+ * The single article-list row, used by every index on the blog. Five facts,
+ * left to right: numeral marker · title (+ subject chips) · domain · date ·
+ * reading · save. Columns toggle by prop so one component renders the home
+ * plates, the kind plates, and the domain/tag listings.
+ */
+export function IndexRow({
+  article,
+  ordinal,
+  accent,
+  prefix,
+  navigable = NO_NAVIGABLE,
+  showDomain = true,
+  showChips = true,
+  showSave = true,
+  density = "comfortable",
+  first = false,
+}: IndexRowProps) {
+  const { meta, slug } = article;
+  const compact = density === "compact";
+  const tags = meta.tags ?? [];
+
+  return (
+    <li
+      className={cn(
+        "grid grid-cols-[auto_1fr_auto] items-baseline gap-x-4",
+        compact ? "py-2.5" : "py-3.5"
+      )}
+      style={{
+        borderTop: first ? `2px solid ${accent}` : "1px solid var(--border)",
+      }}
+    >
+      <span
+        className={cn(
+          "font-display font-light leading-[0.9] tracking-[-0.03em]",
+          compact ? "text-[22px]" : "text-[28px]"
+        )}
+        style={{ color: accent }}
+      >
+        {prefix}
+        {String(ordinal).padStart(2, "0")}
+      </span>
+
+      <div className="min-w-0">
+        <InternalLink
+          className={cn(
+            "font-display font-medium text-foreground tracking-[-0.012em] no-underline transition-colors hover:text-brand",
+            compact ? "text-[16px] leading-[1.25]" : "text-[19px] leading-[1.2]"
+          )}
+          href={`/articles/${slug}`}
+          previewMeta={meta}
+        >
+          {meta.title}
+        </InternalLink>
+        {showChips && tags.length > 0 && (
+          <div className="mt-1.5">
+            <SubjectChipList limit={3} navigable={navigable} tags={tags} />
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-baseline gap-x-4">
+        {showDomain && meta.domain && (
+          <span className={cn(META_CLASS, "hidden sm:inline")}>
+            <DomainLabel domain={meta.domain} />
+          </span>
+        )}
+        <span className={cn(META_CLASS, "text-right tabular-nums")}>
+          <time dateTime={meta.date}>{formatDateShort(meta.date)}</time> ·{" "}
+          {meta.readingTime}′
+        </span>
+        {showSave && (
+          <span className="-translate-y-0.5">
+            <SaveButton slug={slug} />
+          </span>
+        )}
+      </div>
+    </li>
+  );
+}

--- a/apps/blog/src/app/(blog)/articles/kind-meta.ts
+++ b/apps/blog/src/app/(blog)/articles/kind-meta.ts
@@ -18,3 +18,17 @@ export const KIND_META: Record<TagSectionSlug, KindMeta> = {
   essay: { prefix: "S", color: "var(--domain-syntheses)" },
   index: { prefix: "I", color: "var(--foreground-subtle)" },
 };
+
+/**
+ * Resolve an article's `meta.tag` (e.g. "Essay") to its kind vocabulary.
+ * Falls back to the neutral `index` kind for anything unrecognised.
+ */
+export function kindMetaFor(tag: string | undefined): KindMeta {
+  const key = (tag ?? "").toLowerCase();
+  return KIND_META[key as TagSectionSlug] ?? KIND_META.index;
+}
+
+/** Whether an article kind earns a drop-cap (essays only). */
+export function kindHasDropCap(tag: string | undefined): boolean {
+  return (tag ?? "").toLowerCase() === "essay";
+}

--- a/apps/blog/src/app/(blog)/articles/kind-plate.tsx
+++ b/apps/blog/src/app/(blog)/articles/kind-plate.tsx
@@ -1,9 +1,4 @@
-import { DomainLabel } from "@/components/howardism/domain-label";
-import { SubjectChipList } from "@/components/howardism/subject-chip-list";
-import { InternalLink } from "@/components/internal-link";
-import { SaveButton } from "@/components/save-button";
-import { formatDateShort } from "@/utils/time";
-
+import { IndexRow } from "./index-row";
 import { KIND_META } from "./kind-meta";
 import type { ArticleEntity } from "./service";
 import type { TagSectionSlug } from "./tag-sections";
@@ -40,7 +35,7 @@ export function KindPlate({
 
   return (
     <section
-      className="border-border border-b px-[clamp(20px,5vw,56px)] py-10"
+      className="border-border border-b px-gutter py-10"
       id={slug}
       style={banded ? { background: "var(--card)" } : undefined}
     >
@@ -77,78 +72,19 @@ export function KindPlate({
             </em>
           </h2>
 
-          <table className="mt-5 w-full border-collapse">
-            <caption className="sr-only">
-              {title} articles, sorted by date, newest first.
-            </caption>
-            <thead className="sr-only">
-              <tr>
-                <th scope="col">Index</th>
-                <th scope="col">Title</th>
-                <th scope="col">Domain</th>
-                <th scope="col">Date</th>
-                <th scope="col">Save</th>
-              </tr>
-            </thead>
-            <tbody>
-              {visible.map((article, i) => (
-                <tr
-                  className="align-baseline"
-                  key={article.slug}
-                  style={{
-                    borderTop:
-                      i === 0
-                        ? `2px solid ${meta.color}`
-                        : "1px solid var(--border)",
-                  }}
-                >
-                  <td className="w-[58px] py-3.5 align-baseline">
-                    <span
-                      className="font-display font-light text-[28px] leading-[0.9] tracking-[-0.03em]"
-                      style={{ color: meta.color }}
-                    >
-                      {meta.prefix}
-                      {String(i + 1).padStart(2, "0")}
-                    </span>
-                  </td>
-                  <td className="py-3.5 pr-6 align-baseline">
-                    <InternalLink
-                      className="font-display font-medium text-[19px] text-foreground leading-[1.2] tracking-[-0.013em] no-underline transition-colors hover:text-brand"
-                      href={`/articles/${article.slug}`}
-                      previewMeta={article.meta}
-                    >
-                      {article.meta.title}
-                    </InternalLink>
-                    {article.meta.tags && article.meta.tags.length > 0 && (
-                      <div className="mt-1.5">
-                        <SubjectChipList
-                          limit={3}
-                          navigable={navigable}
-                          tags={article.meta.tags}
-                        />
-                      </div>
-                    )}
-                  </td>
-                  <td className="w-[150px] py-3.5 pr-6 align-baseline">
-                    {article.meta.domain && (
-                      <span className="whitespace-nowrap font-mono text-[10px] text-foreground-subtle uppercase tracking-[0.12em]">
-                        <DomainLabel domain={article.meta.domain} />
-                      </span>
-                    )}
-                  </td>
-                  <td className="w-[150px] whitespace-nowrap py-3.5 text-right align-baseline font-mono text-[10.5px] text-foreground-subtle uppercase tracking-[0.12em]">
-                    <time dateTime={article.meta.date}>
-                      {formatDateShort(article.meta.date)}
-                    </time>{" "}
-                    · {article.meta.readingTime}′
-                  </td>
-                  <td className="w-[36px] py-3.5 pl-1 text-right align-baseline">
-                    <SaveButton slug={article.slug} />
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+          <ol className="m-0 mt-5 list-none p-0">
+            {visible.map((article, i) => (
+              <IndexRow
+                accent={meta.color}
+                article={article}
+                first={i === 0}
+                key={article.slug}
+                navigable={navigable}
+                ordinal={i + 1}
+                prefix={meta.prefix}
+              />
+            ))}
+          </ol>
 
           {articles.length > visible.length && (
             <a

--- a/apps/blog/src/app/(blog)/articles/page.tsx
+++ b/apps/blog/src/app/(blog)/articles/page.tsx
@@ -69,7 +69,7 @@ export default async function ArticlesIndex() {
       plate="articles"
       title="Writing,"
       titleAccent="in order."
-      width="index"
+      width="wide"
     >
       <FilterBar
         sectionSlugs={populated.map(({ section }) => ({

--- a/apps/blog/src/app/(blog)/articles/page.tsx
+++ b/apps/blog/src/app/(blog)/articles/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
 
-import { DiscPageHeader } from "@/components/howardism/disc-page-header";
 import { env } from "@/config/env";
 import { formatDateShort } from "@/utils/time";
 
+import { PlatePage } from "../_shell/plate-page";
 import { FilterBar } from "./filter-bar";
 import { KindPlate } from "./kind-plate";
 import {
@@ -51,29 +51,26 @@ export default async function ArticlesIndex() {
   const oldestDate = visible.entities[visible.ids.at(-1) ?? ""]?.meta.date;
 
   return (
-    <div className="hw-page-enter mx-auto max-w-index">
-      <div className="px-[clamp(20px,5vw,56px)]">
-        <DiscPageHeader
-          data={[
-            ["Pieces", String(total)],
-            ["Sections", String(populated.length)],
-            ["Oldest", oldestDate ? formatDateShort(oldestDate) : "—"],
-            ["Newest", newestDate ? formatDateShort(newestDate) : "—"],
-          ]}
-          number="02"
-          plate="Plate II"
-          title="Writing,"
-          titleAccent="in order."
-          volume="Howardism · Vol. 03"
-        >
-          <p className="mt-6 max-w-[680px] font-body text-[clamp(16px,2.2vw,18px)] text-muted-foreground leading-[1.55]">
-            Every article in the wiki, grouped by kind: <em>Concept</em> notes,{" "}
-            <em>Entity</em> profiles, and <em>Essay</em> pieces. Hover any title
-            for a preview; click to enter.
-          </p>
-        </DiscPageHeader>
-      </div>
-
+    <PlatePage
+      bleed
+      headerChildren={
+        <p className="mt-6 max-w-[680px] font-body text-[clamp(16px,2.2vw,18px)] text-muted-foreground leading-[1.55]">
+          Every article in the wiki, grouped by kind: <em>Concept</em> notes,{" "}
+          <em>Entity</em> profiles, and <em>Essay</em> pieces. Hover any title
+          for a preview; click to enter.
+        </p>
+      }
+      headerData={[
+        ["Pieces", String(total)],
+        ["Sections", String(populated.length)],
+        ["Oldest", oldestDate ? formatDateShort(oldestDate) : "—"],
+        ["Newest", newestDate ? formatDateShort(newestDate) : "—"],
+      ]}
+      plate="articles"
+      title="Writing,"
+      titleAccent="in order."
+      width="index"
+    >
       <FilterBar
         sectionSlugs={populated.map(({ section }) => ({
           slug: section.slug,
@@ -96,6 +93,6 @@ export default async function ArticlesIndex() {
       ))}
 
       <TagIndex tags={tagIndex} />
-    </div>
+    </PlatePage>
   );
 }

--- a/apps/blog/src/app/(blog)/articles/tag-index.tsx
+++ b/apps/blog/src/app/(blog)/articles/tag-index.tsx
@@ -17,10 +17,7 @@ export function TagIndex({ tags }: TagIndexProps) {
   }
 
   return (
-    <section
-      className="border-border border-b px-[clamp(20px,5vw,56px)] py-10"
-      id="subjects"
-    >
+    <section className="border-border border-b px-gutter py-10" id="subjects">
       <div className="grid grid-cols-1 gap-x-11 gap-y-7 lg:grid-cols-[180px_1fr]">
         <div>
           <div className="font-medium font-mono text-[10.5px] text-brand uppercase tracking-[0.22em]">

--- a/apps/blog/src/app/(blog)/articles/tag/[tag]/page.tsx
+++ b/apps/blog/src/app/(blog)/articles/tag/[tag]/page.tsx
@@ -6,6 +6,7 @@ import { formatDateShort } from "@/utils/time";
 
 import { PlatePage } from "../../../_shell/plate-page";
 import { ArticlesTable } from "../../articles-table";
+import { getNavigableTagSet } from "../../service";
 import {
   getSectionArticles,
   resolveTagSection,
@@ -51,7 +52,10 @@ export default async function TagPage({ params }: TagPageProps) {
     notFound();
   }
 
-  const articles = await getSectionArticles(section);
+  const [articles, navigable] = await Promise.all([
+    getSectionArticles(section),
+    getNavigableTagSet(),
+  ]);
   const newestDate = articles.at(0)?.meta.date;
   const oldestDate = articles.at(-1)?.meta.date;
 
@@ -74,6 +78,7 @@ export default async function TagPage({ params }: TagPageProps) {
 
       <ArticlesTable
         articles={articles}
+        navigable={navigable}
         srCaption={`${section.title} articles, sorted by date, newest first.`}
       />
     </PlatePage>

--- a/apps/blog/src/app/(blog)/articles/tag/[tag]/page.tsx
+++ b/apps/blog/src/app/(blog)/articles/tag/[tag]/page.tsx
@@ -70,7 +70,7 @@ export default async function TagPage({ params }: TagPageProps) {
       plate="articles"
       title={`${section.title},`}
       titleAccent="filed."
-      width="index"
+      width="wide"
     >
       <p className="mt-10 mb-12 max-w-[60ch] font-body text-[15px] text-muted-foreground leading-[1.6]">
         {section.intro}

--- a/apps/blog/src/app/(blog)/articles/tag/[tag]/page.tsx
+++ b/apps/blog/src/app/(blog)/articles/tag/[tag]/page.tsx
@@ -1,10 +1,10 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
-import { DiscPageHeader } from "@/components/howardism/disc-page-header";
 import { env } from "@/config/env";
 import { formatDateShort } from "@/utils/time";
 
+import { PlatePage } from "../../../_shell/plate-page";
 import { ArticlesTable } from "../../articles-table";
 import {
   getSectionArticles,
@@ -56,21 +56,18 @@ export default async function TagPage({ params }: TagPageProps) {
   const oldestDate = articles.at(-1)?.meta.date;
 
   return (
-    <div className="hw-page-enter mx-auto max-w-[1120px] px-8 pb-20">
-      <DiscPageHeader
-        data={[
-          ["Pieces", String(articles.length)],
-          ["Section", section.title],
-          ["Oldest", oldestDate ? formatDateShort(oldestDate) : "—"],
-          ["Newest", newestDate ? formatDateShort(newestDate) : "—"],
-        ]}
-        number="02"
-        plate="Plate II"
-        title={`${section.title},`}
-        titleAccent="filed."
-        volume="Howardism · Vol. 03"
-      />
-
+    <PlatePage
+      headerData={[
+        ["Pieces", String(articles.length)],
+        ["Section", section.title],
+        ["Oldest", oldestDate ? formatDateShort(oldestDate) : "—"],
+        ["Newest", newestDate ? formatDateShort(newestDate) : "—"],
+      ]}
+      plate="articles"
+      title={`${section.title},`}
+      titleAccent="filed."
+      width="index"
+    >
       <p className="mt-10 mb-12 max-w-[60ch] font-body text-[15px] text-muted-foreground leading-[1.6]">
         {section.intro}
       </p>
@@ -79,6 +76,6 @@ export default async function TagPage({ params }: TagPageProps) {
         articles={articles}
         srCaption={`${section.title} articles, sorted by date, newest first.`}
       />
-    </div>
+    </PlatePage>
   );
 }

--- a/apps/blog/src/app/(blog)/articles/tagged/[tag]/page.tsx
+++ b/apps/blog/src/app/(blog)/articles/tagged/[tag]/page.tsx
@@ -67,7 +67,7 @@ export default async function TaggedPage({ params }: TaggedPageProps) {
       plate="articles"
       title={`${label},`}
       titleAccent="tagged."
-      width="index"
+      width="wide"
     >
       <p className="mt-10 mb-12 max-w-[60ch] font-body text-[15px] text-muted-foreground leading-[1.6]">
         Every article tagged <em>{label.toLowerCase()}</em>, newest first.

--- a/apps/blog/src/app/(blog)/articles/tagged/[tag]/page.tsx
+++ b/apps/blog/src/app/(blog)/articles/tagged/[tag]/page.tsx
@@ -1,12 +1,12 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
-import { DiscPageHeader } from "@/components/howardism/disc-page-header";
 import { env } from "@/config/env";
 import { humanizeTag } from "@/utils/humanize-tag";
 import { taggedHref } from "@/utils/tagged-href";
 import { formatDateShort } from "@/utils/time";
 
+import { PlatePage } from "../../../_shell/plate-page";
 import { ArticlesTable } from "../../articles-table";
 import { getNavigableTags, getTaggedArticles } from "../../service";
 
@@ -57,21 +57,18 @@ export default async function TaggedPage({ params }: TaggedPageProps) {
   const oldestDate = articles.at(-1)?.meta.date;
 
   return (
-    <div className="hw-page-enter mx-auto max-w-[1120px] px-8 pb-20">
-      <DiscPageHeader
-        data={[
-          ["Notes", String(articles.length)],
-          ["Tag", label],
-          ["Oldest", oldestDate ? formatDateShort(oldestDate) : "—"],
-          ["Newest", newestDate ? formatDateShort(newestDate) : "—"],
-        ]}
-        number="02"
-        plate="Plate II"
-        title={`${label},`}
-        titleAccent="tagged."
-        volume="Howardism · Vol. 03"
-      />
-
+    <PlatePage
+      headerData={[
+        ["Notes", String(articles.length)],
+        ["Tag", label],
+        ["Oldest", oldestDate ? formatDateShort(oldestDate) : "—"],
+        ["Newest", newestDate ? formatDateShort(newestDate) : "—"],
+      ]}
+      plate="articles"
+      title={`${label},`}
+      titleAccent="tagged."
+      width="index"
+    >
       <p className="mt-10 mb-12 max-w-[60ch] font-body text-[15px] text-muted-foreground leading-[1.6]">
         Every article tagged <em>{label.toLowerCase()}</em>, newest first.
       </p>
@@ -80,6 +77,6 @@ export default async function TaggedPage({ params }: TaggedPageProps) {
         articles={articles}
         srCaption={`Articles tagged ${label}, sorted by date, newest first.`}
       />
-    </div>
+    </PlatePage>
   );
 }

--- a/apps/blog/src/app/(blog)/articles/tagged/[tag]/page.tsx
+++ b/apps/blog/src/app/(blog)/articles/tagged/[tag]/page.tsx
@@ -75,6 +75,7 @@ export default async function TaggedPage({ params }: TaggedPageProps) {
 
       <ArticlesTable
         articles={articles}
+        navigable={new Set(navigable)}
         srCaption={`Articles tagged ${label}, sorted by date, newest first.`}
       />
     </PlatePage>

--- a/apps/blog/src/app/(blog)/compare/compare-view.tsx
+++ b/apps/blog/src/app/(blog)/compare/compare-view.tsx
@@ -31,7 +31,7 @@ export function CompareView({ panels }: { panels: ComparePanel[] }) {
   const [active, setActive] = useState(0);
 
   return (
-    <div className="mx-auto max-w-wide px-4 py-6">
+    <div className="mx-auto max-w-wide px-gutter py-6">
       <div className="mb-4 flex items-center justify-between gap-4">
         <h1 className="font-mono text-[11px] text-foreground-subtle uppercase tracking-[0.2em]">
           Comparing {panels.length}{" "}

--- a/apps/blog/src/app/(blog)/compare/page.tsx
+++ b/apps/blog/src/app/(blog)/compare/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { env } from "@/config/env";
 import { resolveCompareIds } from "@/lib/compare-ids";
 
+import { kindHasDropCap } from "../articles/kind-meta";
 import { importArticleModule } from "../articles/render-article";
 import { getArticles } from "../articles/service";
 import { CompareView } from "./compare-view";
@@ -69,7 +70,7 @@ export default async function ComparePage({ searchParams }: ComparePageProps) {
           <div
             className={cn(
               "prose max-w-none",
-              mod.meta.dropCap && "prose-drop-cap"
+              kindHasDropCap(mod.meta.tag) && "prose-drop-cap"
             )}
           >
             <Body />

--- a/apps/blog/src/app/(blog)/compare/page.tsx
+++ b/apps/blog/src/app/(blog)/compare/page.tsx
@@ -24,7 +24,7 @@ interface ComparePageProps {
 
 function CompareEmpty() {
   return (
-    <div className="mx-auto max-w-read px-4 py-20 text-center">
+    <div className="mx-auto max-w-read px-gutter py-20 text-center">
       <h1 className="font-display font-normal text-[22px] text-foreground tracking-[-0.015em]">
         Nothing to compare.
       </h1>

--- a/apps/blog/src/app/(blog)/desk.tsx
+++ b/apps/blog/src/app/(blog)/desk.tsx
@@ -30,7 +30,7 @@ export function Desk({ sources }: DeskProps) {
   }, {});
 
   return (
-    <section className="border-border border-b px-[clamp(20px,5vw,56px)] py-10">
+    <section className="border-border border-b px-gutter py-10">
       <div className="grid grid-cols-1 gap-x-11 gap-y-8 lg:grid-cols-[180px_1fr]">
         <div>
           <div className="font-medium font-mono text-[10.5px] text-brand uppercase tracking-[0.22em]">

--- a/apps/blog/src/app/(blog)/domain-plate.tsx
+++ b/apps/blog/src/app/(blog)/domain-plate.tsx
@@ -1,7 +1,5 @@
-import { InternalLink } from "@/components/internal-link";
-import { formatDateShort } from "@/utils/time";
-
 import { DOMAIN_META } from "./articles/domain-meta";
+import { IndexRow } from "./articles/index-row";
 import type {
   ArticleDomain,
   ArticleEntity,
@@ -39,7 +37,7 @@ export function DomainPlate({
 
   return (
     <section
-      className="border-border border-b px-[clamp(20px,5vw,56px)] py-9"
+      className="border-border border-b px-gutter py-9"
       style={banded ? { background: "var(--card)" } : undefined}
     >
       <div className="grid grid-cols-1 items-start gap-x-11 gap-y-8 lg:grid-cols-[180px_1fr_320px]">
@@ -82,34 +80,16 @@ export function DomainPlate({
 
           <ol className="m-0 mt-5 list-none p-0">
             {notes.map((article, i) => (
-              <li
-                className="grid grid-cols-[auto_1fr_auto] items-baseline gap-x-4 py-2.5"
+              <IndexRow
+                accent={meta.color}
+                article={article}
+                density="compact"
+                first={i === 0}
                 key={article.slug}
-                style={{
-                  borderTop:
-                    i === 0
-                      ? `2px solid ${meta.color}`
-                      : "1px solid var(--border)",
-                }}
-              >
-                <span
-                  className="font-medium font-mono text-[11px] tracking-[0.14em]"
-                  style={{ color: meta.color }}
-                >
-                  {String(i + 1).padStart(2, "0")}
-                </span>
-                <InternalLink
-                  className="font-display font-medium text-[18px] text-foreground leading-[1.25] tracking-[-0.008em] no-underline transition-colors hover:text-brand"
-                  href={`/articles/${article.slug}`}
-                  previewMeta={article.meta}
-                >
-                  {article.meta.title}
-                </InternalLink>
-                <span className="whitespace-nowrap font-mono text-[10.5px] text-foreground-subtle tracking-[0.12em]">
-                  {formatDateShort(article.meta.date)} ·{" "}
-                  {article.meta.readingTime}′
-                </span>
-              </li>
+                ordinal={i + 1}
+                showChips={false}
+                showDomain={false}
+              />
             ))}
             <li className="border-border border-t py-2.5">
               <a

--- a/apps/blog/src/app/(blog)/page.tsx
+++ b/apps/blog/src/app/(blog)/page.tsx
@@ -1,7 +1,7 @@
-import { DiscPageHeader } from "@/components/howardism/disc-page-header";
 import { DomainDot } from "@/components/howardism/domain-dot";
 import { formatDateShort } from "@/utils/time";
 
+import { PlatePage } from "./_shell/plate-page";
 import { DOMAIN_META, DOMAIN_ORDER } from "./articles/domain-meta";
 import {
   type ArticleDomain,
@@ -51,33 +51,30 @@ export default async function Home() {
   );
 
   return (
-    <div className="hw-page-enter mx-auto max-w-[1320px]">
-      <div className="px-[clamp(20px,5vw,56px)]">
-        <DiscPageHeader
-          data={[
-            ["Curator", "Howard Tai"],
-            ["Issue", `Vol. 03 · no. ${total}`],
-            ["Cadence", "Batched, not scheduled"],
-            ["Based", "Taiwan, 23°N"],
-            ["Contact", "howard@howardism.dev"],
-          ]}
-          number="00"
-          plate="Masthead"
-          title="A wiki, set"
-          titleAccent="in plates."
-          volume="Howardism · Vol. 03"
-        >
-          <p className="mt-6 max-w-[760px] font-body text-[clamp(16px,2.2vw,18.5px)] text-muted-foreground leading-[1.55]">
-            Working notes on interaction-era AI, kept publicly. Each plate is a
-            domain; each domain carries its brightest notes and the source
-            I&apos;m currently digesting. {total} notes across {sourceCount}{" "}
-            sources
-            {newestDate ? `, last filed ${formatDateShort(newestDate)}` : ""}.
-            Updated whenever a batch finishes — not on a schedule.
-          </p>
-        </DiscPageHeader>
-      </div>
-
+    <PlatePage
+      bleed
+      headerChildren={
+        <p className="mt-6 max-w-[760px] font-body text-[clamp(16px,2.2vw,18.5px)] text-muted-foreground leading-[1.55]">
+          Working notes on interaction-era AI, kept publicly. Each plate is a
+          domain; each domain carries its brightest notes and the source
+          I&apos;m currently digesting. {total} notes across {sourceCount}{" "}
+          sources
+          {newestDate ? `, last filed ${formatDateShort(newestDate)}` : ""}.
+          Updated whenever a batch finishes — not on a schedule.
+        </p>
+      }
+      headerData={[
+        ["Curator", "Howard Tai"],
+        ["Issue", `Vol. 03 · no. ${total}`],
+        ["Cadence", "Batched, not scheduled"],
+        ["Based", "Taiwan, 23°N"],
+        ["Contact", "howard@howardism.dev"],
+      ]}
+      plate="home"
+      title="A wiki, set"
+      titleAccent="in plates."
+      width="wide"
+    >
       {featured.map((domain, index) => (
         <DomainPlate
           articles={articlesByDomain[domain] ?? []}
@@ -93,7 +90,7 @@ export default async function Home() {
       {tail.length > 0 && <DomainTail counts={counts} domains={tail} />}
 
       <Desk sources={getWikiSources()} />
-    </div>
+    </PlatePage>
   );
 }
 
@@ -106,7 +103,7 @@ function DomainTail({
   domains: ArticleDomain[];
 }) {
   return (
-    <section className="border-border border-b px-[clamp(20px,5vw,56px)] py-9">
+    <section className="border-border border-b px-gutter py-9">
       <div className="font-medium font-mono text-[10.5px] text-foreground-subtle uppercase tracking-[0.22em]">
         Also in the wiki
       </div>

--- a/apps/blog/src/app/(blog)/plate-meta.ts
+++ b/apps/blog/src/app/(blog)/plate-meta.ts
@@ -1,0 +1,21 @@
+/**
+ * Plate taxonomy — the blog's information architecture, numbered once as data.
+ *
+ * Every public page identifies itself by a plate key; the `PlatePage` shell
+ * reads `number` + `label` from here so the eyebrow numbering stays systematic
+ * and unique: Masthead (00), then Plates I–IV in IA order. Domain pages and the
+ * article reader are both leaves of Plate II, so they share the `domains` key
+ * and append the specific domain to the eyebrow (`Plate II · {domain}`).
+ *
+ * `number` is arabic to match the live `{label} · No. {number}` eyebrow format;
+ * `title` is a default the page may override with its own editorial headline.
+ */
+export const PLATE_META = {
+  home: { number: "00", label: "Masthead", title: "The desk" },
+  articles: { number: "01", label: "Plate I", title: "Writing, in order" },
+  domains: { number: "02", label: "Plate II", title: "Domains" },
+  questions: { number: "03", label: "Plate III", title: "Open questions" },
+  shelf: { number: "04", label: "Plate IV", title: "The shelf" },
+} as const;
+
+export type PlateKey = keyof typeof PLATE_META;

--- a/apps/blog/src/app/(blog)/questions/page.tsx
+++ b/apps/blog/src/app/(blog)/questions/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from "next";
 
-import { DiscPageHeader } from "@/components/howardism/disc-page-header";
 import { env } from "@/config/env";
 
+import { PlatePage } from "../_shell/plate-page";
 import { DOMAIN_META, DOMAIN_ORDER } from "../articles/domain-meta";
 import { OpenQuestionsSection } from "../articles/open-questions-section";
 import { getOpenQuestions } from "../articles/service";
@@ -29,26 +29,24 @@ export default function QuestionsPage() {
   })).filter((group) => group.concepts.length > 0);
 
   return (
-    <div className="hw-page-enter mx-auto max-w-[1120px] px-8 pb-20">
-      <DiscPageHeader
-        data={[
-          ["Questions", String(total)],
-          ["Concepts", String(concepts.length)],
-          ["Domains", String(byDomain.length)],
-        ]}
-        number="03"
-        plate="Plate III"
-        title="Open questions,"
-        titleAccent="unresolved."
-        volume="Howardism · Vol. 03"
-      >
+    <PlatePage
+      headerChildren={
         <p className="mt-6 max-w-[680px] font-body text-[clamp(16px,2.2vw,18px)] text-muted-foreground leading-[1.55]">
           The live worklist. Every unanswered question harvested from the
           wiki&apos;s concept notes, grouped by domain. Each links back to the
           note that raised it.
         </p>
-      </DiscPageHeader>
-
+      }
+      headerData={[
+        ["Questions", String(total)],
+        ["Concepts", String(concepts.length)],
+        ["Domains", String(byDomain.length)],
+      ]}
+      plate="questions"
+      title="Open questions,"
+      titleAccent="unresolved."
+      width="index"
+    >
       <div className="mt-4">
         {byDomain.map(({ domain, concepts: group }) => (
           <OpenQuestionsSection
@@ -59,6 +57,6 @@ export default function QuestionsPage() {
           />
         ))}
       </div>
-    </div>
+    </PlatePage>
   );
 }

--- a/apps/blog/src/app/(blog)/questions/page.tsx
+++ b/apps/blog/src/app/(blog)/questions/page.tsx
@@ -45,7 +45,7 @@ export default function QuestionsPage() {
       plate="questions"
       title="Open questions,"
       titleAccent="unresolved."
-      width="index"
+      width="wide"
     >
       <div className="mt-4">
         {byDomain.map(({ domain, concepts: group }) => (

--- a/apps/blog/src/app/(blog)/shelf/page.tsx
+++ b/apps/blog/src/app/(blog)/shelf/page.tsx
@@ -44,9 +44,8 @@ export default async function ShelfPage() {
 
   return (
     <PlatePage
-      header="compact"
       headerChildren={
-        <p className="max-w-[560px] font-body text-[15px] text-muted-foreground leading-[1.6]">
+        <p className="mt-6 max-w-[680px] font-body text-[clamp(16px,2.2vw,18px)] text-muted-foreground leading-[1.55]">
           Articles you&apos;ve meaningfully read, newest first. This list lives
           only in your browser — nothing is sent anywhere.
         </p>
@@ -54,7 +53,7 @@ export default async function ShelfPage() {
       plate="shelf"
       title="Your shelf,"
       titleAccent="read & remembered."
-      width="read"
+      width="wide"
     >
       <ShelfTabs manifest={manifest} />
     </PlatePage>

--- a/apps/blog/src/app/(blog)/shelf/page.tsx
+++ b/apps/blog/src/app/(blog)/shelf/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { env } from "@/config/env";
 import type { ShelfManifestEntry } from "@/lib/shelf-rows";
 
+import { PlatePage } from "../_shell/plate-page";
 import { DOMAIN_META } from "../articles/domain-meta";
 import { getArticles } from "../articles/service";
 import { ShelfTabs } from "./shelf-tabs";
@@ -42,21 +43,20 @@ export default async function ShelfPage() {
   }
 
   return (
-    <div className="hw-page-enter mx-auto max-w-read px-4 pb-20">
-      <header className="border-border border-b border-dashed pt-8 pb-6">
-        <span className="font-mono text-[10.5px] text-foreground-subtle uppercase tracking-[0.22em]">
-          Howardism · Vol. 03
-        </span>
-        <h1 className="mt-3 font-display font-normal text-[27px] text-foreground leading-[1.2] tracking-[-0.015em]">
-          Your shelf, <span className="text-brand">read &amp; remembered.</span>
-        </h1>
-        <p className="mt-4 max-w-[560px] font-body text-[15px] text-muted-foreground leading-[1.6]">
+    <PlatePage
+      header="compact"
+      headerChildren={
+        <p className="max-w-[560px] font-body text-[15px] text-muted-foreground leading-[1.6]">
           Articles you&apos;ve meaningfully read, newest first. This list lives
           only in your browser — nothing is sent anywhere.
         </p>
-      </header>
-
+      }
+      plate="shelf"
+      title="Your shelf,"
+      titleAccent="read & remembered."
+      width="read"
+    >
       <ShelfTabs manifest={manifest} />
-    </div>
+    </PlatePage>
   );
 }

--- a/apps/blog/src/app/(blog)/shelf/shelf-tabs.tsx
+++ b/apps/blog/src/app/(blog)/shelf/shelf-tabs.tsx
@@ -28,7 +28,7 @@ function CompareBar({
   onClear: () => void;
 }) {
   return (
-    <div className="fixed inset-x-0 bottom-0 z-40 border-border border-t bg-card/95 px-4 py-3 shadow-paper-lg backdrop-blur-sm">
+    <div className="fixed inset-x-0 bottom-0 z-40 border-border border-t bg-card/95 px-gutter py-3 shadow-paper-lg backdrop-blur-sm">
       <div className="mx-auto flex max-w-wide items-center justify-between gap-4">
         <span className="font-mono text-[11px] text-foreground-subtle uppercase tracking-[0.16em]">
           {count} selected

--- a/apps/blog/src/components/howardism/disc-page-header.tsx
+++ b/apps/blog/src/components/howardism/disc-page-header.tsx
@@ -1,34 +1,95 @@
+import { cn } from "@howardism/ui/lib/utils";
 import type { ReactNode } from "react";
 
 import { DataGrid } from "./data-grid";
 
 interface DiscPageHeaderProps {
+  /** Domain/kind tint for the compact top rule + title accent. */
+  accent?: string;
   children?: ReactNode;
-  data?: [string, string][];
-  number?: string;
-  plate?: string;
+  data?: [string, ReactNode][];
+  /** Right eyebrow content ("Plate · No.", or reader badges + brand). */
+  eyebrowEnd: ReactNode;
+  /** Left eyebrow content (volume, or "Plate II · domain" on the reader). */
+  eyebrowStart: ReactNode;
+  /** Stack the DataGrid label over value — for the narrow compact column. */
+  stackData?: boolean;
   title: string;
-  titleAccent?: string;
-  volume: string;
+  titleAccent?: ReactNode;
+  /** "full" — masthead double-rule + large title; "compact" — reading/shelf. */
+  variant?: "full" | "compact";
 }
 
 export function DiscPageHeader({
-  volume,
+  variant = "full",
+  eyebrowStart,
+  eyebrowEnd,
   title,
   titleAccent,
-  plate = "Plate",
-  number = "00",
+  accent,
   data,
+  stackData = false,
   children,
 }: DiscPageHeaderProps) {
+  if (variant === "compact") {
+    const hasAccent = Boolean(accent);
+    return (
+      <section className="hw-grain relative">
+        <div
+          className={cn(
+            hasAccent
+              ? "border-t-[3px] border-b border-b-border border-double pt-2.5 pb-10"
+              : "border-border border-b border-dashed pt-8 pb-6"
+          )}
+          style={hasAccent ? { borderTopColor: accent } : undefined}
+        >
+          <div className="mb-7 flex items-baseline justify-between gap-4">
+            <span
+              className={cn(
+                "inline-flex items-center font-mono text-[10.5px] uppercase tracking-[0.22em]",
+                hasAccent ? null : "text-foreground-subtle"
+              )}
+              style={hasAccent ? { color: accent } : undefined}
+            >
+              {eyebrowStart}
+            </span>
+            <span className="inline-flex items-center gap-2 font-mono text-[10.5px] text-foreground-subtle uppercase tracking-[0.22em]">
+              {eyebrowEnd}
+            </span>
+          </div>
+          <h1 className="m-0 font-display font-normal text-[27px] text-foreground leading-[1.2] tracking-[-0.015em]">
+            {title}
+            {titleAccent && (
+              <>
+                {" "}
+                <em
+                  className="italic"
+                  style={{ color: accent ?? "var(--brand)" }}
+                >
+                  {titleAccent}
+                </em>
+              </>
+            )}
+          </h1>
+          {data && (
+            <div className="mt-5">
+              <DataGrid maxWidth={280} rows={data} stack={stackData} />
+            </div>
+          )}
+          {children && <div className="mt-5">{children}</div>}
+        </div>
+      </section>
+    );
+  }
+
   return (
     <section className="hw-grain relative">
       <div className="flex items-baseline justify-between border-foreground border-b-[3px] border-double pb-3">
         <span className="font-mono text-[11px] text-muted-foreground uppercase tracking-[0.18em]">
-          {volume}
+          {eyebrowStart}
         </span>
         <span className="font-mono text-[11px] text-foreground-subtle uppercase tracking-[0.14em]">
-          {plate} · No. {number}
+          {eyebrowEnd}
         </span>
       </div>
 

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -69,13 +69,17 @@
   --radius-xl: calc(var(--radius) + 4px);
   --radius-2xl: calc(var(--radius) + 8px);
 
-  /* shared content widths — one rhythm for reading measure, article+rail, and
-     index/landing. Drives max-w-read / max-w-wide / max-w-index utilities.
+  /* shared content widths — three semantic stops, the only page-container
+     widths. Drives max-w-read / max-w-index / max-w-wide utilities.
      ("read" rather than "prose" to avoid overriding Tailwind's built-in
      max-w-prose, which the error/not-found pages rely on.) */
-  --container-read: 720px;
-  --container-wide: 1120px;
-  --container-index: 1280px;
+  --container-read: 720px; /* prose · shelf · single-column lists */
+  --container-index: 1120px; /* domain · questions · article + rail (720 + 320 + gap) */
+  --container-wide: 1320px; /* home masthead · plate galleries */
+
+  /* one responsive page gutter, applied once on the PlatePage shell.
+     Drives px-gutter / py-gutter so no page hand-rolls horizontal padding. */
+  --spacing-gutter: clamp(20px, 5vw, 56px);
 
   /* `rail:` variant — the viewport width at which the article gains its
      320px navigation rail beside the 720px reading column. */

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -73,13 +73,14 @@
      widths. Drives max-w-read / max-w-index / max-w-wide utilities.
      ("read" rather than "prose" to avoid overriding Tailwind's built-in
      max-w-prose, which the error/not-found pages rely on.) */
-  --container-read: 720px; /* prose · shelf · single-column lists */
-  --container-index: 1120px; /* domain · questions · article + rail (720 + 320 + gap) */
-  --container-wide: 1320px; /* home masthead · plate galleries */
+  --container-read: 720px; /* prose · the reading column · single-column views */
+  --container-index: 1120px; /* the article reader's rail expansion (720 + 320 + gap) */
+  --container-wide: 1320px; /* every plate frame · /compare's three columns */
 
   /* one responsive page gutter, applied once on the PlatePage shell.
-     Drives px-gutter / py-gutter so no page hand-rolls horizontal padding. */
-  --spacing-gutter: clamp(20px, 5vw, 56px);
+     Drives px-gutter / py-gutter so no page hand-rolls horizontal padding.
+     Ceiling is wide enough to keep the wide frame off the backdrop ring. */
+  --spacing-gutter: clamp(20px, 5vw, 72px);
 
   /* `rail:` variant — the viewport width at which the article gains its
      320px navigation rail beside the 720px reading column. */


### PR DESCRIPTION
## Summary

Unifies the blog's fragmented page-layout system into one semantic set of width/gutter tokens and a single page shell. Before this, route templates hand-rolled widths (raw `720`/`1120`/`1280`/`1320px`) and gutters (`px-4`/`px-8`/ad-hoc `clamp()`), and three different listing contexts each rendered article rows their own way. Landed in 5 self-contained phases (one commit each):

1. **Tokens + taxonomy** — reslot the three content-width tokens into a semantic order (`read=720`, `index=1120`, `wide=1320`), add a single `--spacing-gutter` (`px-gutter`) clamp token, and add `plate-meta.ts` as the plate taxonomy (resolves the Articles/Domain "Plate II" eyebrow collision).
2. **PlatePage shell** — one `<PlatePage>` owns content width, the gutter, the page-enter animation, and the numbered `DiscPageHeader`. Home, articles, domain, questions, shelf, the article reader, and the tag/tagged listings all route through it; the Shelf's bespoke `<header>` and the article's one-off `HalfDisc` header are removed.
3. **IndexRow** — one `<IndexRow>` (numeral marker, title + subject chips, optional domain, date · reading, save) replaces the bespoke rows in `KindPlate`, `DomainPlate`, and `ArticlesTable`, toggled by props. `ShelfArticleRow` stays specialised (client, manifest-driven, selection/progress/remove).
4. **Reading column** — derive the reader eyebrow from `PLATE_META`, and replace the `meta.dropCap` frontmatter flag with a kind rule (`kindHasDropCap()`: essays get a drop-cap; concepts/entities/indexes don't), applied in the reader and `/compare`.
5. **Regression guard** — a bun test that fails if a `(blog)` source sets a raw page width or a route entry hand-rolls a `px-4`/`px-8` gutter instead of rendering `<PlatePage>`.

## Changes

24 files, +766/−387. Token defs in `packages/ui/src/styles/globals.css`; the rest under `apps/blog/src/app/(blog)`.

## Verification (this session)

- `bun run type-check` — clean
- `bun run test` — **167/167 pass**
- `bun run build` — green, all routes generated
- Merges cleanly into current `main` (no conflicts)

## Notes

- Stacked on the compare-selection work, which has since merged to `main`; this PR now targets `main` directly and contains only the 5 layout commits.
- `HalfDisc` is no longer used by app code but is kept (still covered by its own test) rather than deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)