### PR TITLE
✨ feat(cli): wiki maintenance automation — translate:drip, content:check, glossary harvest

### DIFF
--- a/.claude/skills/generate-wiki-images/SKILL.md
+++ b/.claude/skills/generate-wiki-images/SKILL.md
@@ -3,7 +3,7 @@ name: generate-wiki-images
 description: Import an Obsidian wiki vault into the blog, validate it, then generate the hero images via the Codex CLI — one at a time, with a measured ETA and live progress. Use when the user wants to run the wiki importer against a vault, backfill or regenerate blog hero illustrations, or says "import the wiki", "generate wiki images", "regenerate blog illustrations".
 ---
 
-Runs this monorepo's wiki importer (`apps/cli`) end to end: import + validate the articles first, then generate hero PNGs **sequentially**. The native importer generates images 6-wide and aborts the whole batch on the first failure; this skill imports with images off, then runs one `codex exec` at a time via a per-slug loop, so each image is timed (real ETA) and a single failure is isolated instead of killing the run.
+Runs this monorepo's wiki importer (`apps/cli`) end to end: import + validate the articles first, generate hero PNGs **sequentially**, then check translation staleness. The native importer generates images 6-wide and aborts the whole batch on the first failure; this skill imports with images off, then runs one `codex exec` at a time via a per-slug loop, so each image is timed (real ETA) and a single failure is isolated instead of killing the run.
 
 ## Input
 
@@ -33,6 +33,12 @@ Runs this monorepo's wiki importer (`apps/cli`) end to end: import + validate th
      <(ls assets/*.png   | xargs -n1 basename | sed 's/\.png$//' | sort)
    ```
    Empty output = every article has an image. Note `bun run type-check` does **not** catch missing images — TS treats `*.png` as an opaque module, so it passes with PNGs absent; only a full `bun run build` actually fails on a missing hero (at the cost of a slow Next build). → *done when the set difference is empty.*
+
+5. **Check translation staleness.** The import adds or edits English source articles, which any translated copies can now lag behind — surface that debt at review time instead of letting it go unnoticed:
+   ```bash
+   cd apps/cli && bun run translate:check
+   ```
+   Paste the printed status summary (the Fresh / Stale / Verbatim-drift / Missing / Orphan / Untranslated counts) into the content PR body. This step only reports; actually refreshing translations is `bun run translate:drip`, a separate quota-paced job that takes hours by design — don't run it here. → *done when the status summary is pasted into the PR body.*
 
 ## Failures & regen
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,13 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      # Fails the build on broken wiki-generated content: hero-image imports with
+      # no PNG, manifest slug references to deleted articles, or missing required
+      # frontmatter. Orphan articles/PNGs and domains without a MOC are emitted as
+      # non-fatal GitHub annotations.
+      - name: Check content integrity
+        run: bun apps/cli/src/content-check.ts
+
       # Warns (GitHub annotations) — does not fail the build — if any committed
       # zh-TW translation is stale/drifted/orphaned vs its source. Never-translated
       # articles are ignored (translation is opt-in). Drop --warn to hard-fail.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ bun run analyze           # production build with @next/bundle-analyzer
 
 - **Bun workspaces** for dependency management
 - **Turborepo** (`turbo.json`) as the task runner — build order is dependency-aware, caches `lint`, `type-check`, `test`, `build`
+- **Git worktrees**: after creating a worktree of this repo, run `bun install` inside it before running any workspace script — workspace module resolution is broken otherwise.
 
 ### Shared packages
 
@@ -74,14 +75,20 @@ Design system: a single set of oklch design tokens in shadcn slots (`--backgroun
 
 ### CLI (`apps/cli`)
 
-`bun run import:wiki` (entry `src/import-wiki/index.ts`) parses an Obsidian-style wiki vault — point `WIKI_PATH` (and optionally `RAW_PATH`) at it — and emits article MDX/frontmatter into the blog plus two committed manifests under `apps/blog/src/data/`: `article-graph.json` (backlink/related graph) and `wiki-sources.json`. Topics are derived from each note's `tags`. The blog reads these JSON files at build time, so re-run the importer and commit the result when source notes change.
+`bun run import:wiki` (entry `src/import-wiki/index.ts`) parses an Obsidian-style wiki vault — point `WIKI_PATH` (and optionally `RAW_PATH`) at it — and emits article MDX/frontmatter into the blog plus two committed manifests under `apps/blog/src/data/`: `article-graph.json` (backlink/related graph) and `wiki-sources.json`. Topics are derived from each note's `tags`. The blog reads these JSON files at build time, so re-run the importer and commit the result when source notes change. For a full refresh (import + hero image generation + validation), use the `generate-wiki-images` skill in `.claude/skills/`.
+
+#### Content integrity gate
+
+`bun run content:check` — also run in CI — fails on missing hero images (MDX↔PNG mismatch), broken slug references in `article-graph.json`/manifests, and missing `title`/`description`/`imageAlt` frontmatter. It warns (non-fatal) on orphan articles (no backlinks), domains without a `moc-<domain>` article, and orphan PNGs.
 
 #### Translation glossary (SQLite + MCP)
 
 The translation service (`bun run translate`) keeps a **do-not-translate (DNT) glossary** of proper nouns and technical terms to leave verbatim. It lives in `src/glossary/` backed by SQLite (`bun:sqlite`, WAL) at `apps/cli/.translate-glossary.db` — a per-machine, gitignored cache. `store.ts` is the shared core (`openDb`, `listTerms`, `addTerm`, `searchTerms`, `ensureSeeded`); `seed.ts` harvests seed terms (Entity-tagged article titles+slugs, wiki-source authors, base tech acronyms). On first use `ensureSeeded` migrates any legacy `.translate-glossary.json` then harvests the corpus; a populated DB is left untouched so added terms persist.
 
+`bun run translate:check` reports translation staleness across six buckets — **Fresh**, **Stale**, **Verbatim-drift**, **Missing**, **Orphan**, **Untranslated** — by comparing each translated article against its English source; CI runs it with `--warn` to post annotations instead of failing the build. `bun run translate:drip --limit N --interval-min M --max-cycles K` is the fix: a quota-paced loop that runs `translate --update` in small batches spaced across engine quota windows (agy/codex exhaust quota mid-run), repeating until `translate:check` reports nothing actionable; it runs `glossary harvest --add` once at startup.
+
 Two interfaces share the one DB:
-- **CLI** — `bun run glossary list` (JSON array of `{term, category}`) and `bun run glossary add "<term>" <category>`. The translation prompt instructs each engine to shell out to these.
+- **CLI** — `bun run glossary list` (JSON array of `{term, category}`), `bun run glossary add "<term>" <category>`, and `bun run glossary harvest [--add] [slug ...]` (pre-scans article MDX for DNT candidates — acronyms, proper nouns — and diffs against the DB; dry-run by default, `--add` registers). The translation prompt instructs each engine to shell out to these.
 - **MCP server** — `bun run glossary:mcp` (stdio) exposes `glossary_list`, `glossary_add`, `glossary_search` so any MCP client can reuse the glossary as native tool calls. Registered for this repo in `.mcp.json`; other agents can point at it with:
 
   ```json

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -9,6 +9,7 @@
     "test": "bun test",
     "import:wiki": "bun src/import-wiki/index.ts",
     "build:search-index": "bun src/search-index.ts",
+    "content:check": "bun src/content-check.ts",
     "translate": "bun src/translate/index.ts",
     "translate:check": "bun src/translate/index.ts --check",
     "translate:drip": "bun src/translate/drip.ts",

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -11,6 +11,7 @@
     "build:search-index": "bun src/search-index.ts",
     "translate": "bun src/translate/index.ts",
     "translate:check": "bun src/translate/index.ts --check",
+    "translate:drip": "bun src/translate/drip.ts",
     "glossary": "bun src/glossary/cli.ts",
     "glossary:mcp": "bun src/glossary/mcp.ts"
   },

--- a/apps/cli/src/__tests__/content-check.test.ts
+++ b/apps/cli/src/__tests__/content-check.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from "bun:test";
+
+import type { ArticleGraph } from "@howardism/article-contract/manifests/graph";
+import type { OpenQuestionsManifest } from "@howardism/article-contract/manifests/open-questions";
+import type { WikiSourcesManifest } from "@howardism/article-contract/manifests/wiki-sources";
+
+import {
+  type ArticleRecord,
+  checkFrontmatter,
+  checkGraphSlugRefs,
+  checkHeroImages,
+  checkOpenQuestionSlugRefs,
+  checkWikiSourceSlugRefs,
+  extractHeroImage,
+  findDomainsWithoutMoc,
+  findOrphanArticles,
+  findOrphanPngs,
+  parseArticle,
+} from "../content-check.ts";
+
+function article(overrides: Partial<ArticleRecord> = {}): ArticleRecord {
+  return {
+    slug: "a",
+    title: "Title",
+    description: "Description",
+    imageAlt: "Alt",
+    domain: "ai-engineering",
+    heroImage: "a.png",
+    ...overrides,
+  };
+}
+
+function mdx(frontmatter: string, hero = "../assets/a.png"): string {
+  return [
+    "---",
+    frontmatter,
+    "---",
+    `export { default as heroImage } from "${hero}";`,
+    "",
+    "Body.",
+    "",
+  ].join("\n");
+}
+
+describe("extractHeroImage", () => {
+  it("captures the PNG filename from the import line", () => {
+    expect(extractHeroImage(mdx("title: X"))).toBe("a.png");
+  });
+
+  it("returns null when no import line is present", () => {
+    expect(extractHeroImage("---\ntitle: X\n---\n\nBody.")).toBeNull();
+  });
+});
+
+describe("parseArticle", () => {
+  it("reads and trims required frontmatter plus the hero image", () => {
+    const raw = mdx(
+      [
+        "title:  Trimmed  ",
+        "description: A desc",
+        "imageAlt: Alt text",
+        "domain: llm-architecture",
+      ].join("\n"),
+      "../assets/slug.png"
+    );
+    expect(parseArticle(raw, "slug")).toEqual({
+      slug: "slug",
+      title: "Trimmed",
+      description: "A desc",
+      imageAlt: "Alt text",
+      domain: "llm-architecture",
+      heroImage: "slug.png",
+    });
+  });
+
+  it("defaults missing fields to empty string and null domain", () => {
+    const parsed = parseArticle(mdx("title: Only"), "only");
+    expect(parsed.description).toBe("");
+    expect(parsed.imageAlt).toBe("");
+    expect(parsed.domain).toBeNull();
+  });
+});
+
+describe("checkHeroImages", () => {
+  it("passes when every hero image resolves to an asset", () => {
+    const articles = [article({ slug: "a", heroImage: "a.png" })];
+    expect(checkHeroImages(articles, new Set(["a.png"]))).toEqual([]);
+  });
+
+  it("flags a hero image with no matching PNG", () => {
+    const articles = [article({ slug: "gone", heroImage: "gone.png" })];
+    const failures = checkHeroImages(articles, new Set(["a.png"]));
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toContain("gone.png");
+  });
+
+  it("flags an article with no hero import line", () => {
+    const articles = [article({ slug: "bare", heroImage: null })];
+    const failures = checkHeroImages(articles, new Set());
+    expect(failures[0]).toContain("no heroImage import");
+  });
+});
+
+describe("checkGraphSlugRefs", () => {
+  const slugs = new Set(["a", "b"]);
+
+  it("passes when all keys and values are real articles", () => {
+    const graph: ArticleGraph = {
+      backlinks: { a: ["b"], b: ["a"] },
+      outgoing: { a: ["b"] },
+      related: { b: ["a"] },
+      generatedOn: "2026-01-01",
+    };
+    expect(checkGraphSlugRefs(graph, slugs)).toEqual([]);
+  });
+
+  it("flags a dangling value slug and a dangling key slug", () => {
+    const graph: ArticleGraph = {
+      backlinks: { a: ["ghost"] },
+      outgoing: { phantom: ["a"] },
+      related: {},
+      generatedOn: "2026-01-01",
+    };
+    const failures = checkGraphSlugRefs(graph, slugs);
+    expect(failures.join("\n")).toContain("ghost");
+    expect(failures.join("\n")).toContain("phantom");
+    expect(failures).toHaveLength(2);
+  });
+});
+
+describe("checkOpenQuestionSlugRefs", () => {
+  it("flags a concept slug with no article", () => {
+    const manifest: OpenQuestionsManifest = {
+      byConcept: [
+        { slug: "a", title: "A", domain: "ai-engineering", questions: ["q"] },
+        {
+          slug: "missing",
+          title: "M",
+          domain: "ai-engineering",
+          questions: [],
+        },
+      ],
+      generatedOn: "2026-01-01",
+    };
+    const failures = checkOpenQuestionSlugRefs(manifest, new Set(["a"]));
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toContain("missing");
+  });
+});
+
+describe("checkWikiSourceSlugRefs", () => {
+  it("flags a citedBy slug with no article", () => {
+    const manifest: WikiSourcesManifest = {
+      sources: [{ title: "Paper", kind: "Paper", citedBy: ["a", "ghost"] }],
+      generatedOn: "2026-01-01",
+    };
+    const failures = checkWikiSourceSlugRefs(manifest, new Set(["a"]));
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toContain("ghost");
+  });
+});
+
+describe("checkFrontmatter", () => {
+  it("passes when title, description and imageAlt are all present", () => {
+    expect(checkFrontmatter([article()])).toEqual([]);
+  });
+
+  it("lists every missing field in one message per article", () => {
+    const failures = checkFrontmatter([
+      article({ slug: "bad", title: "", description: "", imageAlt: "" }),
+    ]);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toContain("title");
+    expect(failures[0]).toContain("description");
+    expect(failures[0]).toContain("imageAlt");
+  });
+});
+
+describe("findOrphanArticles", () => {
+  it("flags articles with missing or empty backlinks", () => {
+    const articles = [
+      article({ slug: "linked" }),
+      article({ slug: "empty" }),
+      article({ slug: "absent" }),
+    ];
+    const backlinks = { linked: ["other"], empty: [] };
+    expect(findOrphanArticles(articles, backlinks)).toEqual([
+      "empty",
+      "absent",
+    ]);
+  });
+
+  it("exempts moc-* start-here pages", () => {
+    const articles = [article({ slug: "moc-ai-engineering" })];
+    expect(findOrphanArticles(articles, {})).toEqual([]);
+  });
+});
+
+describe("findDomainsWithoutMoc", () => {
+  it("flags domains lacking a moc-<domain> article, sorted", () => {
+    const articles = [
+      article({ slug: "moc-ai-engineering", domain: "ai-engineering" }),
+      article({ slug: "note-1", domain: "ai-engineering" }),
+      article({ slug: "note-2", domain: "syntheses" }),
+      article({ slug: "note-3", domain: "product-org" }),
+    ];
+    expect(findDomainsWithoutMoc(articles)).toEqual([
+      "product-org",
+      "syntheses",
+    ]);
+  });
+
+  it("ignores articles without a domain", () => {
+    expect(findDomainsWithoutMoc([article({ domain: null })])).toEqual([]);
+  });
+});
+
+describe("findOrphanPngs", () => {
+  it("flags PNGs with no matching article slug, sorted", () => {
+    const assets = new Set(["a.png", "orphan.png", "z-orphan.png"]);
+    expect(findOrphanPngs(assets, new Set(["a"]))).toEqual([
+      "orphan.png",
+      "z-orphan.png",
+    ]);
+  });
+});

--- a/apps/cli/src/__tests__/glossary-harvest.test.ts
+++ b/apps/cli/src/__tests__/glossary-harvest.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  extractBody,
+  extractCandidates,
+  filterAgainstGlossary,
+} from "../glossary/harvest.ts";
+
+const doc = (slug: string, text: string) => [{ slug, text }];
+
+const termsOf = (candidates: ReturnType<typeof extractCandidates>): string[] =>
+  candidates.map((c) => c.term);
+
+describe("extractCandidates", () => {
+  it("extracts an acronym as tech", () => {
+    const candidates = extractCandidates(
+      doc("a", "The system uses RLHF to align outputs.")
+    );
+    const rlhf = candidates.find((c) => c.term === "RLHF");
+    expect(rlhf?.category).toBe("tech");
+  });
+
+  it("extracts a CamelCase / mixed-case token as product", () => {
+    const candidates = extractCandidates(
+      doc("a", "DeepMind published the paper on TypeScript tooling.")
+    );
+    expect(termsOf(candidates)).toContain("DeepMind");
+    expect(termsOf(candidates)).toContain("TypeScript");
+    const deepmind = candidates.find((c) => c.term === "DeepMind");
+    expect(deepmind?.category).toBe("product");
+  });
+
+  it("extracts a multi-word Capitalized phrase as entity, without also emitting its component words", () => {
+    const candidates = extractCandidates(
+      doc(
+        "a",
+        "Anthropic pioneered Constitutional AI as a technique for training models."
+      )
+    );
+    expect(termsOf(candidates)).toContain("Constitutional AI");
+    // "AI" alone must not also surface as a separate acronym candidate — its
+    // span was already claimed by the phrase match.
+    expect(termsOf(candidates)).not.toContain("AI");
+  });
+
+  it("does not extract a single repeated Capitalized word (no mid-sentence-repeat rule)", () => {
+    const candidates = extractCandidates(
+      doc(
+        "a",
+        "The team praised Hermes for its speed. Later, they upgraded Hermes again. Colleagues still trust Hermes today."
+      )
+    );
+    expect(termsOf(candidates)).not.toContain("Hermes");
+  });
+
+  it("rejects an RFC-2119 keyword as an acronym", () => {
+    const candidates = extractCandidates(
+      doc("a", "Deployments MUST rotate credentials regularly.")
+    );
+    expect(termsOf(candidates)).not.toContain("MUST");
+  });
+
+  it("rejects a phrase containing an RFC-2119 keyword", () => {
+    const candidates = extractCandidates(
+      doc("a", "Deployments MUST enforce the policy.")
+    );
+    expect(termsOf(candidates)).not.toContain("Deployments MUST");
+  });
+
+  it("rejects a phrase that opens on an auxiliary verb", () => {
+    const candidates = extractCandidates(
+      doc("a", "Is GRPO the right choice for this workload?")
+    );
+    expect(termsOf(candidates)).not.toContain("Is GRPO");
+  });
+
+  it("ignores fenced code blocks and the heroImage export line", () => {
+    const raw = [
+      "---",
+      "title: Test",
+      "---",
+      'export { default as heroImage } from "../assets/test.png";',
+      "",
+      "Before text mentions RLHF once.",
+      "",
+      "```ts",
+      "const ZZZFAKE = 'GPT-9';",
+      "```",
+      "",
+      "After text.",
+    ].join("\n");
+    const cleaned = extractBody(raw);
+    expect(cleaned).not.toContain("ZZZFAKE");
+    expect(cleaned).not.toContain("heroImage");
+    const candidates = extractCandidates(doc("a", cleaned));
+    expect(termsOf(candidates)).not.toContain("ZZZFAKE");
+    expect(termsOf(candidates)).not.toContain("GPT-9");
+    expect(termsOf(candidates)).toContain("RLHF");
+  });
+
+  it("strips whole heading lines so Title Case heading text can't form a fake phrase", () => {
+    const raw = [
+      "---",
+      "title: Test",
+      "---",
+      "",
+      "## Models Improve Over Time",
+      "",
+      "The article mentions Deep Modules as a real concept in its prose.",
+    ].join("\n");
+    const cleaned = extractBody(raw);
+    expect(cleaned).not.toContain("Models Improve");
+    const candidates = extractCandidates(doc("a", cleaned));
+    expect(termsOf(candidates)).not.toContain("Models Improve Over Time");
+    expect(termsOf(candidates)).toContain("Deep Modules");
+  });
+});
+
+describe("filterAgainstGlossary", () => {
+  it("drops exact (case-insensitive) matches", () => {
+    const candidates = extractCandidates(
+      doc("a", "The system uses RLHF to align outputs.")
+    );
+    const filtered = filterAgainstGlossary(candidates, [
+      { term: "rlhf", category: "tech" },
+    ]);
+    expect(termsOf(filtered)).not.toContain("RLHF");
+  });
+
+  it("drops a candidate that is a substring of an existing longer entry", () => {
+    const candidates = [{ term: "Cherny", category: "entity", slugs: ["a"] }];
+    const filtered = filterAgainstGlossary(candidates, [
+      { term: "Boris Cherny", category: "entity" },
+    ]);
+    expect(filtered).toEqual([]);
+  });
+
+  it("keeps a candidate that only shares a substring, not a word-bounded one", () => {
+    const candidates = [{ term: "Cherny", category: "entity", slugs: ["a"] }];
+    const filtered = filterAgainstGlossary(candidates, [
+      { term: "Chernyakova", category: "entity" },
+    ]);
+    expect(filtered).toEqual(candidates);
+  });
+});

--- a/apps/cli/src/__tests__/translate-drip.test.ts
+++ b/apps/cli/src/__tests__/translate-drip.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Unit tests for the drip driver's pure decision logic: argv/env parsing,
+ * check-JSON extraction, actionable counting, and per-cycle bookkeeping. The
+ * subprocess loop itself is out of scope (it just wires these together).
+ */
+import { describe, expect, it } from "bun:test";
+import {
+  countActionable,
+  DRIP_DEFAULTS,
+  evaluateCycle,
+  MAX_ZERO_PROGRESS_CYCLES,
+  parseCheckJson,
+  parseDripArgs,
+} from "../translate/drip.ts";
+
+describe("parseDripArgs", () => {
+  it("uses defaults when nothing is supplied", () => {
+    expect(parseDripArgs([], {})).toEqual({
+      limit: DRIP_DEFAULTS.limit,
+      intervalMin: DRIP_DEFAULTS.intervalMin,
+      maxCycles: DRIP_DEFAULTS.maxCycles,
+    });
+  });
+
+  it("reads flags", () => {
+    expect(
+      parseDripArgs(
+        ["--limit", "3", "--interval-min", "5", "--max-cycles", "7"],
+        {}
+      )
+    ).toEqual({ limit: 3, intervalMin: 5, maxCycles: 7 });
+  });
+
+  it("falls back to env vars", () => {
+    expect(
+      parseDripArgs([], {
+        DRIP_LIMIT: "4",
+        DRIP_INTERVAL_MIN: "60",
+        DRIP_MAX_CYCLES: "8",
+      })
+    ).toEqual({ limit: 4, intervalMin: 60, maxCycles: 8 });
+  });
+
+  it("prefers flags over env vars", () => {
+    expect(parseDripArgs(["--limit", "2"], { DRIP_LIMIT: "9" }).limit).toBe(2);
+  });
+
+  it("allows interval-min of 0 but not a limit of 0", () => {
+    expect(parseDripArgs(["--interval-min", "0"], {}).intervalMin).toBe(0);
+    expect(() => parseDripArgs(["--limit", "0"], {})).toThrow();
+    expect(() => parseDripArgs(["--max-cycles", "0"], {})).toThrow();
+  });
+
+  it("rejects non-integer and missing values", () => {
+    expect(() => parseDripArgs(["--limit", "abc"], {})).toThrow();
+    expect(() => parseDripArgs(["--limit"], {})).toThrow();
+    expect(() => parseDripArgs([], { DRIP_MAX_CYCLES: "abc" })).toThrow();
+  });
+});
+
+describe("countActionable", () => {
+  it("sums stale, missing, verbatim-drift, and untranslated only", () => {
+    expect(
+      countActionable({
+        buckets: {
+          fresh: ["a", "b", "c"],
+          missing: ["d"],
+          stale: ["e", "f"],
+          "verbatim-drift": ["g"],
+          orphan: ["h", "i"],
+          untranslated: ["j"],
+        },
+      })
+    ).toBe(5);
+  });
+
+  it("ignores fresh and orphan", () => {
+    expect(
+      countActionable({ buckets: { fresh: ["a"], orphan: ["b", "c"] } })
+    ).toBe(0);
+  });
+
+  it("tolerates missing keys and an absent buckets field", () => {
+    expect(countActionable({ buckets: {} })).toBe(0);
+    expect(countActionable({})).toBe(0);
+  });
+});
+
+describe("parseCheckJson", () => {
+  it("extracts the JSON object from mixed stdout", () => {
+    const stdout = [
+      "=== Translate check (zh-TW) ===",
+      "Fresh:            3  (a, b, c)",
+      "Stale:            1  (d)",
+      "Recorded spend: $1.2345 across 4 tracked",
+      JSON.stringify({ locale: "zh-TW", buckets: { stale: ["d"] } }),
+    ].join("\n");
+    expect(parseCheckJson(stdout)?.buckets).toEqual({ stale: ["d"] });
+  });
+
+  it("returns the last object carrying buckets when several lines are JSON", () => {
+    const stdout = [
+      JSON.stringify({ note: "not it" }),
+      JSON.stringify({ buckets: { stale: ["x"] } }),
+    ].join("\n");
+    expect(parseCheckJson(stdout)?.buckets).toEqual({ stale: ["x"] });
+  });
+
+  it("returns null when there is no bucket JSON", () => {
+    expect(parseCheckJson("Fresh: 3\nStale: 0\n")).toBeNull();
+    expect(parseCheckJson("")).toBeNull();
+  });
+});
+
+describe("evaluateCycle", () => {
+  const base = {
+    consecutiveZeroProgress: 0,
+    cycle: 1,
+    maxCycles: 20,
+    prevRemaining: 10,
+    remaining: 5,
+  };
+
+  it("reports progress and keeps going", () => {
+    const d = evaluateCycle(base);
+    expect(d).toMatchObject({
+      done: false,
+      abort: false,
+      translated: 5,
+      consecutiveZeroProgress: 0,
+    });
+  });
+
+  it("finishes when nothing is actionable", () => {
+    const d = evaluateCycle({ ...base, remaining: 0 });
+    expect(d.done).toBe(true);
+    expect(d.abort).toBe(false);
+    expect(d.consecutiveZeroProgress).toBe(0);
+  });
+
+  it("increments the zero-progress counter when the backlog does not shrink", () => {
+    const d = evaluateCycle({
+      ...base,
+      prevRemaining: 5,
+      remaining: 5,
+      consecutiveZeroProgress: 1,
+    });
+    expect(d.translated).toBe(0);
+    expect(d.consecutiveZeroProgress).toBe(2);
+    expect(d.abort).toBe(false);
+  });
+
+  it("aborts after the configured consecutive zero-progress cycles", () => {
+    const d = evaluateCycle({
+      ...base,
+      prevRemaining: 5,
+      remaining: 5,
+      consecutiveZeroProgress: MAX_ZERO_PROGRESS_CYCLES - 1,
+    });
+    expect(d.abort).toBe(true);
+    expect(d.done).toBe(false);
+    expect(d.consecutiveZeroProgress).toBe(MAX_ZERO_PROGRESS_CYCLES);
+  });
+
+  it("resets the counter after a productive cycle", () => {
+    const d = evaluateCycle({ ...base, consecutiveZeroProgress: 2 });
+    expect(d.consecutiveZeroProgress).toBe(0);
+  });
+
+  it("aborts once the cycle cap is reached with work still pending", () => {
+    const d = evaluateCycle({
+      ...base,
+      cycle: 20,
+      maxCycles: 20,
+      prevRemaining: 10,
+      remaining: 4,
+    });
+    expect(d.abort).toBe(true);
+    expect(d.reason).toContain("max cycles");
+  });
+
+  it("never reports negative progress", () => {
+    const d = evaluateCycle({ ...base, prevRemaining: 3, remaining: 8 });
+    expect(d.translated).toBe(0);
+    expect(d.consecutiveZeroProgress).toBe(1);
+  });
+});

--- a/apps/cli/src/content-check.ts
+++ b/apps/cli/src/content-check.ts
@@ -1,0 +1,343 @@
+/**
+ * Content-integrity gate for the wiki-generated blog. Runs locally and in CI
+ * (see `.github/workflows/ci.yml`). Type-check alone happily passes when hero
+ * PNGs are missing or the link graph points at deleted articles — a real
+ * incident shipped 30 missing images with exit 0 — so this script is the
+ * enforced check that those never reach `main`.
+ *
+ *   bun apps/cli/src/content-check.ts   # exit 1 if any FAILURE, else 0
+ *
+ * FAILURES (exit 1): hero-image imports that resolve to a real PNG, every slug
+ * referenced by the committed manifests existing as an article, and required
+ * frontmatter (`title`, `description`, `imageAlt`) being present.
+ *
+ * WARNINGS (never affect exit code; emitted as GitHub `::warning::` annotations
+ * under CI): orphan articles with no backlinks, domains without a `moc-<domain>`
+ * "start here" article, and orphan PNGs with no article. These are editorial
+ * signals, not build breakers.
+ *
+ * The check functions are pure and unit-tested against small in-memory
+ * fixtures; only `main` touches the filesystem.
+ */
+import { readdir, readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+
+import type { ArticleGraph } from "@howardism/article-contract/manifests/graph";
+import type { OpenQuestionsManifest } from "@howardism/article-contract/manifests/open-questions";
+import type { WikiSourcesManifest } from "@howardism/article-contract/manifests/wiki-sources";
+import matter from "gray-matter";
+
+const HERE = dirname(new URL(import.meta.url).pathname);
+const REPO_ROOT = resolve(HERE, "../../../");
+const ARTICLES_DIR = resolve(REPO_ROOT, "apps/blog/src/content/articles");
+const ASSETS_DIR = resolve(REPO_ROOT, "apps/blog/src/content/assets");
+const DATA_DIR = resolve(REPO_ROOT, "apps/blog/src/data");
+
+const MDX_SUFFIX = /\.mdx$/;
+const PNG_SUFFIX = /\.png$/;
+const MOC_PREFIX = "moc-";
+// The `export { default as heroImage } from "../assets/<file>.png";` line every
+// emitted MDX carries after its frontmatter. Capture the referenced filename.
+const HERO_IMPORT_RE =
+  /export\s*\{\s*default as heroImage\s*\}\s*from\s*["']\.\.\/assets\/([^"']+)["']/;
+
+/** One article reduced to just the fields the integrity checks need. */
+export interface ArticleRecord {
+  description: string;
+  domain: string | null;
+  /** hero PNG filename from the import line (e.g. `foo.png`), or null if absent. */
+  heroImage: string | null;
+  imageAlt: string;
+  slug: string;
+  title: string;
+}
+
+/** Extract the hero-image filename from raw MDX, or null when no import line. */
+export function extractHeroImage(raw: string): string | null {
+  return raw.match(HERO_IMPORT_RE)?.[1] ?? null;
+}
+
+/** Parse one MDX article's raw source into an {@link ArticleRecord}. */
+export function parseArticle(raw: string, slug: string): ArticleRecord {
+  const { data } = matter(raw);
+  return {
+    slug,
+    title: String(data.title ?? "").trim(),
+    description: String(data.description ?? "").trim(),
+    imageAlt: String(data.imageAlt ?? "").trim(),
+    domain: data.domain ? String(data.domain) : null,
+    heroImage: extractHeroImage(raw),
+  };
+}
+
+// ---- FAILURE checks: return one message per broken invariant ----
+
+/** Every article must import a hero image that exists in the assets dir. */
+export function checkHeroImages(
+  articles: ArticleRecord[],
+  assetFilenames: Set<string>
+): string[] {
+  const failures: string[] = [];
+  for (const article of articles) {
+    if (article.heroImage === null) {
+      failures.push(`${article.slug}: no heroImage import line`);
+    } else if (!assetFilenames.has(article.heroImage)) {
+      failures.push(
+        `${article.slug}: hero image "${article.heroImage}" not found in assets/`
+      );
+    }
+  }
+  return failures;
+}
+
+/** Every slug used as a key or value in the link graph must be a real article. */
+export function checkGraphSlugRefs(
+  graph: ArticleGraph,
+  articleSlugs: Set<string>
+): string[] {
+  const failures: string[] = [];
+  for (const relation of ["backlinks", "outgoing", "related"] as const) {
+    for (const [source, targets] of Object.entries(graph[relation] ?? {})) {
+      if (!articleSlugs.has(source)) {
+        failures.push(`graph.${relation} key "${source}" has no article`);
+      }
+      for (const target of targets) {
+        if (!articleSlugs.has(target)) {
+          failures.push(
+            `graph.${relation}["${source}"] → "${target}" has no article`
+          );
+        }
+      }
+    }
+  }
+  return failures;
+}
+
+/** Every concept slug in the open-questions manifest must be a real article. */
+export function checkOpenQuestionSlugRefs(
+  manifest: OpenQuestionsManifest,
+  articleSlugs: Set<string>
+): string[] {
+  const failures: string[] = [];
+  for (const concept of manifest.byConcept ?? []) {
+    if (!articleSlugs.has(concept.slug)) {
+      failures.push(`open-questions concept "${concept.slug}" has no article`);
+    }
+  }
+  return failures;
+}
+
+/** Every `citedBy` slug in the wiki-sources manifest must be a real article. */
+export function checkWikiSourceSlugRefs(
+  manifest: WikiSourcesManifest,
+  articleSlugs: Set<string>
+): string[] {
+  const failures: string[] = [];
+  for (const source of manifest.sources ?? []) {
+    for (const slug of source.citedBy ?? []) {
+      if (!articleSlugs.has(slug)) {
+        failures.push(
+          `wiki-sources "${source.title}" citedBy "${slug}" has no article`
+        );
+      }
+    }
+  }
+  return failures;
+}
+
+/** Required frontmatter must be present and non-empty on every article. */
+export function checkFrontmatter(articles: ArticleRecord[]): string[] {
+  const failures: string[] = [];
+  for (const article of articles) {
+    const missing = (["title", "description", "imageAlt"] as const).filter(
+      (field) => article[field].length === 0
+    );
+    if (missing.length > 0) {
+      failures.push(`${article.slug}: missing ${missing.join(", ")}`);
+    }
+  }
+  return failures;
+}
+
+// ---- WARNING checks: editorial signals, never fail the build ----
+
+/**
+ * Articles no other article links to are dead ends for readers. MOC ("start
+ * here") pages are entry points by design and exempt.
+ */
+export function findOrphanArticles(
+  articles: ArticleRecord[],
+  backlinks: Record<string, string[]>
+): string[] {
+  const orphans: string[] = [];
+  for (const { slug } of articles) {
+    if (slug.startsWith(MOC_PREFIX)) {
+      continue;
+    }
+    if ((backlinks[slug]?.length ?? 0) === 0) {
+      orphans.push(slug);
+    }
+  }
+  return orphans;
+}
+
+/**
+ * Domains without a `moc-<domain>` article have no curated spine — the domain
+ * page falls back to a bare date-sorted table.
+ */
+export function findDomainsWithoutMoc(articles: ArticleRecord[]): string[] {
+  const slugs = new Set(articles.map((a) => a.slug));
+  const domains = new Set<string>();
+  for (const { domain } of articles) {
+    if (domain) {
+      domains.add(domain);
+    }
+  }
+  return [...domains]
+    .filter((domain) => !slugs.has(`${MOC_PREFIX}${domain}`))
+    .sort();
+}
+
+/** PNGs in assets/ with no article that imports them — dead weight. */
+export function findOrphanPngs(
+  assetFilenames: Set<string>,
+  articleSlugs: Set<string>
+): string[] {
+  const orphans: string[] = [];
+  for (const filename of assetFilenames) {
+    const slug = filename.replace(PNG_SUFFIX, "");
+    if (!articleSlugs.has(slug)) {
+      orphans.push(filename);
+    }
+  }
+  return orphans.sort();
+}
+
+// ---- Orchestration (filesystem I/O lives only below this line) ----
+
+interface CheckResult {
+  messages: string[];
+  name: string;
+}
+
+async function readMdxSlugs(dir: string): Promise<string[]> {
+  const entries = await readdir(dir);
+  return entries
+    .filter((name) => MDX_SUFFIX.test(name))
+    .map((name) => name.replace(MDX_SUFFIX, ""))
+    .sort();
+}
+
+async function loadArticles(): Promise<ArticleRecord[]> {
+  const slugs = await readMdxSlugs(ARTICLES_DIR);
+  const articles: ArticleRecord[] = [];
+  for (const slug of slugs) {
+    const raw = await readFile(resolve(ARTICLES_DIR, `${slug}.mdx`), "utf8");
+    articles.push(parseArticle(raw, slug));
+  }
+  return articles;
+}
+
+async function loadAssetFilenames(): Promise<Set<string>> {
+  const entries = await readdir(ASSETS_DIR);
+  return new Set(entries.filter((name) => PNG_SUFFIX.test(name)));
+}
+
+async function loadJson<T>(filename: string): Promise<T> {
+  const raw = await readFile(resolve(DATA_DIR, filename), "utf8");
+  return JSON.parse(raw) as T;
+}
+
+function printResults(title: string, results: CheckResult[]): void {
+  console.log(`\n${title}`);
+  for (const { name, messages } of results) {
+    console.log(`  ${name.padEnd(24)} ${String(messages.length).padStart(4)}`);
+    for (const message of messages) {
+      console.log(`      ${message}`);
+    }
+  }
+}
+
+/** One `::warning::` per warning message so CI surfaces them as annotations. */
+function emitWarningAnnotations(results: CheckResult[]): void {
+  for (const { name, messages } of results) {
+    for (const message of messages) {
+      console.log(`::warning::[content-check] ${name}: ${message}`);
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  const [articles, assetFilenames, graph, openQuestions, wikiSources] =
+    await Promise.all([
+      loadArticles(),
+      loadAssetFilenames(),
+      loadJson<ArticleGraph>("article-graph.json"),
+      loadJson<OpenQuestionsManifest>("open-questions.json"),
+      loadJson<WikiSourcesManifest>("wiki-sources.json"),
+    ]);
+  const articleSlugs = new Set(articles.map((a) => a.slug));
+
+  const failures: CheckResult[] = [
+    {
+      name: "hero-images",
+      messages: checkHeroImages(articles, assetFilenames),
+    },
+    {
+      name: "graph-slug-refs",
+      messages: checkGraphSlugRefs(graph, articleSlugs),
+    },
+    {
+      name: "open-question-slug-refs",
+      messages: checkOpenQuestionSlugRefs(openQuestions, articleSlugs),
+    },
+    {
+      name: "wiki-source-slug-refs",
+      messages: checkWikiSourceSlugRefs(wikiSources, articleSlugs),
+    },
+    { name: "frontmatter-required", messages: checkFrontmatter(articles) },
+  ];
+  const warnings: CheckResult[] = [
+    {
+      name: "orphan-articles",
+      messages: findOrphanArticles(articles, graph.backlinks ?? {}),
+    },
+    {
+      name: "domains-without-moc",
+      messages: findDomainsWithoutMoc(articles),
+    },
+    {
+      name: "orphan-pngs",
+      messages: findOrphanPngs(assetFilenames, articleSlugs),
+    },
+  ];
+
+  const failCount = failures.reduce((n, r) => n + r.messages.length, 0);
+  const warnCount = warnings.reduce((n, r) => n + r.messages.length, 0);
+
+  console.log("=== Content integrity check ===");
+  console.log(`Articles: ${articles.length}   Assets: ${assetFilenames.size}`);
+  printResults("FAILURES", failures);
+  printResults("WARNINGS", warnings);
+
+  if (process.env.GITHUB_ACTIONS) {
+    emitWarningAnnotations(warnings);
+  }
+
+  console.log(
+    `\nResult: ${failCount === 0 ? "PASS" : "FAIL"} (${failCount} failure${
+      failCount === 1 ? "" : "s"
+    }, ${warnCount} warning${warnCount === 1 ? "" : "s"})`
+  );
+
+  if (failCount > 0) {
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.main) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/apps/cli/src/glossary/cli.ts
+++ b/apps/cli/src/glossary/cli.ts
@@ -1,5 +1,7 @@
+import type { Database } from "bun:sqlite";
 import { resolve } from "node:path";
 
+import { harvestGlossaryCandidates } from "./harvest.ts";
 import type { SeedSources } from "./seed.ts";
 import {
   addTerm,
@@ -41,9 +43,13 @@ const printUsage = (): void => {
       "  bun src/glossary/cli.ts list",
       '  bun src/glossary/cli.ts add "<term>" <category>',
       "  bun src/glossary/cli.ts add-many '<json>'",
+      "  bun src/glossary/cli.ts harvest [--add] [slug ...]",
       "",
       `Categories: ${GLOSSARY_CATEGORIES.join(" | ")}`,
       'add-many JSON shape: [{"term":"<t>","category":"<category>"}, ...]',
+      "harvest: pre-scans article MDX for DNT candidates (acronyms, proper",
+      "  nouns) not yet in the glossary. No slugs -> scan every article.",
+      "  Dry-run by default (prints candidates); --add registers them.",
     ].join("\n")
   );
 };
@@ -65,6 +71,48 @@ const parseAddManyJson = (raw: string | undefined): GlossaryEntry[] => {
   }
   return parsed as GlossaryEntry[];
 };
+
+async function runHarvestCommand(
+  db: Database,
+  opts: CliOptions,
+  rest: string[]
+): Promise<number> {
+  const addFlag = rest.includes("--add");
+  const slugs = rest.filter((a) => a !== "--add");
+  const { candidates } = await harvestGlossaryCandidates(
+    {
+      articlesDir: opts.sources.articlesDir,
+      slugs: slugs.length ? slugs : undefined,
+    },
+    listTerms(db)
+  );
+
+  if (candidates.length === 0) {
+    console.log("harvest: no new candidate terms found");
+    return 0;
+  }
+
+  if (addFlag) {
+    const { added } = addTerms(
+      db,
+      candidates.map((c) => ({ term: c.term, category: c.category })),
+      { source: "harvest" }
+    );
+    for (const c of candidates) {
+      console.log(`added: ${c.term} (${c.category}) [${c.slugs.join(", ")}]`);
+    }
+    console.log(
+      `harvest: added ${added} of ${candidates.length} candidate term(s)`
+    );
+    return 0;
+  }
+
+  for (const c of candidates) {
+    console.log(`${c.term} (${c.category}) [${c.slugs.join(", ")}]`);
+  }
+  console.log(`harvest: ${candidates.length} candidate term(s)`);
+  return 0;
+}
 
 async function runCli(argv: string[]): Promise<number> {
   const [command, ...rest] = argv;
@@ -121,6 +169,10 @@ async function runCli(argv: string[]): Promise<number> {
       // output style.
       console.log(JSON.stringify({ added: result.added, total }));
       return 0;
+    }
+
+    if (command === "harvest") {
+      return await runHarvestCommand(db, opts, rest);
     }
 
     console.error(`Unknown command: ${command}`);

--- a/apps/cli/src/glossary/harvest.ts
+++ b/apps/cli/src/glossary/harvest.ts
@@ -1,0 +1,536 @@
+import { readdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import matter from "gray-matter";
+
+import type { GlossaryEntry } from "./store.ts";
+
+export interface HarvestCandidate {
+  category: string;
+  slugs: string[];
+  term: string;
+}
+
+export interface HarvestDoc {
+  slug: string;
+  text: string;
+}
+
+export interface HarvestOptions {
+  articlesDir: string;
+  slugs?: string[];
+}
+
+const MDX_SUFFIX_RE = /\.mdx$/;
+const CODE_FENCE_RE = /```[\s\S]*?```/g;
+const HERO_IMAGE_LINE_RE = /^export\s*\{[^}]*\bheroImage\b[^}]*\}[^\n]*$/gm;
+// Blank out leading list/blockquote markers so they never read as part of a
+// word. Headings are handled separately (see HEADING_FULL_LINE_RE) — their
+// entire line is dropped, not just the marker.
+const MARKDOWN_LINE_PREFIX_RE = /^([-*+]\s+|\d+\.\s+|>\s*)/gm;
+const HEADING_LINE_RE = /^#{1,6}\s+(.*)$/;
+// Any markdown heading line, dropped in full. Title Case headings ("##
+// Recommended Error Categories", "## Models Improve") are the main generator
+// of fake multi-word phrases — real proper-noun phrases occur in body prose,
+// not heading text, so this loses no genuine signal.
+const HEADING_FULL_LINE_RE = /^#{1,6}\s+.*$/gm;
+// Headings that introduce a bullet list of hyperlinked article/citation
+// titles (external sources, or this article's own backlink/related graph) —
+// not the article's own prose.
+const LINK_LIST_HEADING_RE = /^(sources|connections|related|derived)$/i;
+
+/**
+ * Blank out link-list sections (heading through the next heading, or end of
+ * text): `## Sources`, `## Connections`, `## Related`, `## Derived`. Their
+ * arbitrary Title Case (external citation titles, or other articles' titles
+ * from the backlink graph) pollutes candidate extraction — e.g. a citation
+ * called "A Field Guide to Fable" yields the junk phrase "A Field Guide".
+ * Replaces each blanked line with spaces of the same length so character
+ * offsets elsewhere are unaffected.
+ */
+function blankLinkListSections(text: string): string {
+  const lines = text.split("\n");
+  let inLinkList = false;
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i] as string;
+    const headingMatch = HEADING_LINE_RE.exec(line);
+    if (headingMatch) {
+      inLinkList = LINK_LIST_HEADING_RE.test(
+        (headingMatch[1] as string).trim()
+      );
+    }
+    if (inLinkList) {
+      lines[i] = " ".repeat(line.length);
+    }
+  }
+  return lines.join("\n");
+}
+
+// A bare URL (e.g. inside a markdown link's `(...)` target) — its path can
+// contain arbitrary mixed-case IDs (a YouTube video ID, a hash) that read as
+// CamelCase but aren't words at all.
+const URL_RE = /https?:\/\/\S+/g;
+
+/**
+ * Clean a raw MDX file's content down to prose: strip YAML frontmatter (via
+ * gray-matter), link-list sections (Sources/Connections/Related/Derived),
+ * fenced code blocks, the `heroImage` export line, URLs, whole heading
+ * lines, and leading list/blockquote markers. Pure — no IO.
+ */
+export function extractBody(raw: string): string {
+  const { content } = matter(raw);
+  return blankLinkListSections(content)
+    .replace(CODE_FENCE_RE, " ")
+    .replace(HERO_IMAGE_LINE_RE, " ")
+    .replace(URL_RE, (m) => " ".repeat(m.length))
+    .replace(HEADING_FULL_LINE_RE, (m) => " ".repeat(m.length))
+    .replace(MARKDOWN_LINE_PREFIX_RE, (m) => " ".repeat(m.length));
+}
+
+interface Span {
+  end: number;
+  start: number;
+}
+
+const overlapsAny = (span: Span, spans: Span[]): boolean =>
+  spans.some((s) => span.start < s.end && span.end > s.start);
+
+/**
+ * Collect non-overlapping matches of `re` against `text`, skipping any span
+ * that overlaps one already in `consumed` (mutated in place with newly
+ * accepted spans) so a later, lower-priority pattern can't re-split a match
+ * already claimed by a higher-priority one — e.g. "Brown" inside the phrase
+ * match "Noam Brown".
+ */
+function collectNonOverlapping(
+  text: string,
+  re: RegExp,
+  consumed: Span[],
+  filter?: (match: string) => boolean
+): string[] {
+  const out: string[] = [];
+  re.lastIndex = 0;
+  let m = re.exec(text);
+  while (m) {
+    const span: Span = { start: m.index, end: m.index + m[0].length };
+    if (!overlapsAny(span, consumed) && (!filter || filter(m[0]))) {
+      out.push(m[0]);
+      consumed.push(span);
+    }
+    m = re.exec(text);
+  }
+  return out;
+}
+
+// RFC-2119 spec keywords: always-caps, but shouting emphasis ("Deployments
+// MUST ...") rather than a genuine acronym or proper-noun phrase word.
+// Rejected from both the acronym rule and phrase matching (see
+// isValidPhrase below).
+const RFC2119_KEYWORDS = new Set([
+  "must",
+  "should",
+  "shall",
+  "may",
+  "not",
+  "required",
+  "optional",
+  "recommended",
+]);
+
+// 3-8 chars, all caps, digits/hyphens allowed (RLHF, GPT-5, INF). A 2-char
+// floor let through too many ambiguous fragments (Roman numerals "II"/"IV",
+// interjections "OK") relative to genuine acronyms — precision over recall.
+const ACRONYM_RE = /\b[A-Z][A-Z0-9]*(?:-[A-Z0-9]+)*\b/g;
+const MIN_ACRONYM_LEN = 3;
+const MAX_ACRONYM_LEN = 8;
+const isValidAcronym = (m: string): boolean =>
+  m.length >= MIN_ACRONYM_LEN &&
+  m.length <= MAX_ACRONYM_LEN &&
+  !RFC2119_KEYWORDS.has(m.toLowerCase());
+
+// CamelCase / mixed-case product tokens (DeepMind, TypeScript, OpenAI): two
+// or more capital-initiated segments glued together.
+const CAMEL_RE = /\b[A-Z][a-z0-9]+(?:[A-Z][a-z0-9]*)+\b/g;
+
+// 2+ consecutive Capitalized words (Constitutional AI, Noam Brown, and —
+// via the internal hyphen — Alignment Fine-Tuning). Each word must be 2+
+// chars so a sentence-initial "A"/"I" doesn't glue onto the real term that
+// follows it ("A Jacobian" -> just "Jacobian"). The separator is same-line
+// whitespace only ([ \t], not \s) so a heading/paragraph break (blank line)
+// never glues its last word onto the next line's first word.
+const PHRASE_RE = /\b[A-Z][A-Za-z0-9-]+(?:[ \t]+[A-Z][A-Za-z0-9-]+)+\b/g;
+
+const MONTH_NAMES = [
+  "january",
+  "february",
+  "march",
+  "april",
+  "may",
+  "june",
+  "july",
+  "august",
+  "september",
+  "october",
+  "november",
+  "december",
+];
+
+// Function words (articles/pronouns/prepositions/conjunctions/auxiliary
+// verbs) that can start a phrase match purely by grammar, not because the
+// phrase is a proper noun ("The Open", "For UI", "Her May", "Is GRPO").
+// Rejecting these as a phrase's FIRST word is safe because a genuine
+// proper-noun phrase never opens on a function word.
+const LEADING_FUNCTION_WORDS = new Set([
+  "the",
+  "a",
+  "an",
+  "i",
+  "you",
+  "he",
+  "she",
+  "it",
+  "we",
+  "they",
+  "this",
+  "that",
+  "these",
+  "those",
+  "his",
+  "her",
+  "its",
+  "our",
+  "your",
+  "their",
+  "who",
+  "whom",
+  "whose",
+  "which",
+  "what",
+  "where",
+  "when",
+  "why",
+  "how",
+  "in",
+  "on",
+  "at",
+  "by",
+  "for",
+  "with",
+  "about",
+  "against",
+  "between",
+  "into",
+  "through",
+  "during",
+  "before",
+  "after",
+  "above",
+  "below",
+  "to",
+  "from",
+  "up",
+  "down",
+  "over",
+  "under",
+  "within",
+  "of",
+  "off",
+  "out",
+  "since",
+  "as",
+  "and",
+  "but",
+  "or",
+  "nor",
+  "so",
+  "yet",
+  "because",
+  "although",
+  "though",
+  "while",
+  "if",
+  "unless",
+  "until",
+  "not",
+  "no",
+  "plus",
+  // Spelled-out cardinal numbers — deliberately EXCLUDING "zero" (Zero
+  // Trust, Zero OKR are real terms in this corpus that open on it).
+  "one",
+  "two",
+  "three",
+  "four",
+  "five",
+  "six",
+  "seven",
+  "eight",
+  "nine",
+  "ten",
+  // Sentence-level adverbs/connectors/participles: a genuine proper-noun
+  // phrase never opens on one either ("Once Claude", "Previously Anthropic",
+  // "Recommended Error Categories" are all sentence/heading fragments).
+  "once",
+  "previously",
+  "recommended",
+  "however",
+  "therefore",
+  "additionally",
+  "meanwhile",
+  "finally",
+  "specifically",
+  "notably",
+  "importantly",
+  "essentially",
+  "furthermore",
+  "moreover",
+  "instead",
+  "otherwise",
+  "similarly",
+  "likewise",
+  "consequently",
+  "accordingly",
+  "now",
+  "today",
+  "recently",
+  "currently",
+  "typically",
+  "generally",
+  "usually",
+  "often",
+  "rarely",
+  "always",
+  "never",
+  "later",
+  "earlier",
+  "soon",
+  "eventually",
+  "certainly",
+  "clearly",
+  "obviously",
+  "surprisingly",
+  "unfortunately",
+  "fortunately",
+  "actually",
+  "basically",
+  "literally",
+  "given",
+  "unlike",
+  "besides",
+  "regarding",
+  "concerning",
+  "including",
+  "excluding",
+  // Structural section/document references ("Part II", "Remark III").
+  "part",
+  "section",
+  "chapter",
+  "remark",
+  "figure",
+  "table",
+  "appendix",
+  "theorem",
+  "lemma",
+  "corollary",
+  // Auxiliary/copula verbs: closed-class, so a genuine proper-noun phrase
+  // never opens on one either ("Is GRPO" is a body-prose rhetorical
+  // question, not a term). Deliberately NOT extending this to open-class
+  // descriptive verbs/nouns ("Hit", "Median") — those are enumerable only
+  // by whack-a-mole, which is out of scope here.
+  "is",
+  "are",
+  "was",
+  "were",
+  "has",
+  "have",
+  "had",
+  "does",
+  "did",
+  "do",
+  "will",
+  "would",
+  "can",
+  "could",
+  "should",
+]);
+
+const PHRASE_WORD_RE = /[ \t]+/;
+
+/**
+ * True unless `term` (a raw {@link PHRASE_RE} match) opens on a function
+ * word ("The Open", "For UI") or contains a bare month name or RFC-2119
+ * keyword ("Her May", "Released April", "Deployments MUST") — all read as
+ * 2+ Capitalized words but aren't proper nouns.
+ */
+const isValidPhrase = (term: string): boolean => {
+  const words = term.split(PHRASE_WORD_RE).map((w) => w.toLowerCase());
+  if (LEADING_FUNCTION_WORDS.has(words[0] as string)) {
+    return false;
+  }
+  return !words.some((w) => MONTH_NAMES.includes(w) || RFC2119_KEYWORDS.has(w));
+};
+
+/**
+ * Extract candidate DNT terms from a set of already-cleaned (see
+ * {@link extractBody}) article bodies. Precision over recall:
+ * - acronyms -> category "tech"
+ * - CamelCase / mixed-case tokens -> "product"
+ * - multi-word Capitalized phrases -> "entity"
+ * A single repeated Capitalized word is deliberately NOT its own rule — at
+ * corpus scale almost any generic English word used as a bolded list-item
+ * label ("**Review**:", "**Sales**:") clears a low repeat bar without being
+ * a genuine proper noun; real single-word DNT terms are rare enough to add
+ * manually. Pure function — no IO, no glossary lookups. Returned candidates
+ * are sorted by term and carry every slug they were seen in.
+ */
+export function extractCandidates(docs: HarvestDoc[]): HarvestCandidate[] {
+  const byKey = new Map<
+    string,
+    { category: string; slugs: Set<string>; term: string }
+  >();
+  const upsert = (term: string, category: string, slug: string): void => {
+    const key = term.toLowerCase();
+    const existing = byKey.get(key);
+    if (existing) {
+      existing.slugs.add(slug);
+      return;
+    }
+    byKey.set(key, { term, category, slugs: new Set([slug]) });
+  };
+
+  for (const { slug, text } of docs) {
+    const consumed: Span[] = [];
+    for (const term of collectNonOverlapping(
+      text,
+      PHRASE_RE,
+      consumed,
+      isValidPhrase
+    )) {
+      upsert(term, "entity", slug);
+    }
+    for (const term of collectNonOverlapping(text, CAMEL_RE, consumed)) {
+      upsert(term, "product", slug);
+    }
+    for (const term of collectNonOverlapping(
+      text,
+      ACRONYM_RE,
+      consumed,
+      isValidAcronym
+    )) {
+      upsert(term, "tech", slug);
+    }
+  }
+
+  return [...byKey.values()]
+    .map((v) => ({
+      term: v.term,
+      category: v.category,
+      slugs: [...v.slugs].sort(),
+    }))
+    .sort((a, b) => a.term.localeCompare(b.term));
+}
+
+const WORD_CHAR_RE = /[a-z0-9]/i;
+const isWordChar = (c: string | undefined): boolean =>
+  !!c && WORD_CHAR_RE.test(c);
+
+/**
+ * True if `term` is a strict substring of some existing (longer) entry at a
+ * word boundary on both sides — e.g. "Cherny" inside "Boris Cherny". Keeps
+ * harvest from re-suggesting a fragment of an already-registered phrase.
+ */
+const isCoveredBySubstring = (
+  term: string,
+  existingLower: string[]
+): boolean => {
+  const lower = term.toLowerCase();
+  return existingLower.some((existing) => {
+    if (existing.length <= lower.length) {
+      return false;
+    }
+    const idx = existing.indexOf(lower);
+    if (idx < 0) {
+      return false;
+    }
+    return !(
+      isWordChar(existing[idx - 1]) || isWordChar(existing[idx + lower.length])
+    );
+  });
+};
+
+/**
+ * Drop candidates already in the glossary (case-insensitive) or that are a
+ * substring of an existing longer entry. Pure — takes `listTerms(db)`'s
+ * output rather than a DB handle.
+ */
+export function filterAgainstGlossary(
+  candidates: HarvestCandidate[],
+  existing: GlossaryEntry[]
+): HarvestCandidate[] {
+  const existingLowerSet = new Set(existing.map((e) => e.term.toLowerCase()));
+  const existingLowerList = [...existingLowerSet];
+  return candidates.filter((c) => {
+    const lower = c.term.toLowerCase();
+    if (existingLowerSet.has(lower)) {
+      return false;
+    }
+    return !isCoveredBySubstring(c.term, existingLowerList);
+  });
+}
+
+/**
+ * Read + clean the given slugs' (or, if omitted, every) `.mdx` article under
+ * `articlesDir`. An explicitly-requested slug whose file is missing is
+ * skipped with a stderr warning rather than failing the whole scan.
+ */
+export async function readArticleDocs(
+  articlesDir: string,
+  slugs?: string[]
+): Promise<HarvestDoc[]> {
+  let filenames: string[];
+  if (slugs && slugs.length > 0) {
+    filenames = slugs.map((slug) => `${slug}.mdx`);
+  } else {
+    try {
+      filenames = (await readdir(articlesDir)).filter((f) =>
+        MDX_SUFFIX_RE.test(f)
+      );
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        return [];
+      }
+      throw err;
+    }
+  }
+
+  const docs: HarvestDoc[] = [];
+  for (const filename of filenames) {
+    const slug = filename.replace(MDX_SUFFIX_RE, "");
+    const filePath = join(articlesDir, filename);
+    let raw: string;
+    try {
+      raw = await readFile(filePath, "utf8");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        console.error(`harvest: skipping missing article "${slug}"`);
+        continue;
+      }
+      throw err;
+    }
+    docs.push({ slug, text: extractBody(raw) });
+  }
+  return docs;
+}
+
+/**
+ * Top-level orchestrator used by the CLI: scan the given (or all) articles,
+ * extract candidate DNT terms, and filter out anything already covered by
+ * `existing` (typically `listTerms(db)`).
+ */
+export async function harvestGlossaryCandidates(
+  options: HarvestOptions,
+  existing: GlossaryEntry[]
+): Promise<{ candidates: HarvestCandidate[]; scannedSlugs: string[] }> {
+  const docs = await readArticleDocs(options.articlesDir, options.slugs);
+  const candidates = filterAgainstGlossary(extractCandidates(docs), existing);
+  return { candidates, scannedSlugs: docs.map((d) => d.slug) };
+}

--- a/apps/cli/src/translate/drip.ts
+++ b/apps/cli/src/translate/drip.ts
@@ -1,0 +1,331 @@
+/**
+ * Quota-paced "drip" driver for the zh-TW translation pipeline.
+ *
+ * Translation engines (agy, codex) exhaust their usage quota mid-run, so a full
+ * sync has to be spread across quota windows (~5h for codex). This loops small
+ * `translate --update --limit N` batches, re-checks remaining work via
+ * `translate --check --json`, and sleeps `interval` between cycles until nothing
+ * actionable remains — or the cycle cap / stall guard trips.
+ *
+ * The subprocess loop is intentionally thin; the decision logic lives in the
+ * exported pure functions below, which the unit tests exercise directly.
+ */
+import { dirname, resolve } from "node:path";
+
+const HERE = dirname(new URL(import.meta.url).pathname);
+const TRANSLATE_ENTRY = resolve(HERE, "index.ts");
+const GLOSSARY_ENTRY = resolve(HERE, "../glossary/cli.ts");
+
+const MS_PER_MINUTE = 60_000;
+
+export const DRIP_DEFAULTS = {
+  limit: 10,
+  intervalMin: 300,
+  maxCycles: 20,
+} as const;
+
+/** Stop after this many consecutive cycles that fail to reduce the backlog. */
+export const MAX_ZERO_PROGRESS_CYCLES = 3;
+
+/**
+ * Buckets a `translate --update` run actually acts on, and therefore what the
+ * drip loops until empty: `stale`/`missing`/`untranslated` get (re)translated,
+ * `verbatim-drift` gets a cheap resync. `fresh` is done; `orphan` is left for
+ * manual cleanup (--update only warns on it, so counting it would never
+ * converge).
+ */
+export const DRIP_ACTIONABLE_BUCKETS = [
+  "missing",
+  "stale",
+  "verbatim-drift",
+  "untranslated",
+] as const;
+
+export interface DripConfig {
+  intervalMin: number;
+  limit: number;
+  maxCycles: number;
+}
+
+export interface CheckJson {
+  buckets?: Record<string, string[]>;
+}
+
+export interface CycleInput {
+  /** Running zero-progress counter as it stood before this cycle. */
+  consecutiveZeroProgress: number;
+  /** 1-based number of the cycle just completed. */
+  cycle: number;
+  maxCycles: number;
+  /** Actionable count from the check before this cycle's batch. */
+  prevRemaining: number;
+  /** Actionable count from the check after this cycle's batch. */
+  remaining: number;
+}
+
+export interface CycleDecision {
+  /** Stop unsuccessfully (stalled or hit the cycle cap). */
+  abort: boolean;
+  consecutiveZeroProgress: number;
+  /** Nothing actionable left — stop successfully. */
+  done: boolean;
+  /** Human-readable stop reason, or null when the loop should continue. */
+  reason: string | null;
+  /** Backlog reduction this cycle (never negative). */
+  translated: number;
+}
+
+/** Sum the buckets a `translate --update` run would clear. */
+export function countActionable(check: CheckJson): number {
+  const buckets = check.buckets ?? {};
+  return DRIP_ACTIONABLE_BUCKETS.reduce((total, key) => {
+    const slugs = buckets[key];
+    return total + (Array.isArray(slugs) ? slugs.length : 0);
+  }, 0);
+}
+
+/**
+ * Pull the check JSON back out of mixed stdout. `--check --json` prints the
+ * human-readable table too, so scan from the end for the last line that parses
+ * to an object carrying `buckets`. Returns null when no such line exists.
+ */
+export function parseCheckJson(stdout: string): CheckJson | null {
+  const lines = stdout.split("\n");
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    const line = lines[i].trim();
+    if (!line.startsWith("{")) {
+      continue;
+    }
+    try {
+      const parsed: unknown = JSON.parse(line);
+      if (parsed && typeof parsed === "object" && "buckets" in parsed) {
+        return parsed as CheckJson;
+      }
+    } catch {
+      // Not JSON (a table row that happens to start with "{"); keep scanning.
+    }
+  }
+  return null;
+}
+
+/** Decide whether to continue, finish, or abort after a completed cycle. */
+export function evaluateCycle(input: CycleInput): CycleDecision {
+  const translated = Math.max(0, input.prevRemaining - input.remaining);
+  const madeProgress = input.remaining < input.prevRemaining;
+  const consecutiveZeroProgress = madeProgress
+    ? 0
+    : input.consecutiveZeroProgress + 1;
+
+  if (input.remaining <= 0) {
+    return {
+      abort: false,
+      consecutiveZeroProgress: 0,
+      done: true,
+      reason: "all translations up to date",
+      translated,
+    };
+  }
+  if (consecutiveZeroProgress >= MAX_ZERO_PROGRESS_CYCLES) {
+    return {
+      abort: true,
+      consecutiveZeroProgress,
+      done: false,
+      reason: `no progress for ${MAX_ZERO_PROGRESS_CYCLES} consecutive cycles (${input.remaining} still actionable)`,
+      translated,
+    };
+  }
+  if (input.cycle >= input.maxCycles) {
+    return {
+      abort: true,
+      consecutiveZeroProgress,
+      done: false,
+      reason: `reached max cycles (${input.maxCycles}); ${input.remaining} still actionable`,
+      translated,
+    };
+  }
+  return {
+    abort: false,
+    consecutiveZeroProgress,
+    done: false,
+    reason: null,
+    translated,
+  };
+}
+
+function parseIntOption(
+  argv: string[],
+  env: Record<string, string | undefined>,
+  flag: string,
+  envKey: string,
+  fallback: number,
+  min: number
+): number {
+  let raw: string | undefined;
+  const idx = argv.indexOf(flag);
+  if (idx >= 0) {
+    raw = argv[idx + 1];
+    if (!raw || raw.startsWith("-")) {
+      throw new Error(`${flag} requires an integer >= ${min}`);
+    }
+  } else {
+    raw = env[envKey];
+  }
+  if (raw == null || raw === "") {
+    return fallback;
+  }
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < min) {
+    throw new Error(
+      `${flag} / ${envKey} must be an integer >= ${min} (got "${raw}")`
+    );
+  }
+  return n;
+}
+
+export function parseDripArgs(
+  argv: string[],
+  env: Record<string, string | undefined>
+): DripConfig {
+  return {
+    limit: parseIntOption(
+      argv,
+      env,
+      "--limit",
+      "DRIP_LIMIT",
+      DRIP_DEFAULTS.limit,
+      1
+    ),
+    intervalMin: parseIntOption(
+      argv,
+      env,
+      "--interval-min",
+      "DRIP_INTERVAL_MIN",
+      DRIP_DEFAULTS.intervalMin,
+      0
+    ),
+    maxCycles: parseIntOption(
+      argv,
+      env,
+      "--max-cycles",
+      "DRIP_MAX_CYCLES",
+      DRIP_DEFAULTS.maxCycles,
+      1
+    ),
+  };
+}
+
+async function runStreaming(args: string[]): Promise<number> {
+  const proc = Bun.spawn(["bun", ...args], {
+    env: process.env,
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  await proc.exited;
+  return proc.exitCode ?? 0;
+}
+
+/** Run `translate --check --json` and parse its buckets out of stdout. */
+async function runCheck(): Promise<CheckJson> {
+  const proc = Bun.spawn(["bun", TRANSLATE_ENTRY, "--check", "--json"], {
+    env: process.env,
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+  const stdout = await new Response(proc.stdout).text();
+  // --check exits 1 when there's drift; that's the signal, not an error. We
+  // only fail if the JSON line itself is missing.
+  await proc.exited;
+  const parsed = parseCheckJson(stdout);
+  if (!parsed) {
+    throw new Error("translate --check --json produced no parseable JSON");
+  }
+  return parsed;
+}
+
+/** Best-effort seed refresh — never fatal. DRY_RUN keeps it read-only too. */
+async function harvestGlossary(): Promise<void> {
+  const addFlag = process.env.DRY_RUN === "1" ? [] : ["--add"];
+  try {
+    const code = await runStreaming([GLOSSARY_ENTRY, "harvest", ...addFlag]);
+    if (code !== 0) {
+      console.warn(`[drip] glossary harvest exited ${code}; continuing`);
+    }
+  } catch (err) {
+    console.warn(
+      `[drip] glossary harvest failed: ${(err as Error).message}; continuing`
+    );
+  }
+}
+
+async function main(): Promise<void> {
+  const cfg = parseDripArgs(process.argv.slice(2), process.env);
+  console.log(
+    `[drip] starting: limit=${cfg.limit} interval=${cfg.intervalMin}min max-cycles=${cfg.maxCycles}`
+  );
+
+  await harvestGlossary();
+
+  let prevRemaining = countActionable(await runCheck());
+  console.log(`[drip] initial actionable: ${prevRemaining}`);
+  if (prevRemaining <= 0) {
+    console.log("[drip] nothing to translate; exiting");
+    return;
+  }
+
+  let consecutiveZeroProgress = 0;
+  const intervalMs = cfg.intervalMin * MS_PER_MINUTE;
+
+  for (let cycle = 1; cycle <= cfg.maxCycles; cycle += 1) {
+    const code = await runStreaming([
+      TRANSLATE_ENTRY,
+      "--update",
+      "--limit",
+      String(cfg.limit),
+    ]);
+    if (code !== 0) {
+      // Engines exhausting quota mid-batch is the normal case this tool exists
+      // for — re-check and let the stall guard catch a genuine dead end.
+      console.warn(
+        `[drip] cycle ${cycle}: translate batch exited ${code} (engine quota exhaustion is expected); continuing`
+      );
+    }
+
+    const remaining = countActionable(await runCheck());
+    const decision = evaluateCycle({
+      consecutiveZeroProgress,
+      cycle,
+      maxCycles: cfg.maxCycles,
+      prevRemaining,
+      remaining,
+    });
+    consecutiveZeroProgress = decision.consecutiveZeroProgress;
+    prevRemaining = remaining;
+
+    const willContinue = !(decision.done || decision.abort);
+    const nextWindow = willContinue
+      ? new Date(Date.now() + intervalMs).toISOString()
+      : "—";
+    console.log(
+      `[drip] cycle ${cycle}/${cfg.maxCycles}: translated ${decision.translated}, ${remaining} remaining, next window ${nextWindow}`
+    );
+
+    if (decision.done) {
+      console.log(`[drip] done: ${decision.reason}`);
+      return;
+    }
+    if (decision.abort) {
+      console.warn(`[drip] stopping: ${decision.reason}`);
+      process.exitCode = 1;
+      return;
+    }
+
+    await Bun.sleep(intervalMs);
+  }
+}
+
+if (import.meta.main) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/apps/cli/src/translate/index.ts
+++ b/apps/cli/src/translate/index.ts
@@ -58,6 +58,8 @@ interface RunOptions {
   engineTimeoutMs: number;
   force: boolean;
   glossaryPath: string;
+  /** With --check: also print the status buckets as one JSON object on stdout. */
+  json: boolean;
   kiroClient: string | undefined;
   /** Cap the number of articles queued per run; null = no limit (all articles). */
   limit: number | null;
@@ -463,6 +465,9 @@ async function runCheck(opts: RunOptions): Promise<void> {
   }
 
   printCheck(opts.locale, buckets, projection);
+  if (opts.json) {
+    printCheckJson(opts.locale, buckets, projection);
+  }
 
   // Tracked translations that drifted — never untranslated ones. With --warn
   // (CI) report them as GitHub annotations and exit 0; otherwise fail the build.
@@ -513,6 +518,30 @@ function printCheck(
   console.log(line("Untranslated:", buckets.untranslated));
   console.log(
     `Recorded spend: $${spend.toFixed(4)} across ${Object.keys(projection.articles).length} tracked`
+  );
+}
+
+/**
+ * Machine-readable twin of {@link printCheck}: one compact JSON object on a
+ * single line so consumers (e.g. the drip driver) can parse it out of stdout.
+ * The `buckets` arrays are the source of truth; counts are their lengths.
+ */
+function printCheckJson(
+  locale: string,
+  buckets: CheckBuckets,
+  projection: TranslationProjection
+): void {
+  const spend = Object.values(projection.articles).reduce(
+    (sum, a) => sum + (a.costUsd ?? 0),
+    0
+  );
+  console.log(
+    JSON.stringify({
+      locale,
+      buckets,
+      spend,
+      tracked: Object.keys(projection.articles).length,
+    })
   );
 }
 
@@ -697,6 +726,7 @@ function parseOptions(): RunOptions {
   const force = argv.includes("--force") || env.FORCE === "1";
   const update = argv.includes("--update") || env.TRANSLATE_UPDATE === "1";
   const check = argv.includes("--check");
+  const json = argv.includes("--json");
   const warn = argv.includes("--warn");
   const adopt = argv.includes("--adopt");
   const dryRun = env.DRY_RUN === "1";
@@ -749,6 +779,7 @@ function parseOptions(): RunOptions {
     engineTimeoutMs,
     force,
     glossaryPath,
+    json,
     kiroClient,
     limit,
     locale: targetLang,


### PR DESCRIPTION
## Why

Session history shows the same wiki-maintenance workflows repeated manually since May: full-sync translations die mid-run on engine quota, a prior import shipped 30 missing hero images with type-check green, and every translation batch started with a dozen manual `glossary add` calls. This PR turns those into repo commands and an enforced CI gate.

## What

1. **`bun run translate:drip`** (`apps/cli/src/translate/drip.ts`) — quota-paced loop: runs `translate --update --limit N` batches spaced `--interval-min` apart (defaults: limit 10, 300 min, 20 cycles max) until `translate --check --json` reports nothing actionable (missing + stale + verbatim-drift + untranslated; orphans excluded since `--update` only warns on them). Stall guard aborts after 3 consecutive zero-progress cycles. Runs `glossary harvest --add` once at startup (skips `--add` under `DRY_RUN=1`). The `--json` flag is a new additive machine-readable twin of the `--check` table.
2. **`bun run content:check`** (`apps/cli/src/content-check.ts`) — fails on: hero-image import without its PNG (or no import line), manifest slug refs to nonexistent articles (article-graph, open-questions, wiki-sources), missing `title`/`description`/`imageAlt`. Warns (GitHub annotations in CI): orphan articles with no backlinks, domains without a `moc-<domain>` spine, orphan PNGs. New step in the existing CI `translations` job.
3. **`bun run glossary harvest [--add] [slug ...]`** — batch do-not-translate candidate scan (acronyms, CamelCase, multi-word proper phrases) diffed against the glossary DB. Headings/code-fences/link-list sections/URLs stripped before extraction; RFC-2119 keywords and phrases opening on function/auxiliary words rejected. Dry-run by default.
4. **Docs** — CLAUDE.md names the exact commands (incl. `translate:check`'s six buckets and the worktree-needs-`bun install` gotcha); the `generate-wiki-images` skill gains Step 5: paste the `translate:check` summary into content PR bodies.

## Verification (run in this session, in this worktree)

- Root `bun run lint` / `type-check` / `test`: all green. `apps/cli` suite 323 tests / 0 fail (651 assertions); blog suite 168 / 0 fail.
- `bun apps/cli/src/content-check.ts` against the real 243-article corpus: exit 0 — 0 failures, 2 known-intentional warnings (synthetic `open-questions` page has no backlinks; `syntheses` domain deliberately has no MOC).
- `glossary harvest` dry-run on the full corpus: 1058 candidates; ~2.2% unambiguous junk in a 45-item sample across 3 offsets (iteratively tightened from >35% by dropping a low-precision single-word rule, stripping headings, and rejecting RFC-2119/auxiliary-verb leads).
- `DRY_RUN=1 translate:drip --limit 1 --max-cycles 1 --interval-min 0`: full loop end-to-end, reports the current 212-item actionable backlog, and the glossary DB mtime is unchanged (dry-run proven read-only).
- `translate --check --json`: valid single-line JSON; existing `--check --warn` tests still pass.
- `ci.yml` YAML validity checked; existing steps untouched.

**Not verified here** (deferred deliberately): a real multi-hour `translate:drip` run against live engines, and a real `harvest --add` DB mutation. The current 212-item translation backlog is the first real drip run's job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014v1veXVrz4xvhzbecmgfTz
