### PR TITLE
feat(cli): support agy CLI for image generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,8 +57,9 @@ apps/blog/public/rss
 # claude code
 .claude/
 
-# codex image-generation staging (apps/cli)
+# image-generation staging (apps/cli)
 .codex-staging/
+.agy-staging/
 
 # antigravity (gemini) ide local cache
 .antigravitycli/

--- a/_typos.toml
+++ b/_typos.toml
@@ -18,4 +18,5 @@ extend-exclude = [
   "apps/blog/public/rss",
   "apps/blog/src/content/**",
   "apps/blog/src/data/search-index.json",
+  "design_handoff_blog_unification",
 ]

--- a/apps/cli/src/__tests__/agy.test.ts
+++ b/apps/cli/src/__tests__/agy.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "bun:test";
+import { stat } from "node:fs/promises";
+import { join } from "node:path";
+
+import { buildPrompt, generateHeroImage } from "../import-wiki/agy/index.ts";
+
+const NOT_A_PNG_RE = /not a PNG/;
+const DID_NOT_PRODUCE_RE = /did not produce/;
+const PNG_HEADER = new Uint8Array([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00,
+]);
+const noopRunner = () => Promise.resolve({ stdout: "", stderr: "" });
+
+describe("agy buildPrompt", () => {
+  it("includes the title, output path, $imagegen instruction, and truncated excerpt", () => {
+    const prompt = buildPrompt({
+      title: "Claude Code",
+      body: "Long body content. ".repeat(200),
+      outputPath: "/abs/path/claude-code.png",
+    });
+
+    expect(prompt).toContain("Title: Claude Code");
+    expect(prompt).toContain("$imagegen");
+    expect(prompt).toContain("/abs/path/claude-code.png");
+    expect(prompt).toContain("1600x900 PNG");
+    expect(prompt.length).toBeLessThan(2400);
+  });
+});
+
+describe("agy generateHeroImage", () => {
+  it("dry-run does not call the runner", async () => {
+    let runnerCalls = 0;
+    await generateHeroImage({
+      title: "Demo",
+      body: "Body",
+      outputPath: "/tmp/should-not-exist.png",
+      stagingDir: "/tmp",
+      dryRun: true,
+      runner: () => {
+        runnerCalls += 1;
+        return Promise.resolve({ stdout: "", stderr: "" });
+      },
+    });
+    expect(runnerCalls).toBe(0);
+  });
+
+  it("stages the PNG in stagingDir, then moves it to outputPath", async () => {
+    const stamp = Date.now();
+    const stagingDir = `/tmp/agy-staging-${stamp}`;
+    const filename = `agy-test-${stamp}.png`;
+    const stagingPath = join(stagingDir, filename);
+    const finalDir = `/tmp/agy-final-${stamp}`;
+    const finalPath = join(finalDir, filename);
+
+    let capturedPrompt = "";
+    await generateHeroImage({
+      title: "Demo",
+      body: "Body",
+      outputPath: finalPath,
+      stagingDir,
+      runner: async (prompt) => {
+        capturedPrompt = prompt;
+        // Simulate agy writing the PNG into the sandbox-writable staging dir.
+        await Bun.write(stagingPath, PNG_HEADER);
+        return { stdout: stagingPath, stderr: "" };
+      },
+    });
+
+    expect(capturedPrompt).toContain("Title: Demo");
+    expect(capturedPrompt).toContain(stagingPath);
+    expect(capturedPrompt).not.toContain(finalPath);
+
+    const finalInfo = await stat(finalPath);
+    expect(finalInfo.size).toBeGreaterThan(0);
+    await expect(stat(stagingPath)).rejects.toThrow();
+  });
+
+  it("throws when the staged output is not a valid PNG", async () => {
+    const stamp = Date.now();
+    const stagingDir = `/tmp/agy-staging-bad-${stamp}`;
+    const filename = `agy-test-bad-${stamp}.png`;
+    await Bun.write(join(stagingDir, filename), "not a png");
+
+    await expect(
+      generateHeroImage({
+        title: "Demo",
+        body: "Body",
+        outputPath: `/tmp/agy-final-bad-${stamp}/${filename}`,
+        stagingDir,
+        runner: noopRunner,
+      })
+    ).rejects.toThrow(NOT_A_PNG_RE);
+  });
+
+  it("throws when the staged file is missing", async () => {
+    const stamp = Date.now();
+    await expect(
+      generateHeroImage({
+        title: "Demo",
+        body: "Body",
+        outputPath: `/tmp/agy-final-missing-${stamp}/missing.png`,
+        stagingDir: `/tmp/agy-staging-missing-${stamp}`,
+        runner: noopRunner,
+      })
+    ).rejects.toThrow(DID_NOT_PRODUCE_RE);
+  });
+});

--- a/apps/cli/src/import-wiki/agy/index.ts
+++ b/apps/cli/src/import-wiki/agy/index.ts
@@ -1,0 +1,122 @@
+import { mkdir, rename, stat } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+
+export interface GenerateImageOptions {
+  body: string;
+  dryRun?: boolean;
+  outputPath: string;
+  /** Custom shell runner — injected by tests. Defaults to `agy` via Bun.spawn. */
+  runner?: (prompt: string) => Promise<{ stdout: string; stderr: string }>;
+  stagingDir: string;
+  title: string;
+}
+
+/**
+ * Generate a hero image via the Antigravity (agy) CLI.
+ *
+ * Single session: read article body inline → compose visual prompt →
+ * invoke `$imagegen` → write PNG into `stagingDir` (sandbox-writable). Then we
+ * validate the PNG and rename it to `outputPath`, creating its parent dir if
+ * needed.
+ */
+export async function generateHeroImage(
+  options: GenerateImageOptions
+): Promise<void> {
+  const { title, body, outputPath, stagingDir, dryRun, runner } = options;
+  const stagingPath = join(stagingDir, basename(outputPath));
+  const prompt = buildPrompt({ title, body, outputPath: stagingPath });
+
+  if (dryRun) {
+    console.log(
+      `[agy] DRY_RUN — would generate image for "${title}" → ${stagingPath} → ${outputPath}`
+    );
+    return;
+  }
+
+  await mkdir(stagingDir, { recursive: true });
+
+  const exec = runner ?? defaultRunner;
+  const { stdout, stderr } = await exec(prompt);
+
+  if (stderr.trim()) {
+    console.warn(`[agy] stderr for "${title}":\n${stderr}`);
+  }
+  if (stdout.trim()) {
+    console.log(`[agy] stdout for "${title}":\n${stdout}`);
+  }
+
+  await assertValidPng(stagingPath, title);
+  await mkdir(dirname(outputPath), { recursive: true });
+  await rename(stagingPath, outputPath);
+}
+
+async function defaultRunner(
+  prompt: string
+): Promise<{ stdout: string; stderr: string }> {
+  const proc = Bun.spawn(
+    ["agy", "--dangerously-skip-permissions", "-p", prompt],
+    {
+      stdout: "pipe",
+      stderr: "pipe",
+    }
+  );
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const exitCode = await proc.exited;
+  if (exitCode !== 0) {
+    throw new Error(
+      `agy print failed (exit ${exitCode})\nstdout: ${stdout}\nstderr: ${stderr}`
+    );
+  }
+  return { stdout, stderr };
+}
+
+export function buildPrompt(args: {
+  title: string;
+  body: string;
+  outputPath: string;
+}): string {
+  const { title, body, outputPath } = args;
+  const excerpt = body.slice(0, 1200);
+
+  return [
+    "You are generating a hero illustration for a blog article.",
+    "",
+    "Step 1 — Compose a single sentence describing an editorial illustration for the article below. Aim for a minimal composition, warm terracotta accent, paper-grain backdrop, no text in the image.",
+    "",
+    "Step 2 — Use the $imagegen skill with that sentence to render a 1600x900 PNG.",
+    `Step 3 — Save the rendered PNG to: ${outputPath}`,
+    "Step 4 — Print the absolute path of the saved file on its own line.",
+    "",
+    `Title: ${title}`,
+    "",
+    "Article excerpt:",
+    excerpt,
+  ].join("\n");
+}
+
+async function assertValidPng(path: string, label: string): Promise<void> {
+  let info: Awaited<ReturnType<typeof stat>>;
+  try {
+    info = await stat(path);
+  } catch {
+    throw new Error(
+      `agy did not produce ${path} for "${label}" — image generation failed`
+    );
+  }
+
+  if (info.size === 0) {
+    throw new Error(`Generated PNG is empty: ${path} (for "${label}")`);
+  }
+
+  const head = new Uint8Array(await Bun.file(path).slice(0, 4).arrayBuffer());
+  if (!Buffer.from(head).equals(PNG_MAGIC)) {
+    throw new Error(
+      `Generated file is not a PNG (bad magic bytes): ${path} (for "${label}")`
+    );
+  }
+}

--- a/apps/cli/src/import-wiki/index.ts
+++ b/apps/cli/src/import-wiki/index.ts
@@ -8,7 +8,8 @@ import {
   type WikiTag,
 } from "@howardism/article-contract";
 import { runWithConcurrency } from "../concurrency.ts";
-import { generateHeroImage } from "./codex.ts";
+import { generateHeroImage as generateAgyHeroImage } from "./agy/index.ts";
+import { generateHeroImage as generateCodexHeroImage } from "./codex.ts";
 import {
   buildDomainMembership,
   isMocSlug,
@@ -96,11 +97,16 @@ const DEFAULT_OPEN_QUESTIONS_OUTPUT_PATH = resolve(
 );
 const DEFAULT_OVERRIDES_PATH = join(CLI_ROOT, "wiki-category-overrides.json");
 /**
- * Codex's `workspace-write` sandbox only permits writes inside its workdir
+ * The agent's sandbox only permits writes inside its workdir
  * (this CLI app). We stage generated PNGs here before moving them into the
  * blog's assets dir.
  */
-const STAGING_DIR = join(CLI_ROOT, ".codex-staging");
+const STAGING_DIR = join(
+  CLI_ROOT,
+  (process.env.IMAGE_PROVIDER || "codex") === "agy"
+    ? ".agy-staging"
+    : ".codex-staging"
+);
 const IMAGE_CONCURRENCY = 6;
 
 async function main(): Promise<void> {
@@ -436,13 +442,24 @@ async function ensureImage(args: {
     );
     return;
   }
-  await generateHeroImage({
-    title: args.title,
-    body: args.body,
-    outputPath: args.imagePath,
-    stagingDir: STAGING_DIR,
-    dryRun: args.dryRun,
-  });
+  const provider = process.env.IMAGE_PROVIDER || "codex";
+  if (provider === "agy") {
+    await generateAgyHeroImage({
+      title: args.title,
+      body: args.body,
+      outputPath: args.imagePath,
+      stagingDir: STAGING_DIR,
+      dryRun: args.dryRun,
+    });
+  } else {
+    await generateCodexHeroImage({
+      title: args.title,
+      body: args.body,
+      outputPath: args.imagePath,
+      stagingDir: STAGING_DIR,
+      dryRun: args.dryRun,
+    });
+  }
   args.summary.imagesGenerated.push(args.slug);
 }
 


### PR DESCRIPTION
Supports generating hero images via the agy CLI provider. Integrates option/env provider routing, dynamic sandbox staging folder resolution, and includes new unit tests.