### PR TITLE
⚡️ perf(blog): close the Lighthouse agentic-browsing gaps

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,10 @@
     "glossary": {
       "command": "bun",
       "args": ["apps/cli/src/glossary/mcp.ts"]
+    },
+    "knowledge": {
+      "command": "bun",
+      "args": ["apps/cli/src/knowledge/mcp.ts"]
     }
   }
 }

--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -25,7 +25,6 @@
     "fast-glob": "^3.3.2",
     "feed": "^5.2.0",
     "focus-visible": "^5.2.0",
-    "fuse.js": "^7.1.0",
     "hast-util-heading-rank": "^3.0.0",
     "hast-util-to-string": "^3.0.1",
     "lodash.throttle": "^4.1.1",

--- a/apps/blog/src/__tests__/llms-txt.test.ts
+++ b/apps/blog/src/__tests__/llms-txt.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "bun:test";
+import { getVisibleArticles } from "@/app/(blog)/articles/service";
+import { GET } from "@/app/llms.txt/route";
+import { env } from "@/config/env";
+
+// Mirrors Lighthouse's agentic `llms-txt` audit
+// (core/audits/agentic/llms-txt.js): a malformed file scores 0, so these
+// checks match its hard requirements verbatim.
+const H1_PATTERN = /^\s*#\s+.+/m;
+const LINK_PATTERN = /\[.+\]\(.+\)/;
+const MIN_LENGTH = 50;
+
+describe("llms.txt route", () => {
+  it("returns a 2xx response with markdown content", async () => {
+    const response = await GET();
+    expect(response.status).toBeGreaterThanOrEqual(200);
+    expect(response.status).toBeLessThan(300);
+
+    const body = await response.text();
+    expect(body.length).toBeGreaterThan(0);
+  });
+
+  it("contains an H1 heading", async () => {
+    const body = await (await GET()).text();
+    expect(H1_PATTERN.test(body)).toBe(true);
+  });
+
+  it("contains at least one markdown link", async () => {
+    const body = await (await GET()).text();
+    expect(LINK_PATTERN.test(body)).toBe(true);
+  });
+
+  it("is at least 50 characters", async () => {
+    const body = await (await GET()).text();
+    expect(body.length).toBeGreaterThanOrEqual(MIN_LENGTH);
+  });
+
+  it("lists every visible article as a markdown link", async () => {
+    const body = await (await GET()).text();
+    const visible = await getVisibleArticles();
+
+    expect(visible.ids.length).toBeGreaterThan(0);
+    for (const slug of visible.ids) {
+      expect(body).toContain(
+        `(${env.NEXT_PUBLIC_DOMAIN_NAME}/articles/${slug})`
+      );
+    }
+  });
+});

--- a/apps/blog/src/__tests__/search/search-data.test.ts
+++ b/apps/blog/src/__tests__/search/search-data.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "bun:test";
 
+import { createFuse, searchEntries } from "@howardism/article-contract/search";
+
 import {
   buildSnippet,
-  createFuse,
   type SearchEntry,
-  searchEntries,
 } from "@/components/search/search-data";
 
 const entries: SearchEntry[] = [

--- a/apps/blog/src/__tests__/search/webmcp-tools.test.ts
+++ b/apps/blog/src/__tests__/search/webmcp-tools.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "bun:test";
+
+import type { SearchEntry } from "@/components/search/search-data";
+import { getArticle, searchArticles } from "@/components/search/webmcp-tools";
+
+const entries: SearchEntry[] = [
+  {
+    slug: "agent-loop-pattern",
+    title: "Agent Loop Pattern",
+    description: "Loops as a next-generation agent primitive.",
+    tag: "Concept",
+    domain: "ai-engineering",
+    tags: ["automation"],
+    body: "A loop repeatedly executes a prompt until a queue is empty.",
+  },
+  {
+    slug: "rlhf",
+    title: "RLHF",
+    description: "Reinforcement learning from human feedback.",
+    tag: "Concept",
+    domain: "llm-architecture",
+    tags: ["alignment"],
+    body: "Reward models shape model behaviour during alignment training.",
+  },
+];
+
+describe("searchArticles", () => {
+  it("returns matching slugs, shaped for an agent, without the body", () => {
+    const json = searchArticles(
+      entries,
+      { query: "loop" },
+      "https://www.howardism.dev"
+    );
+    const results = JSON.parse(json) as Record<string, unknown>[];
+
+    expect(results.map((r) => r.slug)).toContain("agent-loop-pattern");
+    expect(results.every((r) => !("body" in r))).toBe(true);
+
+    const match = results.find((r) => r.slug === "agent-loop-pattern");
+    expect(match?.url).toBe(
+      "https://www.howardism.dev/articles/agent-loop-pattern"
+    );
+    expect(match?.title).toBe("Agent Loop Pattern");
+  });
+
+  it("returns nothing for a blank query", () => {
+    const json = searchArticles(
+      entries,
+      { query: "   " },
+      "https://www.howardism.dev"
+    );
+    expect(JSON.parse(json)).toEqual([]);
+  });
+});
+
+describe("getArticle", () => {
+  it("returns the body for a known slug", () => {
+    expect(getArticle(entries, { slug: "rlhf" })).toBe(
+      "Reward models shape model behaviour during alignment training."
+    );
+  });
+
+  it("returns a not-found message for an unknown slug", () => {
+    const result = getArticle(entries, { slug: "does-not-exist" });
+    expect(result).toContain("does-not-exist");
+    expect(result).not.toBe(entries[0]?.body);
+  });
+});

--- a/apps/blog/src/app/(blog)/(layout)/constants.ts
+++ b/apps/blog/src/app/(blog)/(layout)/constants.ts
@@ -17,3 +17,10 @@ export const FOOTER_NAV: { label: string; href: string }[] = [
   { label: "Shelf", href: "/shelf" },
   { label: "RSS", href: "/rss/feed.xml" },
 ];
+
+/** Machine-readable maps of the site — footer only, not part of the nav. */
+export const REFERENCE_LINKS: { label: string; href: string }[] = [
+  { label: "llms.txt", href: "/llms.txt" },
+  { label: "sitemap.xml", href: "/sitemap.xml" },
+  { label: "feed.json", href: "/rss/feed.json" },
+];

--- a/apps/blog/src/app/(blog)/(layout)/footer.tsx
+++ b/apps/blog/src/app/(blog)/(layout)/footer.tsx
@@ -47,7 +47,6 @@ export function Footer() {
           {SOCIAL_LINKS.map((link) => (
             <li key={link.href}>
               <ExternalLink
-                aria-label={link["aria-label"]}
                 className="flex items-center gap-1.5 font-mono text-[10.5px] text-foreground-subtle uppercase tracking-[0.14em] no-underline transition-colors hover:text-brand"
                 href={link.href}
               >

--- a/apps/blog/src/app/(blog)/(layout)/footer.tsx
+++ b/apps/blog/src/app/(blog)/(layout)/footer.tsx
@@ -6,7 +6,7 @@ import ExternalLink from "@/app/(common)/external-link";
 
 import { SOCIAL_LINKS } from "../social-links";
 import { Avatar } from "./avatar";
-import { FOOTER_NAV } from "./constants";
+import { FOOTER_NAV, REFERENCE_LINKS } from "./constants";
 
 const SOCIAL_LABEL: Record<string, string> = {
   "Follow on GitHub": "github.com/Howard86",
@@ -56,6 +56,22 @@ export function Footer() {
             </li>
           ))}
         </ul>
+
+        {/* Reference row */}
+        <nav aria-label="Machine-readable references">
+          <ul className="flex list-none flex-wrap items-center gap-x-4 gap-y-2 p-0">
+            {REFERENCE_LINKS.map(({ label, href }) => (
+              <li key={href}>
+                <Link
+                  className="font-mono text-[10.5px] text-foreground-subtle uppercase tracking-[0.14em] no-underline transition-colors hover:text-brand"
+                  href={href}
+                >
+                  {label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </nav>
 
         {/* Colophon */}
         <span className="font-mono text-[10px] text-foreground-subtle tracking-[0.02em]">

--- a/apps/blog/src/app/(blog)/articles/[slug]/article-layout.tsx
+++ b/apps/blog/src/app/(blog)/articles/[slug]/article-layout.tsx
@@ -154,6 +154,11 @@ export function ArticleLayout({
             <Image
               alt={meta.imageAlt}
               className="mb-10 h-auto w-full rounded-md"
+              // `priority` alone emits the preload link and drops loading=lazy,
+              // but Next 16 does not set fetchpriority on the element itself —
+              // which is exactly what Lighthouse's LCP `priorityHinted` check
+              // reads. Both are needed.
+              fetchPriority="high"
               placeholder="blur"
               priority
               sizes="(min-width: 760px) 720px, 100vw"

--- a/apps/blog/src/app/(blog)/articles/[slug]/article-layout.tsx
+++ b/apps/blog/src/app/(blog)/articles/[slug]/article-layout.tsx
@@ -155,6 +155,7 @@ export function ArticleLayout({
               alt={meta.imageAlt}
               className="mb-10 h-auto w-full rounded-md"
               placeholder="blur"
+              priority
               sizes="(min-width: 760px) 720px, 100vw"
               src={heroImage}
             />

--- a/apps/blog/src/app/llms.txt/route.ts
+++ b/apps/blog/src/app/llms.txt/route.ts
@@ -1,0 +1,54 @@
+import { DOMAIN_META, DOMAIN_ORDER } from "@/app/(blog)/articles/domain-meta";
+import { getVisibleArticles } from "@/app/(blog)/articles/service";
+import { SITE_DESCRIPTION, SITE_NAME } from "@/app/constants";
+import { env } from "@/config/env";
+
+export const dynamic = "force-static";
+
+/**
+ * llms.txt (https://llmstxt.org/): a markdown map of the site for agentic
+ * browsers — an H1, a one-line summary, then `##` sections grouping every
+ * visible article by knowledge domain as `- [Title](url): description`.
+ */
+export async function GET() {
+  const visible = await getVisibleArticles();
+  const baseUrl = env.NEXT_PUBLIC_DOMAIN_NAME;
+
+  const linesByDomain = new Map<string, string[]>();
+  for (const slug of visible.ids) {
+    const entity = visible.entities[slug];
+    const domain = entity?.meta.domain;
+    if (!(entity && domain)) {
+      continue;
+    }
+    const line = `- [${entity.meta.title}](${baseUrl}/articles/${slug}): ${entity.meta.description}`;
+    const lines = linesByDomain.get(domain);
+    if (lines) {
+      lines.push(line);
+    } else {
+      linesByDomain.set(domain, [line]);
+    }
+  }
+
+  const sections = DOMAIN_ORDER.filter((domain) => linesByDomain.has(domain))
+    .map((domain) => {
+      const lines = linesByDomain.get(domain);
+      return `## ${DOMAIN_META[domain].label}\n\n${lines?.join("\n")}`;
+    })
+    .join("\n\n");
+
+  const body = `# ${SITE_NAME}
+
+> ${SITE_DESCRIPTION}
+
+Articles-only blog. Notes are organized into knowledge domains below; the full index is at ${baseUrl}/articles.
+
+${sections}
+`;
+
+  return new Response(body, {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  });
+}

--- a/apps/blog/src/components/google-analytics.tsx
+++ b/apps/blog/src/components/google-analytics.tsx
@@ -32,19 +32,23 @@ export default function GoogleAnalytics({
 
   return (
     <>
-      <Script
-        src={`https://www.googletagmanager.com/gtag/js?id=${measurementId}`}
-        strategy="lazyOnload"
-      />
-      <Script id="google-analytics">
+      {/* ponytail: shim must load beforeInteractive and the gtag.js library must
+          stay lazyOnload — the shim buffers calls into window.dataLayer until the
+          166 KB library arrives at idle. Reverting either strategy to the default
+          re-races the library against LCP without gaining anything. */}
+      <Script id="google-analytics" strategy="beforeInteractive">
         {`
           window.dataLayer = window.dataLayer || [];
           function gtag(){dataLayer.push(arguments);}
           gtag('js', new Date());
- 
+
           gtag('config', '${measurementId}');
         `}
       </Script>
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${measurementId}`}
+        strategy="lazyOnload"
+      />
     </>
   );
 }

--- a/apps/blog/src/components/search/search-data.ts
+++ b/apps/blog/src/components/search/search-data.ts
@@ -2,7 +2,6 @@ import type {
   SearchIndex,
   SearchIndexEntry,
 } from "@howardism/article-contract/manifests/search-index";
-import Fuse, { type IFuseOptions } from "fuse.js";
 
 /**
  * One searchable article. The shape is owned by `@howardism/article-contract`
@@ -10,24 +9,6 @@ import Fuse, { type IFuseOptions } from "fuse.js";
  * it is read against the shared type without a zod parse on read.
  */
 export type SearchEntry = SearchIndexEntry;
-
-const FUSE_OPTIONS: IFuseOptions<SearchEntry> = {
-  keys: [
-    { name: "title", weight: 0.4 },
-    { name: "tags", weight: 0.18 },
-    { name: "domain", weight: 0.12 },
-    { name: "description", weight: 0.12 },
-    { name: "tag", weight: 0.1 },
-    { name: "body", weight: 0.08 },
-  ],
-  // Body text is long; match anywhere rather than penalising position.
-  ignoreLocation: true,
-  includeScore: true,
-  threshold: 0.35,
-  minMatchCharLength: 2,
-};
-
-const DEFAULT_LIMIT = 12;
 
 let indexPromise: Promise<SearchEntry[]> | null = null;
 
@@ -48,22 +29,6 @@ export function loadSearchIndex(): Promise<SearchEntry[]> {
       });
   }
   return indexPromise;
-}
-
-export function createFuse(entries: SearchEntry[]): Fuse<SearchEntry> {
-  return new Fuse(entries, FUSE_OPTIONS);
-}
-
-export function searchEntries(
-  fuse: Fuse<SearchEntry>,
-  query: string,
-  limit = DEFAULT_LIMIT
-): SearchEntry[] {
-  const trimmed = query.trim();
-  if (trimmed.length === 0) {
-    return [];
-  }
-  return fuse.search(trimmed, { limit }).map((result) => result.item);
 }
 
 export interface Snippet {

--- a/apps/blog/src/components/search/search-palette.tsx
+++ b/apps/blog/src/components/search/search-palette.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { createFuse, searchEntries } from "@howardism/article-contract/search";
 import {
   CommandDialog,
   CommandEmpty,
@@ -12,12 +13,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 
 import { ResultRow } from "./result-row";
-import {
-  createFuse,
-  loadSearchIndex,
-  type SearchEntry,
-  searchEntries,
-} from "./search-data";
+import { loadSearchIndex, type SearchEntry } from "./search-data";
 
 interface SearchPaletteProps {
   onOpenChange: (open: boolean) => void;

--- a/apps/blog/src/components/search/search-provider.tsx
+++ b/apps/blog/src/components/search/search-provider.tsx
@@ -17,6 +17,11 @@ const SearchPalette = dynamic(
   { ssr: false }
 );
 
+const WebMcpTools = dynamic(
+  () => import("./webmcp-tools").then((m) => m.WebMcpTools),
+  { ssr: false }
+);
+
 interface SearchContextValue {
   openSearch: () => void;
 }
@@ -40,6 +45,7 @@ export function SearchProvider({ children }: { children: ReactNode }) {
     <SearchContext value={value}>
       {children}
       <SearchPalette onOpenChange={setOpen} open={open} />
+      <WebMcpTools />
     </SearchContext>
   );
 }

--- a/apps/blog/src/components/search/webmcp-tools.tsx
+++ b/apps/blog/src/components/search/webmcp-tools.tsx
@@ -21,10 +21,15 @@ interface ModelContextToolDescriptor<TInput> {
 }
 
 interface ModelContext {
+  /**
+   * The explainer types this as returning a Promise, but Chrome 150 returns
+   * `undefined` synchronously — hence the union and the defensive `register`
+   * helper below.
+   */
   registerTool<TInput>(
     descriptor: ModelContextToolDescriptor<TInput>,
     options?: { signal?: AbortSignal }
-  ): Promise<unknown>;
+  ): Promise<unknown> | undefined;
 }
 
 declare global {
@@ -111,62 +116,71 @@ export function WebMcpTools() {
     const modelContext = document.modelContext;
     const controller = new AbortController();
 
-    modelContext
-      .registerTool<SearchArticlesInput>(
-        {
-          name: SEARCH_ARTICLES_TOOL,
-          description:
-            "Search the howardism.dev article knowledge base by keyword. Returns matching articles' metadata (title, description, domain, tag, url) ranked by relevance — not the full article body.",
-          inputSchema: {
-            type: "object",
-            properties: {
-              query: { type: "string", description: "Search keywords." },
-              limit: {
-                type: "number",
-                description: "Maximum number of results (default 12).",
-              },
-            },
-            required: ["query"],
-          },
-          annotations: { readOnlyHint: true },
-          // `loadSearchIndex()` pulls a ~200KB+ JSON chunk; it is called only
-          // here, inside `execute`, never at registration/mount time.
-          execute: async (input) => {
-            const entries = await loadSearchIndex();
-            return searchArticles(entries, input, window.location.origin);
-          },
-        },
-        { signal: controller.signal }
-      )
-      .catch(() => {
-        // Registration can lose a race with unmount (the signal aborts before
-        // it resolves) — nothing to do but drop the rejection.
-      });
+    /**
+     * WebMCP is experimental and its return contract is unstable — Chrome 150
+     * returns `undefined` where the explainer promises a Promise, so chaining
+     * `.catch` directly throws and takes the whole render down with it. Both
+     * shapes are normalised here, and any throw is swallowed: failing to
+     * register an optional agent tool must never break the page.
+     */
+    const register = <TInput,>(
+      descriptor: ModelContextToolDescriptor<TInput>
+    ) => {
+      try {
+        Promise.resolve(
+          modelContext.registerTool<TInput>(descriptor, {
+            signal: controller.signal,
+          })
+        ).catch(() => {
+          // Registration can also lose a race with unmount (the signal aborts
+          // before it resolves) — nothing to do but drop the rejection.
+        });
+      } catch {
+        // Synchronous throw from an unstable experimental API.
+      }
+    };
 
-    modelContext
-      .registerTool<GetArticleInput>(
-        {
-          name: GET_ARTICLE_TOOL,
-          description:
-            "Fetch the full body of one howardism.dev article by slug, as returned by search_articles.",
-          inputSchema: {
-            type: "object",
-            properties: {
-              slug: { type: "string", description: "The article slug." },
-            },
-            required: ["slug"],
-          },
-          annotations: { readOnlyHint: true },
-          execute: async (input) => {
-            const entries = await loadSearchIndex();
-            return getArticle(entries, input);
+    register<SearchArticlesInput>({
+      name: SEARCH_ARTICLES_TOOL,
+      description:
+        "Search the howardism.dev article knowledge base by keyword. Returns matching articles' metadata (title, description, domain, tag, url) ranked by relevance — not the full article body.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: { type: "string", description: "Search keywords." },
+          limit: {
+            type: "number",
+            description: "Maximum number of results (default 12).",
           },
         },
-        { signal: controller.signal }
-      )
-      .catch(() => {
-        // See above.
-      });
+        required: ["query"],
+      },
+      annotations: { readOnlyHint: true },
+      // `loadSearchIndex()` pulls a ~200KB+ JSON chunk; it is called only
+      // here, inside `execute`, never at registration/mount time.
+      execute: async (input) => {
+        const entries = await loadSearchIndex();
+        return searchArticles(entries, input, window.location.origin);
+      },
+    });
+
+    register<GetArticleInput>({
+      name: GET_ARTICLE_TOOL,
+      description:
+        "Fetch the full body of one howardism.dev article by slug, as returned by search_articles.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          slug: { type: "string", description: "The article slug." },
+        },
+        required: ["slug"],
+      },
+      annotations: { readOnlyHint: true },
+      execute: async (input) => {
+        const entries = await loadSearchIndex();
+        return getArticle(entries, input);
+      },
+    });
 
     return () => {
       controller.abort();

--- a/apps/blog/src/components/search/webmcp-tools.tsx
+++ b/apps/blog/src/components/search/webmcp-tools.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { createFuse, searchEntries } from "@howardism/article-contract/search";
+import { useEffect } from "react";
+
+import { loadSearchIndex, type SearchEntry } from "./search-data";
+
+/**
+ * Minimal ambient shape for the experimental WebMCP imperative API (Chrome
+ * 150+, behind `--enable-features=WebMCP`, `[SecureContext]` only). There are
+ * no upstream type declarations yet, so this is kept as narrow as the calls
+ * below actually need. `navigator.modelContext` is deprecated as of Chrome
+ * 150 in favour of `document.modelContext` — only the latter is declared.
+ */
+interface ModelContextToolDescriptor<TInput> {
+  annotations?: { readOnlyHint?: boolean };
+  description: string;
+  execute: (input: TInput) => Promise<string>;
+  inputSchema: Record<string, unknown>;
+  name: string;
+}
+
+interface ModelContext {
+  registerTool<TInput>(
+    descriptor: ModelContextToolDescriptor<TInput>,
+    options?: { signal?: AbortSignal }
+  ): Promise<unknown>;
+}
+
+declare global {
+  interface Document {
+    modelContext?: ModelContext;
+  }
+}
+
+const SEARCH_ARTICLES_TOOL = "search_articles";
+const GET_ARTICLE_TOOL = "get_article";
+
+interface SearchArticlesInput {
+  limit?: number;
+  query: string;
+}
+
+interface SearchArticlesResult {
+  description: string;
+  domain: string | undefined;
+  slug: string;
+  tag: string;
+  title: string;
+  url: string;
+}
+
+/**
+ * Ranks `entries` against `input.query` and shapes the agent-facing payload.
+ * Deliberately omits `body` — the article knowledge base can be large, and
+ * the full text would flood the calling agent's context; `get_article` fetches
+ * it on demand for one slug. Pure and browser-free so it is unit-testable
+ * without `document.modelContext`.
+ */
+export function searchArticles(
+  entries: SearchEntry[],
+  input: SearchArticlesInput,
+  origin: string
+): string {
+  const fuse = createFuse(entries);
+  const results = searchEntries(fuse, input.query, input.limit);
+  const payload: SearchArticlesResult[] = results.map((entry) => ({
+    slug: entry.slug,
+    title: entry.title,
+    description: entry.description,
+    domain: entry.domain,
+    tag: entry.tag,
+    url: `${origin}/articles/${entry.slug}`,
+  }));
+  return JSON.stringify(payload);
+}
+
+interface GetArticleInput {
+  slug: string;
+}
+
+/**
+ * Returns the full body of the entry matching `input.slug`, already present
+ * on every loaded index entry — no network fetch needed. Pure and
+ * browser-free so it is unit-testable without `document.modelContext`.
+ */
+export function getArticle(
+  entries: SearchEntry[],
+  input: GetArticleInput
+): string {
+  const entry = entries.find((candidate) => candidate.slug === input.slug);
+  if (!entry) {
+    return `No article found for slug "${input.slug}".`;
+  }
+  return entry.body;
+}
+
+/**
+ * Registers `search_articles` and `get_article` as WebMCP tools so an
+ * agentic browser can query the article knowledge base directly, without
+ * scraping rendered pages. A complete no-op wherever `document.modelContext`
+ * is absent (every browser without the WebMCP flag, and any non-secure
+ * context) — renders nothing either way.
+ */
+export function WebMcpTools() {
+  useEffect(() => {
+    if (typeof document === "undefined" || !document.modelContext) {
+      return;
+    }
+
+    const modelContext = document.modelContext;
+    const controller = new AbortController();
+
+    modelContext
+      .registerTool<SearchArticlesInput>(
+        {
+          name: SEARCH_ARTICLES_TOOL,
+          description:
+            "Search the howardism.dev article knowledge base by keyword. Returns matching articles' metadata (title, description, domain, tag, url) ranked by relevance — not the full article body.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              query: { type: "string", description: "Search keywords." },
+              limit: {
+                type: "number",
+                description: "Maximum number of results (default 12).",
+              },
+            },
+            required: ["query"],
+          },
+          annotations: { readOnlyHint: true },
+          // `loadSearchIndex()` pulls a ~200KB+ JSON chunk; it is called only
+          // here, inside `execute`, never at registration/mount time.
+          execute: async (input) => {
+            const entries = await loadSearchIndex();
+            return searchArticles(entries, input, window.location.origin);
+          },
+        },
+        { signal: controller.signal }
+      )
+      .catch(() => {
+        // Registration can lose a race with unmount (the signal aborts before
+        // it resolves) — nothing to do but drop the rejection.
+      });
+
+    modelContext
+      .registerTool<GetArticleInput>(
+        {
+          name: GET_ARTICLE_TOOL,
+          description:
+            "Fetch the full body of one howardism.dev article by slug, as returned by search_articles.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              slug: { type: "string", description: "The article slug." },
+            },
+            required: ["slug"],
+          },
+          annotations: { readOnlyHint: true },
+          execute: async (input) => {
+            const entries = await loadSearchIndex();
+            return getArticle(entries, input);
+          },
+        },
+        { signal: controller.signal }
+      )
+      .catch(() => {
+        // See above.
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, []);
+
+  return null;
+}

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -14,7 +14,8 @@
     "translate:check": "bun src/translate/index.ts --check",
     "translate:drip": "bun src/translate/drip.ts",
     "glossary": "bun src/glossary/cli.ts",
-    "glossary:mcp": "bun src/glossary/mcp.ts"
+    "glossary:mcp": "bun src/glossary/mcp.ts",
+    "knowledge:mcp": "bun src/knowledge/mcp.ts"
   },
   "dependencies": {
     "@howardism/article-contract": "workspace:*",

--- a/apps/cli/src/__tests__/knowledge-mcp.test.ts
+++ b/apps/cli/src/__tests__/knowledge-mcp.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  DEFAULT_SEARCH_INDEX_PATH,
+  knowledgeGetHandler,
+  knowledgeSearchHandler,
+} from "../knowledge/mcp.ts";
+
+const parse = (res: { content: { text: string }[] }): unknown =>
+  JSON.parse(res.content[0]?.text ?? "null");
+
+const indexRaw = await Bun.file(DEFAULT_SEARCH_INDEX_PATH).json();
+const KNOWN_SLUG = indexRaw.entries[0].slug as string;
+
+describe("knowledge MCP tool handlers", () => {
+  it("knowledge_search returns results for a plausible query, without body", async () => {
+    const results = parse(
+      await knowledgeSearchHandler(DEFAULT_SEARCH_INDEX_PATH, {
+        query: "AI",
+      })
+    ) as Record<string, unknown>[];
+
+    expect(results.length).toBeGreaterThan(0);
+    for (const result of results) {
+      expect(result).not.toHaveProperty("body");
+      expect(result).toHaveProperty("slug");
+      expect(result).toHaveProperty("title");
+      expect(result).toHaveProperty("description");
+      expect(result).toHaveProperty("tag");
+    }
+  });
+
+  it("knowledge_get returns the full entry (including body) for a known slug", async () => {
+    const entry = parse(
+      await knowledgeGetHandler(DEFAULT_SEARCH_INDEX_PATH, {
+        slug: KNOWN_SLUG,
+      })
+    ) as { body: string; slug: string };
+
+    expect(entry.slug).toBe(KNOWN_SLUG);
+    expect(typeof entry.body).toBe("string");
+    expect(entry.body.length).toBeGreaterThan(0);
+  });
+
+  it("knowledge_get handles an unknown slug gracefully rather than throwing", async () => {
+    const result = parse(
+      await knowledgeGetHandler(DEFAULT_SEARCH_INDEX_PATH, {
+        slug: "definitely-not-a-real-slug",
+      })
+    ) as { error: string };
+
+    expect(result.error).toContain("definitely-not-a-real-slug");
+  });
+});

--- a/apps/cli/src/import-wiki/index.ts
+++ b/apps/cli/src/import-wiki/index.ts
@@ -9,6 +9,7 @@ import {
   type WikiTag,
 } from "@howardism/article-contract";
 import { runWithConcurrency } from "../concurrency.ts";
+import { writeSearchIndex } from "../search-index.ts";
 import { generateHeroImage as generateAgyHeroImage } from "./agy/index.ts";
 import { generateHeroImage as generateCodexHeroImage } from "./codex.ts";
 import {
@@ -74,6 +75,7 @@ interface ImportSummary {
   missingRawSources: Map<string, Set<string>>;
   /** Slugs pruned because their vault note was deleted or renamed. */
   prunedArticles: string[];
+  searchIndex: { entryCount: number; outputPath: string } | null;
   /** Concept-folder notes not listed in any MOC; fell back to `syntheses`. */
   unmappedConcepts: Set<string>;
   unresolvedWikilinks: Map<string, Set<string>>;
@@ -177,6 +179,8 @@ async function main(): Promise<void> {
       onlySlug: opts.onlySlug,
       dryRun: opts.dryRun,
     });
+
+    summary.searchIndex = await writeSearchIndex({ dryRun: opts.dryRun });
   }
 
   printSummary(summary);
@@ -247,6 +251,7 @@ function createSummary(): ImportSummary {
     imagesCached: [],
     missingRawSources: new Map(),
     prunedArticles: [],
+    searchIndex: null,
     unmappedConcepts: new Set(),
     unresolvedWikilinks: new Map(),
   };
@@ -603,6 +608,11 @@ function printSummary(summary: ImportSummary): void {
   console.log(`Images cached:    ${summary.imagesCached.length}`);
   if (summary.graphPath) {
     console.log(`Graph:            ${summary.graphPath}`);
+  }
+  if (summary.searchIndex) {
+    console.log(
+      `Search index:     ${summary.searchIndex.entryCount} entries → ${summary.searchIndex.outputPath}`
+    );
   }
   if (summary.prunedArticles.length > 0) {
     console.log("\nPruned orphaned articles (vault note deleted or renamed):");

--- a/apps/cli/src/knowledge/mcp.ts
+++ b/apps/cli/src/knowledge/mcp.ts
@@ -1,0 +1,142 @@
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+
+import {
+  parseSearchIndex,
+  type SearchIndexEntry,
+} from "@howardism/article-contract/manifests/search-index";
+import { createFuse, searchEntries } from "@howardism/article-contract/search";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+
+const HERE = dirname(new URL(import.meta.url).pathname);
+const CLI_ROOT = resolve(HERE, "../../");
+const REPO_ROOT = resolve(CLI_ROOT, "../../");
+
+/** The blog's committed search index — see apps/cli/src/search-index.ts. */
+export const DEFAULT_SEARCH_INDEX_PATH = resolve(
+  REPO_ROOT,
+  "apps/blog/src/data/search-index.json"
+);
+
+/**
+ * MCP tool handlers. Kept as plain (indexPath, args) → CallToolResult
+ * functions so they're unit-testable without driving a transport. Each
+ * returns a single text block of pretty JSON — the shape MCP clients render
+ * to the model. The return type is left inferred so it stays assignable to
+ * the SDK's result type (which carries an index signature a named interface
+ * could not satisfy).
+ */
+const jsonResult = (data: unknown) => ({
+  content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }],
+});
+
+interface SearchIndexState {
+  entries: SearchIndexEntry[];
+  fuse: ReturnType<typeof createFuse>;
+}
+
+// Lazily parsed + Fuse-indexed search index, keyed by resolved path so tests
+// exercising different paths don't share state. Parsing + Fuse construction
+// only happen on first use of a given path (the index is ~400KB of JSON),
+// not at import time.
+const indexCache = new Map<string, Promise<SearchIndexState>>();
+
+function loadIndex(indexPath: string): Promise<SearchIndexState> {
+  let state = indexCache.get(indexPath);
+  if (!state) {
+    state = (async () => {
+      const raw = await readFile(indexPath, "utf8");
+      const { entries } = parseSearchIndex(JSON.parse(raw));
+      return { entries, fuse: createFuse(entries) };
+    })();
+    indexCache.set(indexPath, state);
+  }
+  return state;
+}
+
+/** The fields `knowledge_search` returns — no `body`, to keep results small. */
+type KnowledgeSearchResult = Omit<SearchIndexEntry, "body" | "tags">;
+
+const toSearchResult = (entry: SearchIndexEntry): KnowledgeSearchResult => ({
+  slug: entry.slug,
+  title: entry.title,
+  description: entry.description,
+  ...(entry.domain ? { domain: entry.domain } : {}),
+  tag: entry.tag,
+});
+
+export async function knowledgeSearchHandler(
+  indexPath: string,
+  args: { limit?: number; query: string }
+) {
+  const { fuse } = await loadIndex(indexPath);
+  const results = searchEntries(fuse, args.query, args.limit).map(
+    toSearchResult
+  );
+  return jsonResult(results);
+}
+
+export async function knowledgeGetHandler(
+  indexPath: string,
+  args: { slug: string }
+) {
+  const { entries } = await loadIndex(indexPath);
+  const entry = entries.find((candidate) => candidate.slug === args.slug);
+  if (!entry) {
+    return jsonResult({
+      error: `No article found for slug "${args.slug}".`,
+    });
+  }
+  return jsonResult(entry);
+}
+
+/** Register the two knowledge-base tools on an MCP server reading `indexPath`. */
+export function registerKnowledgeTools(
+  server: McpServer,
+  indexPath: string
+): void {
+  server.registerTool(
+    "knowledge_search",
+    {
+      title: "Search Howard's wiki knowledge base",
+      description:
+        "Full-text search over Howard Tai's personal wiki/blog knowledge base (Howardism) — his published articles on AI, software engineering, and other topics. Ranks results the same fuzzy-match algorithm as the site's own command-palette search. Returns each match's slug, title, description, domain, and tag — NOT the article body (use knowledge_get with the slug to fetch full content). Use this first to find which articles are relevant to a topic.",
+      inputSchema: {
+        query: z.string().min(1),
+        limit: z.number().int().positive().optional(),
+      },
+    },
+    (args) => knowledgeSearchHandler(indexPath, args)
+  );
+
+  server.registerTool(
+    "knowledge_get",
+    {
+      title: "Get a full article from Howard's wiki knowledge base",
+      description:
+        "Fetch one article's full content — including its body text — from Howard Tai's personal wiki/blog knowledge base (Howardism) by slug. Call knowledge_search first to find the right slug. Returns a clear error message (not a thrown error) if the slug doesn't exist.",
+      inputSchema: {
+        slug: z.string().min(1),
+      },
+    },
+    (args) => knowledgeGetHandler(indexPath, args)
+  );
+}
+
+const resolveIndexPath = (): string =>
+  resolve(process.env.SEARCH_INDEX_PATH ?? DEFAULT_SEARCH_INDEX_PATH);
+
+async function main(): Promise<void> {
+  const server = new McpServer({ name: "knowledge", version: "0.1.0" });
+  registerKnowledgeTools(server, resolveIndexPath());
+  await server.connect(new StdioServerTransport());
+}
+
+if (import.meta.main) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/apps/cli/src/search-index.ts
+++ b/apps/cli/src/search-index.ts
@@ -101,16 +101,23 @@ async function buildIndex(generatedOn: string): Promise<SearchIndex> {
   return { generatedOn, entries };
 }
 
-async function main(): Promise<void> {
+/**
+ * Build the search index and write it to `OUTPUT_PATH`, unless a dry run was
+ * requested (`DRY_RUN=1` env var, or `options.dryRun` for callers driving
+ * this programmatically, e.g. the wiki importer).
+ */
+export async function writeSearchIndex(options?: {
+  dryRun?: boolean;
+}): Promise<{ entryCount: number; outputPath: string }> {
   const generatedOn = new Date().toISOString().slice(0, 10);
   const index = await buildIndex(generatedOn);
   const json = JSON.stringify(SearchIndexSchema.parse(index), null, 2);
 
-  if (process.env.DRY_RUN === "1") {
+  if (process.env.DRY_RUN === "1" || options?.dryRun) {
     console.log(
       `[search-index] DRY_RUN — ${index.entries.length} entries, ${json.length} bytes (not written)`
     );
-    return;
+    return { entryCount: index.entries.length, outputPath: OUTPUT_PATH };
   }
 
   await mkdir(dirname(OUTPUT_PATH), { recursive: true });
@@ -118,10 +125,11 @@ async function main(): Promise<void> {
   console.log(
     `[search-index] wrote ${index.entries.length} entries → ${OUTPUT_PATH}`
   );
+  return { entryCount: index.entries.length, outputPath: OUTPUT_PATH };
 }
 
 if (import.meta.main) {
-  main().catch((err) => {
+  writeSearchIndex().catch((err) => {
     console.error(err);
     process.exit(1);
   });

--- a/bun.lock
+++ b/bun.lock
@@ -95,6 +95,7 @@
       "name": "@howardism/article-contract",
       "version": "0.0.1",
       "dependencies": {
+        "fuse.js": "^7.1.0",
         "gray-matter": "^4.0.3",
         "zod": "^4.3.6",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -45,7 +45,6 @@
         "fast-glob": "^3.3.2",
         "feed": "^5.2.0",
         "focus-visible": "^5.2.0",
-        "fuse.js": "^7.1.0",
         "hast-util-heading-rank": "^3.0.0",
         "hast-util-to-string": "^3.0.1",
         "lodash.throttle": "^4.1.1",

--- a/packages/article-contract/package.json
+++ b/packages/article-contract/package.json
@@ -6,6 +6,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./schema": "./src/schema.ts",
+    "./search": "./src/search.ts",
     "./surface": "./src/surface.ts",
     "./manifests/graph": "./src/manifests/graph.ts",
     "./manifests/wiki-sources": "./src/manifests/wiki-sources.ts",
@@ -18,6 +19,7 @@
     "clean": "rm -rf node_modules"
   },
   "dependencies": {
+    "fuse.js": "^7.1.0",
     "gray-matter": "^4.0.3",
     "zod": "^4.3.6"
   },

--- a/packages/article-contract/src/search.ts
+++ b/packages/article-contract/src/search.ts
@@ -1,0 +1,39 @@
+import Fuse, { type IFuseOptions } from "fuse.js";
+
+import type { SearchIndexEntry } from "./manifests/search-index";
+
+const FUSE_OPTIONS: IFuseOptions<SearchIndexEntry> = {
+  keys: [
+    { name: "title", weight: 0.4 },
+    { name: "tags", weight: 0.18 },
+    { name: "domain", weight: 0.12 },
+    { name: "description", weight: 0.12 },
+    { name: "tag", weight: 0.1 },
+    { name: "body", weight: 0.08 },
+  ],
+  // Body text is long; match anywhere rather than penalising position.
+  ignoreLocation: true,
+  includeScore: true,
+  threshold: 0.35,
+  minMatchCharLength: 2,
+};
+
+const DEFAULT_LIMIT = 12;
+
+export function createFuse(
+  entries: SearchIndexEntry[]
+): Fuse<SearchIndexEntry> {
+  return new Fuse(entries, FUSE_OPTIONS);
+}
+
+export function searchEntries(
+  fuse: Fuse<SearchIndexEntry>,
+  query: string,
+  limit = DEFAULT_LIMIT
+): SearchIndexEntry[] {
+  const trimmed = query.trim();
+  if (trimmed.length === 0) {
+    return [];
+  }
+  return fuse.search(trimmed, { limit }).map((result) => result.item);
+}

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -108,7 +108,7 @@
     --background: oklch(0.965 0.012 82);
     --background-2: oklch(0.945 0.016 80);
     --foreground: oklch(0.24 0.02 45);
-    --foreground-subtle: oklch(0.58 0.015 55);
+    --foreground-subtle: oklch(0.53 0.015 55);
 
     --card: oklch(0.985 0.008 85);
     --card-foreground: oklch(0.24 0.02 45);


### PR DESCRIPTION
Reviews the blog against Chrome's [Lighthouse agentic-browsing scoring](https://developer.chrome.com/docs/lighthouse/agentic-browsing/scoring) docs and closes the gaps found, plus a live bug discovered on the way.

## What the published doc leaves out

The scoring page is deliberately vague ("still under development"), so the plan was derived from the shipped implementation in `lighthouse@13.4.1` (`core/config/agentic-browsing-config.js`): six audits, weight 1 each, `categoryScoreDisplayMode: 'fraction'`.

Two mechanics that changed the plan:

- **`notApplicable` audits leave the denominator.** A *missing* `llms.txt` costs nothing (`{score: 1, notApplicable: true}` on 404), but a *malformed* one scores 0. The site was already 2/2 before this PR — the gap was coverage, not failure.
- **The WebMCP audits cannot raise the score.** `webmcp-registered-tools` reports as `informative`; `webmcp-form-coverage` returns `score: 1` on every path. Only `webmcp-schema-validity` moves the number, and only downward, via declarative-form errors. WebMCP is here for function, not points — and deliberately uses the imperative API.

## Blocking bug found first

`apps/blog/src/data/search-index.json` held **130 entries against a corpus of 243**, generated `2026-06-07`. `build:search-index` was wired into nothing — not `turbo.json`, not the blog build, not CI. The command palette had been silently missing ~46% of articles, and both new MCP surfaces read this file.

Fixed at the choke point: the wiki importer, which already emits the sibling manifests, now regenerates the index too.

## Commits

| Commit | What |
|---|---|
| `perf(blog)` | hero image `priority` — it was the LCP element rendering `loading="lazy"` |
| `fix(ui)` | `--foreground-subtle` 0.58 → 0.53; one token caused **all 85** contrast violations |
| `perf(blog)` | gtag shim `beforeInteractive`, 166 KB library `lazyOnload` |
| `fix(cli)` | search index 130 → 243 + regenerate from the importer |
| `feat(blog)` | `/llms.txt` |
| `feat(blog)` | WebMCP `search_articles` / `get_article` |
| `feat(cli)` | local stdio knowledge MCP server |
| `fix(blog)` | `fetchPriority` — `priority` alone doesn't set it |
| `fix(blog)` | WebMCP registration crash |

The last two were caught by verification, not review — details below.

## Two bugs my own verification caught

**`priority` was not sufficient.** Next 16 emits the preload link and drops `loading="lazy"`, but does not set `fetchpriority` on the element — the exact attribute Lighthouse's `priorityHinted` check reads. It kept failing with `eagerlyLoaded` already true. Both are needed.

**WebMCP registration crashed the page.** `registerTool(...).catch()` assumed the Promise the explainer documents; Chrome 150 returns `undefined` synchronously, so it threw inside the mount effect. Only visible with `--enable-features=WebMCP`, which is why it passed every earlier check — Lighthouse was auditing a half-rendered document and reported accessibility 93 and CLS 0.078. Both return shapes are now normalised and any throw swallowed.

## Verification actually run

Repo gates on the final branch: `lint` 2/2, `type-check` 4/4, `test` **503 pass / 0 fail**, `build` clean.

Lighthouse, article page, **`localhost` production build** with `--enable-features=WebMCP`:

| | Before (prod) | After (localhost) |
|---|---|---|
| Accessibility | 96 | **100** |
| Agentic Browsing | 2/2 | **100% (6/6 participating)** |
| SEO | 100 | 100 |
| Performance | 76 | 80 |

Audit-level, all confirmed flipped: `color-contrast` 0 → 1 · `label-content-name-mismatch` 0 → 1 · `llms-txt` N/A → 1 · `webmcp-schema-validity` N/A → 1 · `lcp-discovery-insight` 0 → 1 (all three checks true) · CLS 0.

Also verified: built `llms.txt` against the audit's exact H1/link/length regexes (243 bullets, 9 sections), and the MCP server end-to-end over real stdio JSON-RPC — ranked results returned with no `body` leakage.

**Read the numbers with care.** "After" is a localhost build, so LCP/TTFB are not directly comparable to the production baseline; the audit-level pass/fail flips are. `Best Practices` reads 96 locally only because `/_vercel/insights/script.js` 404s off-Vercel.

## Not done

- **Canonical domain.** Production sets `NEXT_PUBLIC_DOMAIN_NAME=https://howardism.dev`, but the apex 308-redirects to `www`. Canonical, `robots.txt` host, all ~243 sitemap URLs, RSS and OG images point at redirecting URLs. One env var in Vercel — a dashboard change I can't make.
- **LCP is still 5.6s.** The image now loads eagerly at high priority (~126ms observed); the remaining cost is **423 KB of fonts** across four woff2 files. Subsetting or dropping a family is the next lever, but that's a design call.
- **WebMCP needs `--enable-features=WebMCP`** to exercise; it is a no-op in stock Chrome and on non-secure origins by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LBfeVwn5MZUw8uX7fd1YXL
