### PR TITLE
✨ feat(skills): add generate-wiki-images project skill

### DIFF
--- a/.claude/skills/generate-wiki-images/SKILL.md
+++ b/.claude/skills/generate-wiki-images/SKILL.md
@@ -7,25 +7,32 @@ Runs this monorepo's wiki importer (`apps/cli`) end to end: import + validate th
 
 ## Input
 
-`WIKI_PATH` — absolute path to the Obsidian wiki root, supplied by the caller (no default; a remote runner must pass it). If the user didn't give one, ask. `RAW_PATH` defaults to `<WIKI_PATH>/../raw` and needs no input. Run every command from the repo root.
+`WIKI_PATH` — absolute path to the Obsidian wiki root, supplied by the caller (no default; a remote runner must pass it). If the user didn't give one, ask. `RAW_PATH` defaults to `<WIKI_PATH>/../raw` and needs no input. `MAX_IMAGES` (optional) caps how many images one run generates — for a smoke test or to stay under Codex quota; unset generates all missing. Run every command from the repo root.
 
 ## Steps
 
-1. **Preflight.** Confirm all three: `codex --version` succeeds (Codex CLI installed *and* logged in — `codex exec` needs auth), `bun` is on PATH, and `WIKI_PATH` resolves to an existing directory. → *ready when all three check out.*
+1. **Preflight.** On a fresh checkout, run `bun install` at the repo root first — the importer imports workspace packages (e.g. `@howardism/article-contract`) and dies with "Cannot find module" without it (bites remote runners especially). Then confirm all three: `codex --version` succeeds (Codex CLI installed *and* logged in — `codex exec` needs auth), `bun` is on PATH, and `WIKI_PATH` resolves to an existing directory. → *ready when `bun install` completes and all three check out.*
 
 2. **Import & validate.** Import articles and manifests with images off (fast, no Codex), then validate the summary:
    ```bash
    cd apps/cli && SKIP_IMAGES=1 WIKI_PATH="$WIKI_PATH" bun run import:wiki
    ```
-   Confirm the printed summary reports articles written and manifests generated with no thrown error. Unresolved wikilinks and missing-raw warnings are expected (MOC internal links resolve to `home`). → *done when the import exits 0 and `apps/blog/src/data/{article-graph,wiki-sources,open-questions}.json` are updated.* (Blog type-check is deferred to step 4 — it fails until images exist.)
+   Confirm the printed summary reports articles written and manifests generated with no thrown error. Unresolved wikilinks and missing-raw warnings are expected (MOC internal links resolve to `home`). → *done when the import exits 0 and `apps/blog/src/data/{article-graph,wiki-sources,open-questions}.json` are updated.* (The summary's "leaving missing asset" lines name the articles needing images — step 3 fills them.)
 
-3. **Generate images sequentially.** From the repo root, run the bundled script in the background, logging to a file, then monitor and relay progress:
+3. **Generate images sequentially.** From the repo root, run the bundled script — background it for a large batch and log to a file — then monitor and relay progress:
    ```bash
    WIKI_PATH="$WIKI_PATH" bash .claude/skills/generate-wiki-images/scripts/sequential-images.sh
+   # smoke-test or quota-cap this run: prefix MAX_IMAGES=2
    ```
-   It dry-runs first (no Codex calls) to list the slugs missing a PNG, then generates them one at a time, printing `[i/N] slug ✓ 47s | elapsed 3m | ETA ~38m` after each. The ETA is measured from real per-image time and announced after the first completes — relay it. → *done when the script prints `Done: N/N generated, 0 failed`.*
+   It dry-runs first (no Codex calls) to list the slugs missing a PNG, then generates them one at a time, printing `[i/N] slug ✓ 98s | elapsed 3m | ETA ~38m` after each. The ETA is measured from real per-image time and announced after the first completes — relay it. → *done when the script prints `Done: N/N generated, 0 failed`.*
 
-4. **Validate the build.** Now that images exist, run the real gate: `bun run type-check` (blog compiles only with every hero PNG present) and confirm `apps/blog/src/content/assets/*.png` count matches `apps/blog/src/content/articles/*.mdx`. → *done when type-check passes and the counts match.*
+4. **Validate.** The image-presence gate is a filesystem check — every article has its hero PNG (the importer names each `<slug>.png`):
+   ```bash
+   cd apps/blog/src/content && comm -23 \
+     <(ls articles/*.mdx | xargs -n1 basename | sed 's/\.mdx$//' | sort) \
+     <(ls assets/*.png   | xargs -n1 basename | sed 's/\.png$//' | sort)
+   ```
+   Empty output = every article has an image. Note `bun run type-check` does **not** catch missing images — TS treats `*.png` as an opaque module, so it passes with PNGs absent; only a full `bun run build` actually fails on a missing hero (at the cost of a slow Next build). → *done when the set difference is empty.*
 
 ## Failures & regen
 
@@ -40,5 +47,5 @@ Runs this monorepo's wiki importer (`apps/cli`) end to end: import + validate th
 - **Codex sandbox staging.** Images render into `apps/cli/.codex-staging/` (inside Codex's `workspace-write` sandbox) and then move to `assets/`. Run from the repo, or the sandbox can't write.
 - **Non-fatal noise is normal.** Missing Python `PIL`/`numpy` warnings and an ImageMagick draw error have appeared without blocking past runs — don't chase them.
 - **Deleting a live hero PNG 404s its article** (the MDX statically imports it). Only delete when regenerating.
-- **~2.4 MB per PNG, ~30–90 s each.** A ~50-image backfill is roughly an hour — hence the background run + ETA.
+- **~2 MB per PNG, ~90–120 s each** (measured 98–109 s on codex 0.144). ~30 images ≈ 50 min — hence the background run, ETA, and `MAX_IMAGES` cap.
 - **Per-slug re-parse.** Each `--only` run re-parses the whole vault; that overhead is a few percent of Codex time — the price of clean sequential timing and failure isolation.

--- a/.claude/skills/generate-wiki-images/SKILL.md
+++ b/.claude/skills/generate-wiki-images/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: generate-wiki-images
+description: Import an Obsidian wiki vault into the blog, validate it, then generate the hero images via the Codex CLI — one at a time, with a measured ETA and live progress. Use when the user wants to run the wiki importer against a vault, backfill or regenerate blog hero illustrations, or says "import the wiki", "generate wiki images", "regenerate blog illustrations".
+---
+
+Runs this monorepo's wiki importer (`apps/cli`) end to end: import + validate the articles first, then generate hero PNGs **sequentially**. The native importer generates images 6-wide and aborts the whole batch on the first failure; this skill imports with images off, then runs one `codex exec` at a time via a per-slug loop, so each image is timed (real ETA) and a single failure is isolated instead of killing the run.
+
+## Input
+
+`WIKI_PATH` — absolute path to the Obsidian wiki root, supplied by the caller (no default; a remote runner must pass it). If the user didn't give one, ask. `RAW_PATH` defaults to `<WIKI_PATH>/../raw` and needs no input. Run every command from the repo root.
+
+## Steps
+
+1. **Preflight.** Confirm all three: `codex --version` succeeds (Codex CLI installed *and* logged in — `codex exec` needs auth), `bun` is on PATH, and `WIKI_PATH` resolves to an existing directory. → *ready when all three check out.*
+
+2. **Import & validate.** Import articles and manifests with images off (fast, no Codex), then validate the summary:
+   ```bash
+   cd apps/cli && SKIP_IMAGES=1 WIKI_PATH="$WIKI_PATH" bun run import:wiki
+   ```
+   Confirm the printed summary reports articles written and manifests generated with no thrown error. Unresolved wikilinks and missing-raw warnings are expected (MOC internal links resolve to `home`). → *done when the import exits 0 and `apps/blog/src/data/{article-graph,wiki-sources,open-questions}.json` are updated.* (Blog type-check is deferred to step 4 — it fails until images exist.)
+
+3. **Generate images sequentially.** From the repo root, run the bundled script in the background, logging to a file, then monitor and relay progress:
+   ```bash
+   WIKI_PATH="$WIKI_PATH" bash .claude/skills/generate-wiki-images/scripts/sequential-images.sh
+   ```
+   It dry-runs first (no Codex calls) to list the slugs missing a PNG, then generates them one at a time, printing `[i/N] slug ✓ 47s | elapsed 3m | ETA ~38m` after each. The ETA is measured from real per-image time and announced after the first completes — relay it. → *done when the script prints `Done: N/N generated, 0 failed`.*
+
+4. **Validate the build.** Now that images exist, run the real gate: `bun run type-check` (blog compiles only with every hero PNG present) and confirm `apps/blog/src/content/assets/*.png` count matches `apps/blog/src/content/articles/*.mdx`. → *done when type-check passes and the counts match.*
+
+## Failures & regen
+
+- A slug that fails during step 3 is listed at the end (the run does not abort). Re-check Codex auth/quota, then re-run just those: `cd apps/cli && WIKI_PATH="$WIKI_PATH" bun run import:wiki -- --only <slug>`.
+- Cache is filename-only: to regenerate a changed article's image, delete `apps/blog/src/content/assets/<slug>.png` first, then re-run step 3.
+
+## Gotchas (from prior runs)
+
+- **Codex must be logged in**, not just installed — `codex exec` shells to the local Codex CLI's default model (no `--model` is passed) and uses its `$imagegen` skill. A cold/unauthed CLI fails the image.
+- **No retry, no timeout in the importer.** A hung `codex exec` blocks forever; the per-slug loop limits the blast radius to one image — watch the log and Ctrl-C a stuck image if needed.
+- **Fail-loud, no placeholders.** A missing/invalid PNG (magic-byte check) throws; there is no silent placeholder fallback.
+- **Codex sandbox staging.** Images render into `apps/cli/.codex-staging/` (inside Codex's `workspace-write` sandbox) and then move to `assets/`. Run from the repo, or the sandbox can't write.
+- **Non-fatal noise is normal.** Missing Python `PIL`/`numpy` warnings and an ImageMagick draw error have appeared without blocking past runs — don't chase them.
+- **Deleting a live hero PNG 404s its article** (the MDX statically imports it). Only delete when regenerating.
+- **~2.4 MB per PNG, ~30–90 s each.** A ~50-image backfill is roughly an hour — hence the background run + ETA.
+- **Per-slug re-parse.** Each `--only` run re-parses the whole vault; that overhead is a few percent of Codex time — the price of clean sequential timing and failure isolation.

--- a/.claude/skills/generate-wiki-images/scripts/sequential-images.sh
+++ b/.claude/skills/generate-wiki-images/scripts/sequential-images.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Sequentially generate missing blog hero images via the Codex CLI — one
+# article at a time, with a measured ETA. The native importer runs Codex
+# 6-wide and aborts the whole batch on the first codex failure; this loop
+# runs one `codex exec` per slug, so each image is timed and a single
+# failure is isolated (logged, skipped) instead of killing the run.
+#
+# Usage:  WIKI_PATH=/abs/path/to/vault  bash sequential-images.sh
+# Run from the monorepo root (or apps/cli). No paths are hardcoded —
+# WIKI_PATH is supplied by the caller, apps/cli is located from the CWD.
+# Requires: codex CLI on PATH and logged in; bun; WIKI_PATH = Obsidian wiki root.
+
+: "${WIKI_PATH:?set WIKI_PATH to your Obsidian wiki root}"
+[ -d "$WIKI_PATH" ] || { echo "WIKI_PATH not a directory: $WIKI_PATH" >&2; exit 1; }
+# Resolve to absolute now, before we cd into apps/cli.
+WIKI_PATH="$(cd "$WIKI_PATH" && pwd)"
+command -v codex >/dev/null || { echo "codex CLI not found on PATH" >&2; exit 1; }
+command -v bun   >/dev/null || { echo "bun not found on PATH" >&2; exit 1; }
+
+if [ -f "apps/cli/package.json" ]; then cd apps/cli
+elif [ -f "package.json" ] && [ -d "src/import-wiki" ]; then :   # already in apps/cli
+else echo "run this from the monorepo root (or apps/cli)" >&2; exit 1
+fi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+echo "==> Planning (DRY_RUN, no codex calls)…"
+if ! DRY_RUN=1 WIKI_PATH="$WIKI_PATH" bun run import:wiki >"$tmp/dry.log" 2>&1; then
+  echo "dry run failed:" >&2; tail -n 40 "$tmp/dry.log" >&2; exit 1
+fi
+
+# The dry-run line is: [codex] DRY_RUN — would generate image for "<title>" → <staging>/<slug>.png → <assets>/<slug>.png
+# ponytail: basename-of-.png heuristic; staging+output share a basename so sort -u collapses them.
+grep 'would generate' "$tmp/dry.log" \
+  | grep -oE '[A-Za-z0-9._-]+\.png' \
+  | sed 's/\.png$//' | sort -u >"$tmp/slugs.txt"
+
+total=$(wc -l <"$tmp/slugs.txt" | tr -d ' ')
+if [ "$total" -eq 0 ]; then
+  echo "==> All hero images already present. Nothing to generate."
+  exit 0
+fi
+echo "==> $total image(s) missing. Generating one at a time via 'codex exec'."
+echo "    Per-image time is measured, not guessed — ETA appears after #1."
+
+i=0; cum=0; failed=0
+: >"$tmp/failures.txt"
+while IFS= read -r slug; do
+  i=$((i + 1))
+  start=$SECONDS
+  if WIKI_PATH="$WIKI_PATH" bun run import:wiki -- --only "$slug" >"$tmp/last.log" 2>&1; then
+    dur=$((SECONDS - start)); cum=$((cum + dur))
+    avg=$((cum / i)); remaining=$(((total - i) * avg))
+    printf '[%d/%d] %s ✓ %ds | elapsed %dm | ETA ~%dm\n' \
+      "$i" "$total" "$slug" "$dur" "$((cum / 60))" "$((remaining / 60))"
+  else
+    failed=$((failed + 1)); echo "$slug" >>"$tmp/failures.txt"
+    printf '[%d/%d] %s ✗ FAILED (continuing) — last log lines:\n' "$i" "$total" "$slug"
+    tail -n 15 "$tmp/last.log"
+  fi
+done <"$tmp/slugs.txt"
+
+echo "==> Done: $((total - failed))/$total generated, $failed failed."
+if [ "$failed" -gt 0 ]; then
+  echo "Failed slugs:"; cat "$tmp/failures.txt"
+  echo "Re-run each after checking codex auth/quota:"
+  echo "  cd apps/cli && WIKI_PATH=\"$WIKI_PATH\" bun run import:wiki -- --only <slug>"
+  exit 1
+fi

--- a/.claude/skills/generate-wiki-images/scripts/sequential-images.sh
+++ b/.claude/skills/generate-wiki-images/scripts/sequential-images.sh
@@ -43,27 +43,39 @@ if [ "$total" -eq 0 ]; then
   echo "==> All hero images already present. Nothing to generate."
   exit 0
 fi
-echo "==> $total image(s) missing. Generating one at a time via 'codex exec'."
+# Optional cap for smoke-testing / quota control. MAX_IMAGES=N generates the
+# first N missing images this run; unset or 0 means all of them.
+planned="$total"
+if [ "${MAX_IMAGES:-0}" -gt 0 ] && [ "${MAX_IMAGES}" -lt "$total" ]; then
+  planned="$MAX_IMAGES"
+  echo "==> $total missing; MAX_IMAGES=$MAX_IMAGES — generating the first $planned this run."
+else
+  echo "==> $total image(s) missing. Generating one at a time via 'codex exec'."
+fi
 echo "    Per-image time is measured, not guessed — ETA appears after #1."
 
 i=0; cum=0; failed=0
 : >"$tmp/failures.txt"
 while IFS= read -r slug; do
+  [ "$i" -ge "$planned" ] && break
   i=$((i + 1))
   start=$SECONDS
   if WIKI_PATH="$WIKI_PATH" bun run import:wiki -- --only "$slug" >"$tmp/last.log" 2>&1; then
     dur=$((SECONDS - start)); cum=$((cum + dur))
-    avg=$((cum / i)); remaining=$(((total - i) * avg))
+    avg=$((cum / i)); remaining=$(((planned - i) * avg))
     printf '[%d/%d] %s ✓ %ds | elapsed %dm | ETA ~%dm\n' \
-      "$i" "$total" "$slug" "$dur" "$((cum / 60))" "$((remaining / 60))"
+      "$i" "$planned" "$slug" "$dur" "$((cum / 60))" "$((remaining / 60))"
   else
     failed=$((failed + 1)); echo "$slug" >>"$tmp/failures.txt"
-    printf '[%d/%d] %s ✗ FAILED (continuing) — last log lines:\n' "$i" "$total" "$slug"
+    printf '[%d/%d] %s ✗ FAILED (continuing) — last log lines:\n' "$i" "$planned" "$slug"
     tail -n 15 "$tmp/last.log"
   fi
 done <"$tmp/slugs.txt"
 
-echo "==> Done: $((total - failed))/$total generated, $failed failed."
+echo "==> Done: $((i - failed))/$i generated, $failed failed."
+if [ "$planned" -lt "$total" ]; then
+  echo "    Capped at $planned; $((total - i)) still missing — re-run to continue."
+fi
 if [ "$failed" -gt 0 ]; then
   echo "Failed slugs:"; cat "$tmp/failures.txt"
   echo "Re-run each after checking codex auth/quota:"

--- a/.gitignore
+++ b/.gitignore
@@ -54,8 +54,9 @@ apps/blog/public/rss
 # turborepo
 .turbo/
 
-# claude code
-.claude/
+# claude code (local config ignored; shared skills tracked for reuse)
+.claude/*
+!.claude/skills/
 
 # codex image-generation staging (apps/cli)
 .codex-staging/


### PR DESCRIPTION
Moves the wiki hero-image workflow from a **personal** skill into a **project-level** skill so remote runners get it straight from the repo, and expands it to run the importer end to end.

## What it does now
1. **Preflight** — codex installed + logged in, bun present, `WIKI_PATH` resolves.
2. **Import & validate** — `SKIP_IMAGES=1 … import:wiki` writes articles + manifests (no Codex), then checks the summary and manifests.
3. **Generate images sequentially** — `scripts/sequential-images.sh` dry-runs to find missing `<slug>.png`, then generates them **one at a time** (`bun run import:wiki -- --only <slug>`), timed, with a **measured ETA** and **per-image failure isolation**. The native importer runs Codex 6-wide and aborts the whole batch on the first failure; this loop does not.
4. **Validate build** — `bun run type-check` (blog only compiles once every hero PNG exists) + asset/article count match.

## Portability
- No local paths baked in — `WIKI_PATH` is caller-supplied; `apps/cli` is located from the CWD; the script invocation is repo-relative.
- `.gitignore`: un-ignore `.claude/skills/` (rest of `.claude/` — worktrees, local settings — stays ignored) so the skill travels with the repo for remote reuse.

## Notes / not done
- The bundled gotchas come from 7 prior import runs (codex-must-be-logged-in, filename-only cache, no retry/timeout, fail-loud, sandbox staging, benign PIL/ImageMagick noise, ~2.4 MB & ~30–90 s per image).
- **Not run live** — a full generation is ~1 h and consumes Codex quota; verified `bash -n`, the slug-extraction pipeline against the real dry-run log format, `.gitignore` rules, and that ultracite/gitleaks pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
