### PR TITLE
✨ feat(blog): App Store support + privacy pages

### DIFF
--- a/apps/blog/src/app/(blog)/(layout)/constants.ts
+++ b/apps/blog/src/app/(blog)/(layout)/constants.ts
@@ -16,4 +16,6 @@ export const FOOTER_NAV: { label: string; href: string }[] = [
   { label: "Questions", href: "/questions" },
   { label: "Shelf", href: "/shelf" },
   { label: "RSS", href: "/rss/feed.xml" },
+  { label: "Support", href: "/support" },
+  { label: "Privacy", href: "/privacy" },
 ];

--- a/apps/blog/src/app/(blog)/privacy/page.tsx
+++ b/apps/blog/src/app/(blog)/privacy/page.tsx
@@ -1,0 +1,49 @@
+import type { Metadata } from "next";
+
+import { DiscPageHeader } from "@/components/howardism/disc-page-header";
+import { env } from "@/config/env";
+
+import { PlatePage } from "../_shell/plate-page";
+
+// The App Store Privacy Policy URL points here. Apple requires a privacy policy
+// URL for every app, even one that collects no data.
+
+const PRIVACY_URL = `${env.NEXT_PUBLIC_DOMAIN_NAME}/privacy`;
+const SUPPORT_EMAIL = "support@howardism.dev";
+
+export const dynamic = "error";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy — Howardism",
+  description: "Privacy policy for the app.",
+  alternates: { canonical: PRIVACY_URL },
+  openGraph: { url: PRIVACY_URL },
+};
+
+export default function PrivacyPage() {
+  return (
+    <PlatePage header="none" plate="home" width="read">
+      <DiscPageHeader
+        eyebrowEnd="HOWARDISM"
+        eyebrowStart="Privacy"
+        title="Privacy policy"
+        variant="compact"
+      />
+      <div className="prose mt-8 max-w-none">
+        {/*
+          TODO(privacy): replace everything inside this block with the privacy
+          policy text you provide. The app collects no data ("Data Not
+          Collected" in App Store Connect), so the policy can be short. Keep a
+          "Last updated" date and a contact line pointing at the address below.
+        */}
+        <p>
+          <strong>TODO — replace with your privacy policy text.</strong>
+        </p>
+        <p>
+          Questions about this policy? Email{" "}
+          <a href={`mailto:${SUPPORT_EMAIL}`}>{SUPPORT_EMAIL}</a>.
+        </p>
+      </div>
+    </PlatePage>
+  );
+}

--- a/apps/blog/src/app/(blog)/support/page.tsx
+++ b/apps/blog/src/app/(blog)/support/page.tsx
@@ -1,0 +1,91 @@
+import type { Metadata } from "next";
+
+import { DiscPageHeader } from "@/components/howardism/disc-page-header";
+import { env } from "@/config/env";
+
+import { PlatePage } from "../_shell/plate-page";
+
+// The App Store Support URL points here. Apple's reviewer will open it and
+// expect a working way to reach you plus a plain intro to the app.
+
+// TODO(support): replace these placeholders with the real app details before launch.
+const APP_NAME = "TODO — App Name";
+const APP_TAGLINE =
+  "TODO — one line describing what the app does and who it is for.";
+const APP_PLATFORM = "iOS"; // TODO — confirm the platform(s).
+const SUPPORT_EMAIL = "support@howardism.dev";
+
+// TODO(support): replace with 3–5 real questions users actually ask.
+const FAQ: { q: string; a: string }[] = [
+  {
+    q: "TODO — a common question about the app?",
+    a: "TODO — a clear, short answer.",
+  },
+  {
+    q: "TODO — another common question?",
+    a: "TODO — the answer.",
+  },
+];
+
+// TODO(support): list any known issues, or leave the fallback below.
+const KNOWN_ISSUES: string[] = [];
+
+const SUPPORT_URL = `${env.NEXT_PUBLIC_DOMAIN_NAME}/support`;
+
+export const dynamic = "error";
+
+export const metadata: Metadata = {
+  title: `${APP_NAME} — Support`,
+  description: `Support, FAQ, and contact for ${APP_NAME}.`,
+  alternates: { canonical: SUPPORT_URL },
+  openGraph: { url: SUPPORT_URL },
+};
+
+export default function SupportPage() {
+  return (
+    <PlatePage header="none" plate="home" width="read">
+      <DiscPageHeader
+        eyebrowEnd="HOWARDISM"
+        eyebrowStart="Support"
+        title={`${APP_NAME} support`}
+        variant="compact"
+      />
+      <div className="prose mt-8 max-w-none">
+        <p>{APP_TAGLINE}</p>
+        <p>
+          {APP_NAME} is available on {APP_PLATFORM}. Found a bug, or have a
+          question? Email{" "}
+          <a href={`mailto:${SUPPORT_EMAIL}`}>{SUPPORT_EMAIL}</a> and I will get
+          back to you.
+        </p>
+
+        <h2>Frequently asked questions</h2>
+        <dl>
+          {FAQ.map((item) => (
+            <div key={item.q}>
+              <dt>{item.q}</dt>
+              <dd>{item.a}</dd>
+            </div>
+          ))}
+        </dl>
+
+        <h2>Known issues</h2>
+        {KNOWN_ISSUES.length > 0 ? (
+          <ul>
+            {KNOWN_ISSUES.map((issue) => (
+              <li key={issue}>{issue}</li>
+            ))}
+          </ul>
+        ) : (
+          <p>No known issues at this time.</p>
+        )}
+
+        <h2>Contact</h2>
+        <p>
+          Email <a href={`mailto:${SUPPORT_EMAIL}`}>{SUPPORT_EMAIL}</a>. I aim
+          to respond within a few days.
+        </p>
+      </div>
+    </PlatePage>
+  );
+}


### PR DESCRIPTION
## What

Adds the two pages the App Store submission needs, linked from the footer:

- **`/support`** → App Store Connect *Support URL*. Intro + FAQ + known issues + `support@howardism.dev` contact.
- **`/privacy`** → App Store Connect *Privacy Policy URL*. Scaffold for the "Data Not Collected" policy text.
- **Footer**: `Support` + `Privacy` chips appended to `FOOTER_NAV`.

Both render through the existing `PlatePage` shell (`header="none"` + compact `DiscPageHeader` + `prose` body). English-only, prerendered static.

## Decisions (from grilling)

| Branch | Outcome |
|---|---|
| Data profile | None collected → "Data Not Collected" |
| Pages | Two clean URLs: `/support`, `/privacy` |
| Support channel | Intro + FAQ + known issues + email |
| Privacy text | User provides verbatim (placeholder for now) |
| Contact | Dedicated `support@howardism.dev` |
| Sitemap | Not added (matches convention: `/questions`, `/shelf` also omitted) |

## ⚠️ Before merge / App Store submission — owner action required

These are content placeholders (marked `TODO(...)` in the files), not design gaps:

1. **App name / one-liner / platform** — fill `APP_NAME`, `APP_TAGLINE`, `APP_PLATFORM` in `support/page.tsx`.
2. **Privacy policy text** — replace the placeholder block in `privacy/page.tsx`.
3. **FAQ** — 3–5 real Q&As in `support/page.tsx`.
4. **Create the `support@howardism.dev` alias** at the mail host (Apple's reviewer may email it).

## Verification

- `bun x ultracite fix` — clean
- `bun run type-check` — passes
- `bun run test` — 168 pass, 0 fail
- `bun run build` — `/support` and `/privacy` prerender as static `○`; rendered HTML contains the contact email, FAQ, and placeholders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
