### PR TITLE
perf(blog): defer Google Analytics and code-split the search palette

### DIFF
--- a/apps/blog/src/components/google-analytics.tsx
+++ b/apps/blog/src/components/google-analytics.tsx
@@ -34,6 +34,7 @@ export default function GoogleAnalytics({
     <>
       <Script
         src={`https://www.googletagmanager.com/gtag/js?id=${measurementId}`}
+        strategy="lazyOnload"
       />
       <Script id="google-analytics">
         {`

--- a/apps/blog/src/components/search/search-provider.tsx
+++ b/apps/blog/src/components/search/search-provider.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import {
   createContext,
   type ReactNode,
@@ -11,7 +12,10 @@ import {
 
 import { useKeyboardShortcut } from "@/hooks/use-keyboard-shortcut";
 
-import { SearchPalette } from "./search-palette";
+const SearchPalette = dynamic(
+  () => import("./search-palette").then((m) => m.SearchPalette),
+  { ssr: false }
+);
 
 interface SearchContextValue {
   openSearch: () => void;


### PR DESCRIPTION
## What

Two performance fixes for `www.howardism.dev`, driven by a desktop PageSpeed/Lighthouse report of the homepage. Both target the report's weak spots — **TBT (300 ms)** and the **LCP element render delay (1,890 ms)** — which are dominated by JavaScript on the main thread, not by bytes or the server (FCP 0.3 s, CLS 0, TTFB ~10 ms are all already green).

### 1. Defer Google Analytics (`⚡️ strategy="lazyOnload"`)
`gtag/js` was loading with the default `afterInteractive` strategy, executing right in the critical hydration window. The report measured it at **156 KiB transfer + 113 ms main-thread time** — the single largest cost on the page and a top "reduce unused JavaScript" entry (64 KiB unused). Switching the library `<Script>` to `lazyOnload` moves it out of the critical window; the inline `dataLayer`/`gtag` shim keeps its default strategy so early calls still buffer. Analytics stays fully functional (kept, not removed).

### 2. Code-split the search command palette
`SearchPalette` was statically imported and mounted eagerly on every page, shipping `cmdk` + the palette UI in the initial bundle even though it only appears on ⌘/Ctrl-K. Loading it via `next/dynamic` with `ssr: false` splits it into its own on-demand chunk, trimming first-party JS off the critical path (the report flagged ~27 KiB unused in the hot first-party chunk).

## Verification (this session)
- `bun run type-check` ✓ · `bun run lint` (ultracite) ✓ · `bun run build` ✓ (exit 0)
- Pre-push hook (turbo lint + type-check + test across all packages) ✓
- I did **not** re-run PageSpeed against these changes (they aren't deployed yet), so the numbers above are the **diagnosed before-state costs** from the report, not a measured post-change score.

## What was investigated and deliberately dropped
A third candidate — adding a modern `browserslist` to stop shipping legacy-JS polyfills (the report's `Array.prototype.at/flat/flatMap`, `Object.fromEntries/hasOwn`, `String.prototype.trim*`, 13.9 KiB) — was **dropped**. A controlled A/B build (with vs. without `browserslist`) produced **byte-identical** polyfill output. Those polyfills come from **core-js pre-bundled inside a dependency's dist** (no runtime `core-js` dep, no app import), which `browserslist` cannot strip — it only governs *your* code's transpilation. Shipping the config would have misrepresented a fix. Eliminating that ~14 KiB would need a dependency-level change (finding and replacing whatever bundles core-js) — out of scope for this PR and low ROI (it's a shared, long-cached chunk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
