### PR TITLE
📝 docs(blog): design foundation — PRODUCT.md + DESIGN.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,8 +55,9 @@ apps/blog/public/rss
 .turbo/
 
 # claude code (local config ignored; shared skills tracked for reuse)
-.claude/*
-!.claude/skills/
+# `**/` so nested workspace configs (apps/*/.claude) follow the same rule
+**/.claude/*
+!**/.claude/skills/
 
 # image-generation staging (apps/cli)
 .codex-staging/

--- a/apps/blog/.impeccable/design.json
+++ b/apps/blog/.impeccable/design.json
@@ -1,0 +1,729 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-07-29T10:39:20.881Z",
+  "title": "Design System: Howardism",
+  "extensions": {
+    "colorMeta": {
+      "plate-red": {
+        "role": "primary",
+        "displayName": "Plate Red",
+        "canonical": "oklch(0.55 0.155 35)",
+        "darkValue": "oklch(0.74 0.13 40)",
+        "tonalRamp": [
+          "oklch(0.150 0.155 35)",
+          "oklch(0.264 0.155 35)",
+          "oklch(0.379 0.155 35)",
+          "oklch(0.493 0.155 35)",
+          "oklch(0.607 0.155 35)",
+          "oklch(0.721 0.155 35)",
+          "oklch(0.836 0.155 35)",
+          "oklch(0.950 0.155 35)"
+        ]
+      },
+      "verdigris": {
+        "role": "tertiary",
+        "displayName": "Verdigris",
+        "canonical": "oklch(0.62 0.11 150)",
+        "darkValue": "oklch(0.75 0.1 150)",
+        "tonalRamp": [
+          "oklch(0.150 0.11 150)",
+          "oklch(0.264 0.11 150)",
+          "oklch(0.379 0.11 150)",
+          "oklch(0.493 0.11 150)",
+          "oklch(0.607 0.11 150)",
+          "oklch(0.721 0.11 150)",
+          "oklch(0.836 0.11 150)",
+          "oklch(0.950 0.11 150)"
+        ]
+      },
+      "paper": {
+        "role": "neutral",
+        "displayName": "Paper",
+        "canonical": "oklch(0.965 0.012 82)",
+        "darkValue": "oklch(0.18 0.015 260)",
+        "tonalRamp": [
+          "oklch(0.150 0.012 82)",
+          "oklch(0.264 0.012 82)",
+          "oklch(0.379 0.012 82)",
+          "oklch(0.493 0.012 82)",
+          "oklch(0.607 0.012 82)",
+          "oklch(0.721 0.012 82)",
+          "oklch(0.836 0.012 82)",
+          "oklch(0.950 0.012 82)"
+        ]
+      },
+      "paper-recessed": {
+        "role": "neutral",
+        "displayName": "Paper Recessed",
+        "canonical": "oklch(0.945 0.016 80)",
+        "darkValue": "oklch(0.22 0.02 260)",
+        "tonalRamp": [
+          "oklch(0.150 0.016 80)",
+          "oklch(0.264 0.016 80)",
+          "oklch(0.379 0.016 80)",
+          "oklch(0.493 0.016 80)",
+          "oklch(0.607 0.016 80)",
+          "oklch(0.721 0.016 80)",
+          "oklch(0.836 0.016 80)",
+          "oklch(0.950 0.016 80)"
+        ]
+      },
+      "plate": {
+        "role": "neutral",
+        "displayName": "Plate",
+        "canonical": "oklch(0.985 0.008 85)",
+        "darkValue": "oklch(0.24 0.018 260)",
+        "tonalRamp": [
+          "oklch(0.150 0.008 85)",
+          "oklch(0.264 0.008 85)",
+          "oklch(0.379 0.008 85)",
+          "oklch(0.493 0.008 85)",
+          "oklch(0.607 0.008 85)",
+          "oklch(0.721 0.008 85)",
+          "oklch(0.836 0.008 85)",
+          "oklch(0.950 0.008 85)"
+        ]
+      },
+      "ink": {
+        "role": "neutral",
+        "displayName": "Ink",
+        "canonical": "oklch(0.24 0.02 45)",
+        "darkValue": "oklch(0.94 0.01 80)",
+        "tonalRamp": [
+          "oklch(0.150 0.02 45)",
+          "oklch(0.264 0.02 45)",
+          "oklch(0.379 0.02 45)",
+          "oklch(0.493 0.02 45)",
+          "oklch(0.607 0.02 45)",
+          "oklch(0.721 0.02 45)",
+          "oklch(0.836 0.02 45)",
+          "oklch(0.950 0.02 45)"
+        ]
+      },
+      "ink-muted": {
+        "role": "neutral",
+        "displayName": "Ink Muted",
+        "canonical": "oklch(0.42 0.02 50)",
+        "darkValue": "oklch(0.78 0.015 75)",
+        "tonalRamp": [
+          "oklch(0.150 0.02 50)",
+          "oklch(0.264 0.02 50)",
+          "oklch(0.379 0.02 50)",
+          "oklch(0.493 0.02 50)",
+          "oklch(0.607 0.02 50)",
+          "oklch(0.721 0.02 50)",
+          "oklch(0.836 0.02 50)",
+          "oklch(0.950 0.02 50)"
+        ]
+      },
+      "ink-subtle": {
+        "role": "neutral",
+        "displayName": "Ink Subtle",
+        "canonical": "oklch(0.53 0.015 55)",
+        "darkValue": "oklch(0.62 0.015 70)",
+        "tonalRamp": [
+          "oklch(0.150 0.015 55)",
+          "oklch(0.264 0.015 55)",
+          "oklch(0.379 0.015 55)",
+          "oklch(0.493 0.015 55)",
+          "oklch(0.607 0.015 55)",
+          "oklch(0.721 0.015 55)",
+          "oklch(0.836 0.015 55)",
+          "oklch(0.950 0.015 55)"
+        ]
+      },
+      "rule": {
+        "role": "neutral",
+        "displayName": "Rule",
+        "canonical": "oklch(0.85 0.018 70)",
+        "darkValue": "oklch(0.32 0.02 260)",
+        "tonalRamp": [
+          "oklch(0.150 0.018 70)",
+          "oklch(0.264 0.018 70)",
+          "oklch(0.379 0.018 70)",
+          "oklch(0.493 0.018 70)",
+          "oklch(0.607 0.018 70)",
+          "oklch(0.721 0.018 70)",
+          "oklch(0.836 0.018 70)",
+          "oklch(0.950 0.018 70)"
+        ]
+      },
+      "rule-strong": {
+        "role": "neutral",
+        "displayName": "Rule Strong",
+        "canonical": "oklch(0.78 0.02 65)",
+        "darkValue": "oklch(0.4 0.025 260)",
+        "tonalRamp": [
+          "oklch(0.150 0.02 65)",
+          "oklch(0.264 0.02 65)",
+          "oklch(0.379 0.02 65)",
+          "oklch(0.493 0.02 65)",
+          "oklch(0.607 0.02 65)",
+          "oklch(0.721 0.02 65)",
+          "oklch(0.836 0.02 65)",
+          "oklch(0.950 0.02 65)"
+        ]
+      },
+      "hover-wash": {
+        "role": "neutral",
+        "displayName": "Hover Wash",
+        "canonical": "oklch(0.93 0.018 75)",
+        "darkValue": "oklch(0.26 0.02 260)",
+        "tonalRamp": [
+          "oklch(0.150 0.018 75)",
+          "oklch(0.264 0.018 75)",
+          "oklch(0.379 0.018 75)",
+          "oklch(0.493 0.018 75)",
+          "oklch(0.607 0.018 75)",
+          "oklch(0.721 0.018 75)",
+          "oklch(0.836 0.018 75)",
+          "oklch(0.950 0.018 75)"
+        ]
+      },
+      "correction-red": {
+        "role": "destructive",
+        "displayName": "Correction Red",
+        "canonical": "oklch(0.58 0.21 27)",
+        "darkValue": "oklch(0.65 0.2 27)",
+        "tonalRamp": [
+          "oklch(0.150 0.21 27)",
+          "oklch(0.264 0.21 27)",
+          "oklch(0.379 0.21 27)",
+          "oklch(0.493 0.21 27)",
+          "oklch(0.607 0.21 27)",
+          "oklch(0.721 0.21 27)",
+          "oklch(0.836 0.21 27)",
+          "oklch(0.950 0.21 27)"
+        ]
+      },
+      "domain-agent-systems": {
+        "role": "secondary",
+        "displayName": "Agent Systems Green",
+        "canonical": "oklch(0.52 0.11 150)",
+        "darkValue": "oklch(0.76 0.1 152)",
+        "tonalRamp": [
+          "oklch(0.150 0.11 150)",
+          "oklch(0.264 0.11 150)",
+          "oklch(0.379 0.11 150)",
+          "oklch(0.493 0.11 150)",
+          "oklch(0.607 0.11 150)",
+          "oklch(0.721 0.11 150)",
+          "oklch(0.836 0.11 150)",
+          "oklch(0.950 0.11 150)"
+        ]
+      },
+      "domain-agent-security": {
+        "role": "secondary",
+        "displayName": "Agent Security Crimson",
+        "canonical": "oklch(0.51 0.13 356)",
+        "darkValue": "oklch(0.74 0.12 358)",
+        "tonalRamp": [
+          "oklch(0.150 0.13 356)",
+          "oklch(0.264 0.13 356)",
+          "oklch(0.379 0.13 356)",
+          "oklch(0.493 0.13 356)",
+          "oklch(0.607 0.13 356)",
+          "oklch(0.721 0.13 356)",
+          "oklch(0.836 0.13 356)",
+          "oklch(0.950 0.13 356)"
+        ]
+      },
+      "domain-ai-coding-practice": {
+        "role": "secondary",
+        "displayName": "Coding Practice Moss",
+        "canonical": "oklch(0.53 0.11 123)",
+        "darkValue": "oklch(0.76 0.1 125)",
+        "tonalRamp": [
+          "oklch(0.150 0.11 123)",
+          "oklch(0.264 0.11 123)",
+          "oklch(0.379 0.11 123)",
+          "oklch(0.493 0.11 123)",
+          "oklch(0.607 0.11 123)",
+          "oklch(0.721 0.11 123)",
+          "oklch(0.836 0.11 123)",
+          "oklch(0.950 0.11 123)"
+        ]
+      },
+      "domain-evals-and-benchmarks": {
+        "role": "secondary",
+        "displayName": "Evals Teal",
+        "canonical": "oklch(0.52 0.09 172)",
+        "darkValue": "oklch(0.75 0.09 174)",
+        "tonalRamp": [
+          "oklch(0.150 0.09 172)",
+          "oklch(0.264 0.09 172)",
+          "oklch(0.379 0.09 172)",
+          "oklch(0.493 0.09 172)",
+          "oklch(0.607 0.09 172)",
+          "oklch(0.721 0.09 172)",
+          "oklch(0.836 0.09 172)",
+          "oklch(0.950 0.09 172)"
+        ]
+      },
+      "domain-model-capability-and-training": {
+        "role": "secondary",
+        "displayName": "Capability Ochre",
+        "canonical": "oklch(0.55 0.1 70)",
+        "darkValue": "oklch(0.78 0.1 75)",
+        "tonalRamp": [
+          "oklch(0.150 0.1 70)",
+          "oklch(0.264 0.1 70)",
+          "oklch(0.379 0.1 70)",
+          "oklch(0.493 0.1 70)",
+          "oklch(0.607 0.1 70)",
+          "oklch(0.721 0.1 70)",
+          "oklch(0.836 0.1 70)",
+          "oklch(0.950 0.1 70)"
+        ]
+      },
+      "domain-alignment-and-safety": {
+        "role": "secondary",
+        "displayName": "Alignment Magenta",
+        "canonical": "oklch(0.5 0.12 333)",
+        "darkValue": "oklch(0.73 0.11 335)",
+        "tonalRamp": [
+          "oklch(0.150 0.12 333)",
+          "oklch(0.264 0.12 333)",
+          "oklch(0.379 0.12 333)",
+          "oklch(0.493 0.12 333)",
+          "oklch(0.607 0.12 333)",
+          "oklch(0.721 0.12 333)",
+          "oklch(0.836 0.12 333)",
+          "oklch(0.950 0.12 333)"
+        ]
+      },
+      "domain-interpretability": {
+        "role": "secondary",
+        "displayName": "Interpretability Olive",
+        "canonical": "oklch(0.53 0.1 97)",
+        "darkValue": "oklch(0.76 0.1 99)",
+        "tonalRamp": [
+          "oklch(0.150 0.1 97)",
+          "oklch(0.264 0.1 97)",
+          "oklch(0.379 0.1 97)",
+          "oklch(0.493 0.1 97)",
+          "oklch(0.607 0.1 97)",
+          "oklch(0.721 0.1 97)",
+          "oklch(0.836 0.1 97)",
+          "oklch(0.950 0.1 97)"
+        ]
+      },
+      "domain-interaction-multimodal": {
+        "role": "secondary",
+        "displayName": "Interaction Vermilion",
+        "canonical": "oklch(0.56 0.15 35)",
+        "darkValue": "oklch(0.74 0.13 40)",
+        "tonalRamp": [
+          "oklch(0.150 0.15 35)",
+          "oklch(0.264 0.15 35)",
+          "oklch(0.379 0.15 35)",
+          "oklch(0.493 0.15 35)",
+          "oklch(0.607 0.15 35)",
+          "oklch(0.721 0.15 35)",
+          "oklch(0.836 0.15 35)",
+          "oklch(0.950 0.15 35)"
+        ]
+      },
+      "domain-formal-math": {
+        "role": "secondary",
+        "displayName": "Formal Math Indigo",
+        "canonical": "oklch(0.53 0.1 250)",
+        "darkValue": "oklch(0.74 0.1 250)",
+        "tonalRamp": [
+          "oklch(0.150 0.1 250)",
+          "oklch(0.264 0.1 250)",
+          "oklch(0.379 0.1 250)",
+          "oklch(0.493 0.1 250)",
+          "oklch(0.607 0.1 250)",
+          "oklch(0.721 0.1 250)",
+          "oklch(0.836 0.1 250)",
+          "oklch(0.950 0.1 250)"
+        ]
+      },
+      "domain-startup-founder": {
+        "role": "secondary",
+        "displayName": "Founder Amber",
+        "canonical": "oklch(0.55 0.13 55)",
+        "darkValue": "oklch(0.77 0.12 58)",
+        "tonalRamp": [
+          "oklch(0.150 0.13 55)",
+          "oklch(0.264 0.13 55)",
+          "oklch(0.379 0.13 55)",
+          "oklch(0.493 0.13 55)",
+          "oklch(0.607 0.13 55)",
+          "oklch(0.721 0.13 55)",
+          "oklch(0.836 0.13 55)",
+          "oklch(0.950 0.13 55)"
+        ]
+      },
+      "domain-product-org": {
+        "role": "secondary",
+        "displayName": "Product Violet",
+        "canonical": "oklch(0.49 0.11 310)",
+        "darkValue": "oklch(0.73 0.11 310)",
+        "tonalRamp": [
+          "oklch(0.150 0.11 310)",
+          "oklch(0.264 0.11 310)",
+          "oklch(0.379 0.11 310)",
+          "oklch(0.493 0.11 310)",
+          "oklch(0.607 0.11 310)",
+          "oklch(0.721 0.11 310)",
+          "oklch(0.836 0.11 310)",
+          "oklch(0.950 0.11 310)"
+        ]
+      },
+      "domain-ai-economics-and-labor": {
+        "role": "secondary",
+        "displayName": "Economics Rose",
+        "canonical": "oklch(0.52 0.13 20)",
+        "darkValue": "oklch(0.74 0.12 22)",
+        "tonalRamp": [
+          "oklch(0.150 0.13 20)",
+          "oklch(0.264 0.13 20)",
+          "oklch(0.379 0.13 20)",
+          "oklch(0.493 0.13 20)",
+          "oklch(0.607 0.13 20)",
+          "oklch(0.721 0.13 20)",
+          "oklch(0.836 0.13 20)",
+          "oklch(0.950 0.13 20)"
+        ]
+      },
+      "domain-superintelligence-trajectory": {
+        "role": "secondary",
+        "displayName": "Trajectory Steel",
+        "canonical": "oklch(0.53 0.1 222)",
+        "darkValue": "oklch(0.74 0.1 224)",
+        "tonalRamp": [
+          "oklch(0.150 0.1 222)",
+          "oklch(0.264 0.1 222)",
+          "oklch(0.379 0.1 222)",
+          "oklch(0.493 0.1 222)",
+          "oklch(0.607 0.1 222)",
+          "oklch(0.721 0.1 222)",
+          "oklch(0.836 0.1 222)",
+          "oklch(0.950 0.1 222)"
+        ]
+      },
+      "domain-entities": {
+        "role": "secondary",
+        "displayName": "Entities Purple",
+        "canonical": "oklch(0.5 0.11 290)",
+        "darkValue": "oklch(0.72 0.11 290)",
+        "tonalRamp": [
+          "oklch(0.150 0.11 290)",
+          "oklch(0.264 0.11 290)",
+          "oklch(0.379 0.11 290)",
+          "oklch(0.493 0.11 290)",
+          "oklch(0.607 0.11 290)",
+          "oklch(0.721 0.11 290)",
+          "oklch(0.836 0.11 290)",
+          "oklch(0.950 0.11 290)"
+        ]
+      },
+      "domain-syntheses": {
+        "role": "secondary",
+        "displayName": "Syntheses Cyan",
+        "canonical": "oklch(0.52 0.09 195)",
+        "darkValue": "oklch(0.75 0.09 195)",
+        "tonalRamp": [
+          "oklch(0.150 0.09 195)",
+          "oklch(0.264 0.09 195)",
+          "oklch(0.379 0.09 195)",
+          "oklch(0.493 0.09 195)",
+          "oklch(0.607 0.09 195)",
+          "oklch(0.721 0.09 195)",
+          "oklch(0.836 0.09 195)",
+          "oklch(0.950 0.09 195)"
+        ]
+      }
+    },
+    "typographyMeta": {
+      "display": {
+        "displayName": "Display",
+        "purpose": "The masthead h1 on a full plate header. One per page, directly under the triple rule."
+      },
+      "headline": {
+        "displayName": "Headline",
+        "purpose": "The compact plate title — the article reader, the only page on the compact variant. Deliberately close to body scale."
+      },
+      "title": {
+        "displayName": "Title",
+        "purpose": "Article title inside an index row. Drops to 16px/1.25 at compact density."
+      },
+      "numeral": {
+        "displayName": "Numeral",
+        "purpose": "The ordinal marker in the margin of every index row (C01, E07, S12), tinted with the row accent."
+      },
+      "body": {
+        "displayName": "Body",
+        "purpose": "Site-wide default set on body."
+      },
+      "prose": {
+        "displayName": "Prose",
+        "purpose": "Article bodies only, in the 720px reading column. Scales 0.9x / 1.12x via the reader text-size control."
+      },
+      "label": {
+        "displayName": "Label",
+        "purpose": "Mono marginalia — every eyebrow, data-grid key, row metadata, and the site's bespoke controls. Tracking widens with importance: 0.12em row metadata, 0.16em controls, 0.18em data-grid keys, 0.22em plate eyebrows. Chips sit outside this range at 12px / 0.08em — a chip is a tappable object, not marginalia."
+      },
+      "control": {
+        "displayName": "Control",
+        "purpose": "The shadcn Button and Input — Newsreader 500 at 14px, sentence case. Bespoke controls that sit among marginalia (shelf Clear/Compare/Select, the resume pill, labeled SaveButton, the filter bar) take the Label role in mono uppercase instead."
+      }
+    },
+    "shadows": [
+      {
+        "name": "paper",
+        "value": "0 1px 0 oklch(0.85 0.02 70 / 0.6), 0 4px 12px -6px oklch(0.3 0.05 50 / 0.15)",
+        "purpose": "Resting floating chrome — the desktop nav pill, cards, popovers. Leads with a 1px warm edge so it reads as one sheet on another."
+      },
+      {
+        "name": "paper-lg",
+        "value": "0 1px 0 oklch(0.85 0.02 70 / 0.6), 0 10px 30px -12px oklch(0.3 0.05 50 / 0.18)",
+        "purpose": "Fixed overlays anchored to a viewport edge — the resume-reading pill, the sticky shelf control bar."
+      },
+      {
+        "name": "paper-dark",
+        "value": "0 1px 0 oklch(0.1 0.02 260 / 0.6), 0 4px 12px -6px oklch(0 0 0 / 0.4)",
+        "purpose": "Dark-mode counterpart of paper."
+      },
+      {
+        "name": "paper-lg-dark",
+        "value": "0 1px 0 oklch(0.1 0.02 260 / 0.6), 0 10px 30px -12px oklch(0 0 0 / 0.5)",
+        "purpose": "Dark-mode counterpart of paper-lg."
+      }
+    ],
+    "motion": [
+      {
+        "name": "page-enter",
+        "value": "hw-page-in 0.45s cubic-bezier(0.2, 0.7, 0.2, 1)",
+        "purpose": "Every page fades up 6px on mount, applied by the PlatePage shell. Suppressed under prefers-reduced-motion."
+      },
+      {
+        "name": "theme-swap",
+        "value": "background-color 0.3s ease, color 0.3s ease",
+        "purpose": "The light/dark transition on body."
+      },
+      {
+        "name": "header-condense",
+        "value": "padding 200ms, color 200ms",
+        "purpose": "The sticky site bar tightening past 80px of scroll."
+      }
+    ],
+    "breakpoints": [
+      {
+        "name": "sm",
+        "value": "640px"
+      },
+      {
+        "name": "md",
+        "value": "768px"
+      },
+      {
+        "name": "lg",
+        "value": "1024px"
+      },
+      {
+        "name": "rail",
+        "value": "80rem"
+      }
+    ],
+    "containers": [
+      {
+        "name": "read",
+        "value": "720px",
+        "purpose": "The reading column and every single-column view."
+      },
+      {
+        "name": "index",
+        "value": "1120px",
+        "purpose": "Reading column plus its 320px navigation rail; the article reader and /shelf."
+      },
+      {
+        "name": "wide",
+        "value": "1320px",
+        "purpose": "Everything that lays plates across the page: the home masthead, /articles, the domain / tag / tagged indexes, /questions, and /compare's three columns."
+      },
+      {
+        "name": "gutter",
+        "value": "clamp(20px, 5vw, 72px)",
+        "purpose": "The single horizontal page padding, applied once on the PlatePage shell."
+      }
+    ],
+    "surfaces": [
+      {
+        "name": "body-grain",
+        "value": "radial-gradient(ellipse 80% 50% at 50% -10%, oklch(from var(--brand) l c h / 0.06), transparent 60%), fractal-noise SVG data URI at 220px tile",
+        "purpose": "The permanent paper material under every page — an accent bleed from the top edge plus grain. Dark mode raises the bleed to 0.12 and switches the noise matrix to white at 0.025 alpha."
+      },
+      {
+        "name": "hw-grain",
+        "value": "::after overlay, 320px fractal-noise tile, mix-blend-mode: multiply, opacity 0.4",
+        "purpose": "Adds grain to a specific surface (plate headers, the half-disc) without re-stacking the body grain. Dark mode switches to screen at 0.3."
+      }
+    ]
+  },
+  "components": [
+    {
+      "name": "Primary Button",
+      "kind": "button",
+      "refersTo": "button-primary",
+      "description": "The only filled button in the general vocabulary. Ink on paper — the shelf's compare toggle is the single sanctioned Plate Red fill.",
+      "html": "<button class=\"ds-btn-primary\">Save article</button>",
+      "css": ".ds-btn-primary { display: inline-flex; align-items: center; justify-content: center; height: 32px; padding: 0 10px; gap: 6px; border: 1px solid transparent; border-radius: 10px; background: var(--primary, oklch(0.24 0.02 45)); color: var(--primary-foreground, oklch(0.965 0.012 82)); font-family: var(--font-body, Newsreader, Georgia, serif); font-size: 14px; font-weight: 500; white-space: nowrap; cursor: pointer; transition: all 150ms ease; } .ds-btn-primary:hover { background: color-mix(in oklch, var(--primary, oklch(0.24 0.02 45)) 80%, transparent); } .ds-btn-primary:focus-visible { outline: none; border-color: var(--ring, oklch(0.55 0.155 35)); box-shadow: 0 0 0 3px color-mix(in oklch, var(--ring, oklch(0.55 0.155 35)) 50%, transparent); } .ds-btn-primary:active { transform: translateY(1px); }"
+    },
+    {
+      "name": "Ghost Button",
+      "kind": "button",
+      "refersTo": "button-ghost",
+      "description": "The system default. Transparent until hover, when it takes the muted wash.",
+      "html": "<button class=\"ds-btn-ghost\">Compare</button>",
+      "css": ".ds-btn-ghost { display: inline-flex; align-items: center; justify-content: center; height: 32px; padding: 0 10px; gap: 6px; border: 1px solid transparent; border-radius: 10px; background: transparent; color: var(--muted-foreground, oklch(0.42 0.02 50)); font-family: var(--font-body, Newsreader, Georgia, serif); font-size: 14px; font-weight: 500; white-space: nowrap; cursor: pointer; transition: all 150ms ease; } .ds-btn-ghost:hover { background: var(--muted, oklch(0.945 0.016 80)); color: var(--foreground, oklch(0.24 0.02 45)); } .ds-btn-ghost:focus-visible { outline: none; border-color: var(--ring, oklch(0.55 0.155 35)); box-shadow: 0 0 0 3px color-mix(in oklch, var(--ring, oklch(0.55 0.155 35)) 50%, transparent); } .ds-btn-ghost:active { transform: translateY(1px); }"
+    },
+    {
+      "name": "Subject Chip",
+      "kind": "chip",
+      "refersTo": "badge-chip",
+      "description": "A free-form subject tag. Fully round, mono uppercase, with a Plate Red dot as its only color. Links when the tag has its own page, inert when it doesn't.",
+      "html": "<a class=\"ds-chip\" href=\"#\">Agent Harness</a> <span class=\"ds-chip ds-chip-inert\">Abstraction</span>",
+      "css": ".ds-chip { display: inline-flex; align-items: center; gap: 6px; height: auto; padding: 4px 10px; margin: 0 6px 4px 0; border: 1px solid var(--input, oklch(0.78 0.02 65)); border-radius: 9999px; background: color-mix(in oklch, var(--card, oklch(0.985 0.008 85)) 60%, transparent); color: var(--muted-foreground, oklch(0.42 0.02 50)); font-family: var(--font-mono, 'JetBrains Mono', ui-monospace, monospace); font-size: 12px; font-weight: 500; letter-spacing: 0.08em; text-transform: uppercase; text-decoration: none; white-space: nowrap; transition: color 150ms ease, border-color 150ms ease; } .ds-chip::before { content: ''; flex: 0 0 auto; width: 6px; height: 6px; border-radius: 9999px; background: var(--brand, oklch(0.55 0.155 35)); } .ds-chip:not(.ds-chip-inert):hover { border-color: var(--brand, oklch(0.55 0.155 35)); color: var(--brand, oklch(0.55 0.155 35)); } .ds-chip:focus-visible { outline: none; border-color: var(--ring, oklch(0.55 0.155 35)); box-shadow: 0 0 0 3px color-mix(in oklch, var(--ring, oklch(0.55 0.155 35)) 50%, transparent); }"
+    },
+    {
+      "name": "Text Input",
+      "kind": "input",
+      "refersTo": "input-default",
+      "description": "Transparent over the page with a single stroke, under a mono Label-scale caption. Focus shifts the border to the ring hue and adds a 3px halo. The placeholder is a hint, never the field's name — every input carries an associated label.",
+      "html": "<label class=\"ds-input-label\" for=\"ds-input-demo\">Search</label> <input class=\"ds-input\" id=\"ds-input-demo\" placeholder=\"Search 275 notes\" type=\"text\" />",
+      "css": ".ds-input-label { display: block; margin-bottom: 8px; font-family: var(--font-mono, 'JetBrains Mono', ui-monospace, monospace); font-size: 10.5px; font-weight: 500; letter-spacing: 0.12em; text-transform: uppercase; color: var(--foreground-subtle, oklch(0.53 0.015 55)); } .ds-input { display: block; width: 100%; min-width: 0; height: 32px; padding: 4px 10px; border: 1px solid var(--input, oklch(0.78 0.02 65)); border-radius: 10px; background: transparent; color: var(--foreground, oklch(0.24 0.02 45)); font-family: var(--font-body, Newsreader, Georgia, serif); font-size: 14px; outline: none; transition: border-color 150ms ease, box-shadow 150ms ease; } .ds-input::placeholder { color: var(--muted-foreground, oklch(0.42 0.02 50)); } .ds-input:focus-visible { border-color: var(--ring, oklch(0.55 0.155 35)); box-shadow: 0 0 0 3px color-mix(in oklch, var(--ring, oklch(0.55 0.155 35)) 50%, transparent); } .ds-input:disabled { opacity: 0.5; cursor: not-allowed; background: color-mix(in oklch, var(--input, oklch(0.78 0.02 65)) 50%, transparent); }"
+    },
+    {
+      "name": "Navigation Pill",
+      "kind": "nav",
+      "refersTo": "nav-link",
+      "description": "The floating desktop nav. A round card-tinted pill with a blurred backdrop; the active route takes a 10% brand wash behind Plate Red text.",
+      "html": "<nav class=\"ds-nav\" aria-label=\"Primary\"><a class=\"ds-nav-link\" href=\"#\">Home</a><a class=\"ds-nav-link ds-nav-link-active\" href=\"#\" aria-current=\"page\">Articles</a><a class=\"ds-nav-link\" href=\"#\">Questions</a><a class=\"ds-nav-link\" href=\"#\">Shelf</a></nav>",
+      "css": ".ds-nav { display: inline-flex; gap: 2px; padding: 6px; border: 1px solid var(--border, oklch(0.85 0.018 70)); border-radius: 9999px; background: color-mix(in oklch, var(--card, oklch(0.985 0.008 85)) 85%, transparent); box-shadow: 0 1px 0 oklch(0.85 0.02 70 / 0.6), 0 4px 12px -6px oklch(0.3 0.05 50 / 0.15); backdrop-filter: blur(12px); } .ds-nav-link { padding: 8px 16px; border-radius: 9999px; color: var(--muted-foreground, oklch(0.42 0.02 50)); font-family: var(--font-body, Newsreader, Georgia, serif); font-size: 0.9rem; font-weight: 500; text-decoration: none; transition: color 150ms ease, background 150ms ease; } .ds-nav-link:hover { color: var(--foreground, oklch(0.24 0.02 45)); } .ds-nav-link-active { background: color-mix(in oklch, var(--brand, oklch(0.55 0.155 35)) 10%, transparent); color: var(--brand, oklch(0.55 0.155 35)); }"
+    },
+    {
+      "name": "Card",
+      "kind": "card",
+      "refersTo": "card",
+      "description": "The sheet on the page — one tonal step up, an 18px corner, a hairline stroke, and the one sanctioned resting shadow.",
+      "html": "<div class=\"ds-card\"><div class=\"ds-card-eyebrow\">About this piece</div><div class=\"ds-card-body\">Imported from the wiki vault on 15 Jun 2026. Three external sources, seven backlinks.</div></div>",
+      "css": ".ds-card { display: flex; flex-direction: column; gap: 16px; padding: 16px; border: 1px solid var(--border, oklch(0.85 0.018 70)); border-radius: 18px; background: var(--card, oklch(0.985 0.008 85)); color: var(--card-foreground, oklch(0.24 0.02 45)); box-shadow: 0 1px 0 oklch(0.85 0.02 70 / 0.6), 0 4px 12px -6px oklch(0.3 0.05 50 / 0.15); overflow: hidden; } .ds-card-eyebrow { font-family: var(--font-mono, 'JetBrains Mono', ui-monospace, monospace); font-size: 10.5px; font-weight: 500; letter-spacing: 0.22em; text-transform: uppercase; color: var(--foreground-subtle, oklch(0.53 0.015 55)); } .ds-card-body { font-family: var(--font-body, Newsreader, Georgia, serif); font-size: 15px; line-height: 1.6; color: var(--muted-foreground, oklch(0.42 0.02 50)); }"
+    },
+    {
+      "name": "Plate Header (compact)",
+      "kind": "custom",
+      "refersTo": null,
+      "description": "Signature. Every page's identity block in its compact variant — a 3px double accent top rule over a 1px double bottom rule, a mono eyebrow pair carrying the plate number, a 27px headline, and a mono data grid.",
+      "html": "<section class=\"ds-plate-header\"><div class=\"ds-plate-eyebrows\"><span class=\"ds-plate-eyebrow ds-plate-eyebrow-accent\"><span class=\"ds-domain-dot\"></span>Plate II · Agent Systems</span><span class=\"ds-plate-eyebrow\">Plate II · No. 02</span></div><h1 class=\"ds-plate-title\">The Abstraction Barrier <em>a limit</em></h1><div class=\"ds-plate-data\"><span>Filed</span><b>15 Jun 2026</b><span>Reading</span><b>5 min</b></div></section>",
+      "css": ".ds-plate-header { position: relative; padding: 10px 0 40px; border-top: 3px double var(--article-accent, var(--domain-agent-systems, oklch(0.52 0.11 150))); border-bottom: 1px double var(--border, oklch(0.85 0.018 70)); } .ds-plate-eyebrows { display: flex; align-items: baseline; justify-content: space-between; gap: 16px; margin-bottom: 28px; } .ds-plate-eyebrow { display: inline-flex; align-items: center; font-family: var(--font-mono, 'JetBrains Mono', ui-monospace, monospace); font-size: 10.5px; letter-spacing: 0.22em; text-transform: uppercase; color: var(--foreground-subtle, oklch(0.53 0.015 55)); } .ds-plate-eyebrow-accent { color: var(--article-accent, var(--domain-agent-systems, oklch(0.52 0.11 150))); } .ds-domain-dot { display: inline-block; width: 6px; height: 6px; margin-right: 8px; border-radius: 9999px; background: currentColor; } .ds-plate-title { margin: 0; font-family: var(--font-display, Fraunces, 'Times New Roman', serif); font-size: 27px; font-weight: 400; line-height: 1.2; letter-spacing: -0.015em; color: var(--foreground, oklch(0.24 0.02 45)); } .ds-plate-title em { font-style: italic; color: var(--article-accent, var(--brand, oklch(0.55 0.155 35))); } .ds-plate-data { display: grid; grid-template-columns: auto 1fr; gap: 6px 16px; max-width: 280px; margin-top: 20px; font-family: var(--font-mono, 'JetBrains Mono', ui-monospace, monospace); font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--foreground-subtle, oklch(0.53 0.015 55)); } .ds-plate-data b { font-family: var(--font-body, Newsreader, Georgia, serif); font-weight: 400; letter-spacing: 0.02em; text-transform: none; color: var(--muted-foreground, oklch(0.42 0.02 50)); }"
+    },
+    {
+      "name": "Index Row",
+      "kind": "custom",
+      "refersTo": "index-row",
+      "description": "Signature. The article-list row used by every index on the site — numeral marker, title with subject chips, domain label, date · reading, save. The first row in a list takes a 2px accent rule instead of a hairline. The shelf runs the same pattern through its own ShelfArticleRow, which adds progress and selection.",
+      "html": "<ul class=\"ds-index\"><li class=\"ds-index-row ds-index-row-first\"><span class=\"ds-index-numeral\">C01</span><div class=\"ds-index-main\"><a class=\"ds-index-title\" href=\"#\">The Abstraction Barrier</a><div class=\"ds-index-chips\"><span class=\"ds-index-chip\">Theory</span><span class=\"ds-index-chip\">Limits</span></div></div><div class=\"ds-index-meta\"><span class=\"ds-index-domain\"><span class=\"ds-index-dot\"></span>Superintelligence</span><span class=\"ds-index-date\">15 Jun · 5′</span><button class=\"ds-index-save\" type=\"button\" aria-label=\"Save for later\" aria-pressed=\"false\"><svg viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"1.5\" width=\"15\" height=\"15\" aria-hidden=\"true\"><path d=\"M6 4h12v16l-6-4-6 4V4z\"/></svg></button></div></li></ul>",
+      "css": ".ds-index { list-style: none; margin: 0; padding: 0; } .ds-index-row { display: grid; grid-template-columns: auto 1fr auto; align-items: baseline; gap: 0 16px; padding: 14px 0; border-top: 1px solid var(--border, oklch(0.85 0.018 70)); } .ds-index-row-first { border-top: 2px solid var(--domain-superintelligence-trajectory, oklch(0.53 0.1 222)); } .ds-index-numeral { font-family: var(--font-display, Fraunces, 'Times New Roman', serif); font-size: 28px; font-weight: 300; line-height: 0.9; letter-spacing: -0.03em; color: var(--domain-superintelligence-trajectory, oklch(0.53 0.1 222)); } .ds-index-main { min-width: 0; } .ds-index-title { font-family: var(--font-display, Fraunces, 'Times New Roman', serif); font-size: 19px; font-weight: 500; line-height: 1.2; letter-spacing: -0.012em; color: var(--foreground, oklch(0.24 0.02 45)); text-decoration: none; transition: color 150ms ease; } .ds-index-title:hover { color: var(--brand, oklch(0.55 0.155 35)); } .ds-index-chips { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 6px; } .ds-index-chip { display: inline-flex; align-items: center; gap: 6px; padding: 3px 9px; border: 1px solid var(--input, oklch(0.78 0.02 65)); border-radius: 9999px; background: color-mix(in oklch, var(--card, oklch(0.985 0.008 85)) 60%, transparent); font-family: var(--font-mono, 'JetBrains Mono', ui-monospace, monospace); font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--muted-foreground, oklch(0.42 0.02 50)); } .ds-index-chip::before { content: ''; width: 5px; height: 5px; border-radius: 9999px; background: var(--brand, oklch(0.55 0.155 35)); } .ds-index-meta { display: flex; align-items: baseline; gap: 16px; font-family: var(--font-mono, 'JetBrains Mono', ui-monospace, monospace); font-size: 10.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--foreground-subtle, oklch(0.53 0.015 55)); white-space: nowrap; } .ds-index-dot { display: inline-block; width: 7px; height: 7px; margin-right: 8px; border-radius: 9999px; background: var(--domain-superintelligence-trajectory, oklch(0.53 0.1 222)); vertical-align: middle; } .ds-index-date { font-variant-numeric: tabular-nums; text-align: right; } .ds-index-save { display: inline-flex; align-items: center; justify-content: center; flex: 0 0 auto; width: 28px; height: 28px; padding: 0; border: none; border-radius: 9999px; background: none; color: var(--foreground-subtle, oklch(0.53 0.015 55)); cursor: pointer; transition: color 150ms ease; transform: translateY(-2px); } .ds-index-save:hover, .ds-index-save[aria-pressed=\"true\"] { color: var(--brand, oklch(0.55 0.155 35)); } .ds-index-save:focus-visible { outline: none; box-shadow: 0 0 0 3px color-mix(in oklch, var(--ring, oklch(0.55 0.155 35)) 50%, transparent); }"
+    },
+    {
+      "name": "Domain Label",
+      "kind": "custom",
+      "refersTo": null,
+      "description": "The system's smallest and most-repeated identity element: a round dot in the domain's hue followed by its display label. The primary sanctioned use of a domain color.",
+      "html": "<span class=\"ds-domain-label\"><span class=\"ds-domain-swatch\"></span>Interpretability</span> <span class=\"ds-domain-label ds-domain-label-b\"><span class=\"ds-domain-swatch\"></span>Formal Math</span>",
+      "css": ".ds-domain-label { display: inline-flex; align-items: center; margin-right: 16px; font-family: var(--font-mono, 'JetBrains Mono', ui-monospace, monospace); font-size: 10.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--foreground-subtle, oklch(0.53 0.015 55)); } .ds-domain-swatch { display: inline-block; width: 7px; height: 7px; margin-right: 8px; border-radius: 9999px; background: var(--domain-interpretability, oklch(0.53 0.1 97)); } .ds-domain-label-b .ds-domain-swatch { background: var(--domain-formal-math, oklch(0.53 0.1 250)); }"
+    },
+    {
+      "name": "Half Disc",
+      "kind": "custom",
+      "refersTo": null,
+      "description": "Signature ornament. A 2:1 rectangle clipped to a 999px top radius, filled with a three-stop radial gradient derived from the accent hue and overlaid with grain. A printed illustration on the plate, not a UI shape.",
+      "html": "<div class=\"ds-half-disc\"><div class=\"ds-half-disc-fill\"></div><div class=\"ds-half-disc-grain\"></div></div>",
+      "css": ".ds-half-disc { position: relative; width: 100%; max-width: 380px; aspect-ratio: 2 / 1; border-radius: 999px 999px 0 0; overflow: hidden; } .ds-half-disc-fill { position: absolute; inset: 0; background: radial-gradient(circle at 50% 100%, oklch(from var(--brand, oklch(0.55 0.155 35)) 0.82 0.09 h) 0%, oklch(from var(--brand, oklch(0.55 0.155 35)) 0.56 0.15 h) 55%, oklch(from var(--brand, oklch(0.55 0.155 35)) 0.38 0.1 h) 100%); } .ds-half-disc-grain { position: absolute; inset: 0; pointer-events: none; opacity: 0.6; mix-blend-mode: overlay; background-image: url(\"data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='320' height='320'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.75' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.3  0 0 0 0 0.25  0 0 0 0 0.2  0 0 0 0.06 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>\"); }"
+    }
+  ],
+  "narrative": {
+    "northStar": "The Plate Book",
+    "overview": "This is a bound volume, not a website. The masthead is plate 00; the four sections are Plates I through IV; every article is a leaf of Plate II, stamped with its domain. The running head reads Howardism · Vol. 03. That numbering is not decoration applied after the fact — it is the information architecture, defined once as data in plate-meta.ts and read by the single page shell. When you add a surface, you are adding a plate to the book, and it needs a number.\n\nThe material is warm paper. A fractal-noise grain sits under every page and a faint radial wash of the accent bleeds from the top edge, so the background is never a flat fill. Structure is drawn the way a press draws it: hairline rules, a triple-rule under the masthead, an ordinal in the margin of every row. Type does nearly all the work — Fraunces for the engraved display, Newsreader for the reading column, JetBrains Mono for the small tracked marginalia that labels everything. One red runs through the whole book, and fifteen domain hues mark specimens without ever becoming surfaces.\n\nThe restraint is deliberate and load-bearing. This is a corpus of 275 connected notes; the design's job is to make structure legible and stay out of the reading. Four looks are explicitly rejected: SaaS/dev-tool dark (neon on near-black, gradient-mesh heroes, glassmorphism, Inter), the Medium-style blog (giant centered hero, stock photo, floating clap bar, structureless whitespace), the card-grid content feed (uniform thumbnail cards, which turn a knowledge base into a scroll), and Notion/wiki-tool chrome (sidebar tree, breadcrumbs, emoji, toggles — the look of the tool the notes came from, not of the published edition).",
+    "keyCharacteristics": [
+      "Numbered plates as literal IA — every page declares Masthead 00 or Plate I–IV in its eyebrow",
+      "Warm oklch paper with a permanent grain and accent bleed; never a flat background",
+      "Three content widths, one gutter, one shell — no page sets its own frame",
+      "Hairline rules and tonal steps carry depth; shadows are for floating chrome only",
+      "Mono marginalia (uppercase, tracked 0.12–0.22em, ≤11px — chips excepted at 12px / 0.08em) labels everything and reads nothing",
+      "One rationed red, plus fifteen domain hues that mark but never fill",
+      "Light and dark are one token system: paper→slate, ink→bone, the red lifting to oklch(0.74 0.13 40)"
+    ],
+    "rules": [
+      {
+        "name": "The Second Pass Rule",
+        "body": "Plate Red is a second impression, not a fill. It appears as text, a mark, or a rule — links, the drop-cap, §, the lede rule, an active nav label — never a large area. Its sanctioned surface uses are exactly two: a wash at ≤10% opacity (brand/10 on active nav, brand/5 behind a blockquote), and one solid fill — the shelf's compare toggle, whose armed state has to be unmissable. There is no third. One accent per view.",
+        "section": "colors"
+      },
+      {
+        "name": "The One Hue Per View Rule",
+        "body": "A page carries exactly one domain hue, and everything tinted on it — numerals, top rule, header eyebrow, accent text — uses that hue via --article-accent. The home masthead and cross-domain indexes are the only places the full spectrum appears, and there it functions as a legend.",
+        "section": "colors"
+      },
+      {
+        "name": "The Marker-Never-Surface Rule",
+        "body": "Domain color renders only as a dot, a numeral, a rule of ≤3px, or text. Never a background fill, never a tinted panel, never a badge fill. 1px separates, 2px opens a list, and 3px is reserved for exactly one thing: the compact plate header's double top rule.",
+        "section": "colors"
+      },
+      {
+        "name": "The Marginalia Rule",
+        "body": "Mono is always uppercase and never used for anything a reader reads in sequence. As marginalia it is tracked ≥0.12em and never above 11px; the chip is the single exception, at 12px / 0.08em, because it is an object on the page rather than a note in the margin. If a mono string needs to be a sentence, it is the wrong font.",
+        "section": "typography"
+      },
+      {
+        "name": "The Tightened Display Rule",
+        "body": "Fraunces is never set at default tracking. Larger means tighter: -0.012em at 19px, -0.015em at 27px, -0.03em at 72px and on numerals.",
+        "section": "typography"
+      },
+      {
+        "name": "The Essay-Only Drop Cap Rule",
+        "body": "Drop-caps are derived from article kind, not authored per file: Essays get one, Concepts and Entities never do. It is 4.2em of Fraunces at 600 in Plate Red, stepping to 3.3em below 480px.",
+        "section": "typography"
+      },
+      {
+        "name": "The Three Stops Rule",
+        "body": "max-w-read, max-w-index, max-w-wide are the only page-frame widths in the app. A max-w-[1120px] or a per-page px-8 is a bug, not a variation. A raw max-width capping a paragraph's measure inside the frame is a different thing and is allowed.",
+        "section": "layout"
+      },
+      {
+        "name": "The Hairline Rule",
+        "body": "If two regions need separating, the answer is a 1px --border rule — not a shadow, not a gap, not a filled panel. Weight escalates only for meaning: 1px separates, 2px opens a list in its accent, 3px double-rules a masthead.",
+        "section": "elevation"
+      },
+      {
+        "name": "The Flat Content Rule",
+        "body": "Nothing inside the content column casts a shadow except a Card, which always carries shadow-paper — the one resting shadow that makes it read as a sheet on the page. Anything else that appears to float must be position: fixed or sticky and genuinely above the page.",
+        "section": "elevation"
+      }
+    ],
+    "dos": [
+      "Do give every new page a plate number in plate-meta.ts and render it through PlatePage. A surface without a plate number is not part of the book.",
+      "Do use max-w-read / max-w-index / max-w-wide and px-gutter. Nothing else sets a page width or a horizontal page padding.",
+      "Do reach for a 1px --border rule before a shadow, a gap, or a filled panel.",
+      "Do set mono uppercase, tracked 0.12–0.22em, at 9.5–11px, for every label, eyebrow, and metadata string.",
+      "Do derive an article's accent from its domain and thread it through the whole view via --article-accent.",
+      "Do render every article list through IndexRow — or ShelfArticleRow on the shelf, where rows carry progress and selection — with one date format (formatDateShort · {readingTime}′). The shelf differs twice, both deliberate: a relative read/saved time instead of a publication date, and a trailing control that varies by list — SaveButton on every index and on Saved, RemoveButton on History.",
+      "Do keep content structure square and chrome rounded (10px controls, 18px cards, full-round pills).",
+      "Do define new colors in OKLCH in packages/ui/src/styles/globals.css with a light and a dark value, and clamp accents to L ≤ 0.56 light / L ≈ 0.75 dark so they hold AA on --card."
+    ],
+    "donts": [
+      "Don't fill anything with Plate Red. It is text, a mark, or a rule — plus washes at ≤10% (brand/10, brand/5). Never a button, badge, or panel background — the shelf's compare toggle is the one standing exception, not a precedent.",
+      "Don't let a domain hue become a surface. Dot, numeral, rule of ≤3px (3px only on the compact header), or text only — and one hue per view outside the masthead and cross-domain indexes.",
+      "Don't add a shadow to anything inside the content column. Shadows belong to fixed/sticky chrome, cards, and popovers.",
+      "Don't introduce a fourth content width: no raw page-container width (max-w-[720px], max-w-[1120px], max-w-[1280px], max-w-[1320px]) anywhere, and no raw px-4 / px-8 gutter on a route entry — page-frame.test.ts fails CI on both. A max-w-[680px] or max-w-[60ch] capping a paragraph's measure is not a page frame and is fine.",
+      "Don't set Fraunces at default tracking, or use Newsreader for labels, or JetBrains Mono for anything read in sequence.",
+      "Don't author drop-caps per article. They are an Essay-only rule derived from article kind.",
+      "Don't add a third way to render an article in a list. Extend IndexRow's props, or ShelfArticleRow's if the surface is the shelf. (ResumeCard is not a third row — it is the shelf's card carousel.)",
+      "Don't reach for the four rejected worlds: neon-on-black SaaS chrome with gradient-mesh heroes and glassmorphism; a giant centered hero with a stock photo and a floating clap bar; a uniform rounded card grid with thumbnails; or sidebar-tree, breadcrumb, emoji-icon wiki-tool chrome.",
+      "Don't flatten the background to a solid color. The grain and the top accent bleed are the material."
+    ]
+  }
+}

--- a/apps/blog/DESIGN.md
+++ b/apps/blog/DESIGN.md
@@ -1,0 +1,374 @@
+---
+name: Howardism
+description: A bound volume of numbered plates — warm paper, ink, and one rationed red — for reading a connected knowledge base.
+colors:
+  paper: "oklch(0.965 0.012 82)"
+  paper-recessed: "oklch(0.945 0.016 80)"
+  plate: "oklch(0.985 0.008 85)"
+  ink: "oklch(0.24 0.02 45)"
+  ink-muted: "oklch(0.42 0.02 50)"
+  ink-subtle: "oklch(0.53 0.015 55)"
+  rule: "oklch(0.85 0.018 70)"
+  rule-strong: "oklch(0.78 0.02 65)"
+  hover-wash: "oklch(0.93 0.018 75)"
+  plate-red: "oklch(0.55 0.155 35)"
+  verdigris: "oklch(0.62 0.11 150)"
+  correction-red: "oklch(0.58 0.21 27)"
+  domain-agent-systems: "oklch(0.52 0.11 150)"
+  domain-agent-security: "oklch(0.51 0.13 356)"
+  domain-ai-coding-practice: "oklch(0.53 0.11 123)"
+  domain-evals-and-benchmarks: "oklch(0.52 0.09 172)"
+  domain-model-capability-and-training: "oklch(0.55 0.1 70)"
+  domain-alignment-and-safety: "oklch(0.5 0.12 333)"
+  domain-interpretability: "oklch(0.53 0.1 97)"
+  domain-interaction-multimodal: "oklch(0.56 0.15 35)"
+  domain-formal-math: "oklch(0.53 0.1 250)"
+  domain-startup-founder: "oklch(0.55 0.13 55)"
+  domain-product-org: "oklch(0.49 0.11 310)"
+  domain-ai-economics-and-labor: "oklch(0.52 0.13 20)"
+  domain-superintelligence-trajectory: "oklch(0.53 0.1 222)"
+  domain-entities: "oklch(0.5 0.11 290)"
+  domain-syntheses: "oklch(0.52 0.09 195)"
+typography:
+  display:
+    fontFamily: "Fraunces, 'Times New Roman', serif"
+    fontSize: "clamp(40px, 6vw, 72px)"
+    fontWeight: 400
+    lineHeight: 1.05
+    letterSpacing: "-0.03em"
+  headline:
+    fontFamily: "Fraunces, 'Times New Roman', serif"
+    fontSize: "27px"
+    fontWeight: 400
+    lineHeight: 1.2
+    letterSpacing: "-0.015em"
+  title:
+    fontFamily: "Fraunces, 'Times New Roman', serif"
+    fontSize: "19px"
+    fontWeight: 500
+    lineHeight: 1.2
+    letterSpacing: "-0.012em"
+  numeral:
+    fontFamily: "Fraunces, 'Times New Roman', serif"
+    fontSize: "28px"
+    fontWeight: 300
+    lineHeight: 0.9
+    letterSpacing: "-0.03em"
+  body:
+    fontFamily: "Newsreader, Georgia, serif"
+    fontSize: "1.125rem"
+    fontWeight: 400
+    lineHeight: 1.6
+  prose:
+    fontFamily: "Newsreader, Georgia, serif"
+    fontSize: "1.1875rem"
+    fontWeight: 400
+    lineHeight: 1.75
+  label:
+    fontFamily: "JetBrains Mono, ui-monospace, monospace"
+    fontSize: "10.5px"
+    fontWeight: 400
+    lineHeight: 1.2
+    letterSpacing: "0.22em"
+  control:
+    fontFamily: "Newsreader, Georgia, serif"
+    fontSize: "14px"
+    fontWeight: 500
+    lineHeight: 1.2
+rounded:
+  none: "0"
+  sm: "6px"
+  md: "8px"
+  lg: "10px"
+  xl: "14px"
+  2xl: "18px"
+  full: "9999px"
+spacing:
+  gutter: "clamp(20px, 5vw, 72px)"
+  row: "14px"
+  row-compact: "10px"
+  header-gap: "28px"
+  section: "80px"
+components:
+  button-primary:
+    backgroundColor: "{colors.ink}"
+    textColor: "{colors.paper}"
+    typography: "{typography.control}"
+    rounded: "{rounded.lg}"
+    padding: "0 10px"
+    height: "32px"
+  button-primary-hover:
+    backgroundColor: "color-mix(in oklch, {colors.ink} 80%, transparent)"
+    textColor: "{colors.paper}"
+  button-ghost:
+    backgroundColor: "transparent"
+    textColor: "{colors.ink-muted}"
+    typography: "{typography.control}"
+    rounded: "{rounded.lg}"
+    padding: "0 10px"
+    height: "32px"
+  button-ghost-hover:
+    backgroundColor: "{colors.paper-recessed}"
+    textColor: "{colors.ink}"
+  button-icon:
+    backgroundColor: "transparent"
+    textColor: "{colors.ink-muted}"
+    rounded: "{rounded.full}"
+    size: "36px"
+  badge-chip:
+    backgroundColor: "{colors.plate}"
+    textColor: "{colors.ink-muted}"
+    rounded: "{rounded.full}"
+    padding: "4px 10px"
+  badge-chip-hover:
+    textColor: "{colors.plate-red}"
+  input-default:
+    backgroundColor: "transparent"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.lg}"
+    padding: "4px 10px"
+    height: "32px"
+  nav-link:
+    backgroundColor: "transparent"
+    textColor: "{colors.ink-muted}"
+    rounded: "{rounded.full}"
+    padding: "8px 16px"
+  nav-link-active:
+    textColor: "{colors.plate-red}"
+    rounded: "{rounded.full}"
+    padding: "8px 16px"
+  card:
+    backgroundColor: "{colors.plate}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.2xl}"
+    padding: "16px"
+  index-row:
+    backgroundColor: "transparent"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.none}"
+    padding: "14px 0"
+---
+
+# Design System: Howardism
+
+## Overview
+
+**Creative North Star: "The Plate Book"**
+
+This is a bound volume, not a website. The masthead is plate 00; the four sections are Plates I through IV; every article is a leaf of Plate II, stamped with its domain. The running head reads *Howardism · Vol. 03*. That numbering is not decoration applied after the fact — it is the information architecture, defined once as data in `plate-meta.ts` and read by the single page shell. When you add a surface, you are adding a plate to the book, and it needs a number.
+
+The material is warm paper. A fractal-noise grain sits under every page and a faint radial wash of the accent bleeds from the top edge, so the background is never a flat fill. Structure is drawn the way a press draws it: hairline rules, a triple-rule under the masthead, an ordinal in the margin of every row. Type does nearly all the work — Fraunces for the engraved display, Newsreader for the reading column, JetBrains Mono for the small tracked marginalia that labels everything. One red runs through the whole book, and fifteen domain hues mark specimens without ever becoming surfaces.
+
+The restraint is deliberate and load-bearing. This is a corpus of 275 connected notes; the design's job is to make structure legible and stay out of the reading. Four looks are explicitly rejected: **SaaS/dev-tool dark** (neon on near-black, gradient-mesh heroes, glassmorphism, Inter), the **Medium-style blog** (giant centered hero, stock photo, floating clap bar, structureless whitespace), the **card-grid content feed** (uniform thumbnail cards, which turn a knowledge base into a scroll), and **Notion/wiki-tool chrome** (sidebar tree, breadcrumbs, emoji, toggles — the look of the tool the notes came *from*, not of the published edition).
+
+**Key Characteristics:**
+
+- Numbered plates as literal IA — every page declares `Masthead 00` or `Plate I–IV` in its eyebrow
+- Warm oklch paper with a permanent grain and accent bleed; never a flat background
+- Three content widths, one gutter, one shell — no page sets its own frame
+- Hairline rules and tonal steps carry depth; shadows are for floating chrome only
+- Mono marginalia (uppercase, tracked 0.12–0.22em, ≤11px) labels everything and reads nothing
+- One rationed red, plus fifteen domain hues that mark but never fill
+- Light and dark are one token system: paper→slate, ink→bone, the red lifting to `oklch(0.74 0.13 40)`
+
+## Colors
+
+Warm paper and ink in the low-chroma 45–85° hue band, cut by one saturated red at 35° and a fifteen-hue spectrum reserved entirely for domain identity.
+
+### Primary
+
+- **Plate Red** (`oklch(0.55 0.155 35)`): The ink the press ran in a second pass. It is prose links, the essay drop-cap, the `§ end` mark, the lede's left rule, active nav, and the one accent a view is allowed. AA-compliant for body text on both surfaces — 5.00:1 on `plate`, 4.71:1 on paper. In dark mode it lifts to `oklch(0.74 0.13 40)` (6.81:1 on `card`).
+
+### Secondary
+
+- **The Domain Spectrum** (fifteen hues, `oklch(0.49–0.56 0.09–0.15 …)`): One per curated knowledge domain, spaced around the wheel and clamped to L ≤ 0.56; lifted to L ≈ 0.72–0.78 in dark. They appear as the domain dot, the ordinal numeral in an index row, a ≤3px rule, and the compact header's eyebrow. They are identity, not palette.
+
+  **Contrast, measured.** On `--card` all fifteen clear AA for normal text (≥4.75:1 light, ≥6.4:1 dark), which is what the L clamp guarantees. On `--background` (paper) the margin is thinner and one hue misses: `model-capability-and-training` (`oklch(0.55 0.1 70)`) is **4.48:1**, just under the 4.5:1 threshold, and it is used at 10.5px in the compact header eyebrow, so the large-text exemption does not apply. `interaction-multimodal` sits exactly on 4.50:1 with no margin. Treat the ochre as a defect to fix by darkening it a step — not as licence to place spectrum hues as small text on paper. Dark mode is comfortable throughout.
+
+### Tertiary
+
+- **Verdigris** (`oklch(0.62 0.11 150)`): A cool green counterweight to the red, currently used only in the placeholder ornament. Available for a second signal when one is genuinely needed; not a general-purpose accent. (A `--brand-soft` token is also defined and presently unused — do not reach for it without a reason.)
+
+### Neutral
+
+- **Paper** (`oklch(0.965 0.012 82)`): The page. Carries the grain and the accent bleed.
+- **Paper Recessed** (`oklch(0.945 0.016 80)`): Inset controls and segmented tracks — the `secondary`/`muted` slot.
+- **Plate** (`oklch(0.985 0.008 85)`): The sheet laid on the page — cards, popovers, the nav pill, and the banding on even plate *sections* (never on individual rows; see Banding).
+- **Ink** (`oklch(0.24 0.02 45)`): Body and heading text; also the fill of a primary button.
+- **Ink Muted** (`oklch(0.42 0.02 50)`): Secondary prose, values in a data grid, resting nav.
+- **Ink Subtle** (`oklch(0.53 0.015 55)`): Mono marginalia — eyebrows, labels, row metadata.
+- **Rule** (`oklch(0.85 0.018 70)`): Every hairline. The most-used non-text token in the system.
+- **Rule Strong** (`oklch(0.78 0.02 65)`): Input strokes and chip borders.
+- **Hover Wash** (`oklch(0.93 0.018 75)`): The `accent` slot — a hover surface, deliberately *not* the brand hue.
+- **Correction Red** (`oklch(0.58 0.21 27)`): Destructive only. Distinct in hue from Plate Red so the two never read as the same ink.
+
+### Named Rules
+
+**The Second Pass Rule.** Plate Red is a second impression, not a fill. It appears as text, a mark, or a rule — links, the drop-cap, `§`, the lede rule, an active nav label — never a large area. Its sanctioned surface uses are exactly two: a wash at ≤10% opacity (`brand/10` on active nav, `brand/5` behind a blockquote), and one solid fill — the shelf's compare toggle, whose armed state has to be unmissable. There is no third. One accent per view.
+
+**The One Hue Per View Rule.** A page carries exactly one domain hue, and everything tinted on it — numerals, top rule, header eyebrow, accent text — uses that hue via `--article-accent`. The home masthead and cross-domain indexes are the only places the full spectrum appears, and there it functions as a legend.
+
+**The Marker-Never-Surface Rule.** Domain color renders only as a dot, a numeral, a rule of ≤3px, or text. Never a background fill, never a tinted panel, never a badge fill. 1px is a separator, 2px opens a list, and 3px is reserved for exactly one thing: the compact plate header's `double` top rule.
+
+## Typography
+
+**Display Font:** Fraunces (variable, optical-size axis; fallback Times New Roman, serif)
+**Body Font:** Newsreader (variable, optical-size axis; fallback Georgia, serif)
+**Label/Mono Font:** JetBrains Mono (400/500/600; fallback ui-monospace)
+
+**Character:** Two serifs with different jobs and a monospace that never pretends to be either. Fraunces is the engraved plate — high-contrast, set at normal or light weight, always tightened (-0.012em to -0.03em) so it reads as cut rather than typed. Newsreader is the reading voice: warm, wide-aperture, comfortable at 19px over 1.75. JetBrains Mono is the printer's marginalia — tiny, uppercase, heavily tracked, and used exclusively for labels, numbers, and eyebrows.
+
+### Hierarchy
+
+- **Display** (400, `clamp(40px, 6vw, 72px)`, 1.05, -0.03em): The masthead `h1` on a full plate header. One per page, immediately under the triple rule.
+- **Headline** (400, 27px, 1.2, -0.015em): The compact plate title — the article reader. Deliberately close to body scale; the reading column should not open with a shout.
+- **Title** (500, 19px, 1.2, -0.012em): The article title inside an index row. Drops to 16px/1.25 at compact density.
+- **Numeral** (300, 28px, 0.9, -0.03em): The ordinal marker in the margin of every index row — kind prefix plus zero-padded position (`C01`, `E07`, `S12`, `I03`), tinted with the row's accent. 22px at compact density.
+- **Body** (400, 1.125rem, 1.6): Site-wide default set on `body`.
+- **Prose** (400, 1.1875rem, 1.75): Article bodies only, in a 720px column. Scales to 0.9× / 1.12× via the reader's text-size control.
+- **Label** (400, 10.5–11px, 0.12–0.22em, uppercase): Every eyebrow, data-grid key, row metadata — and the site's bespoke controls. Tracking widens with importance: 0.12em for row metadata, 0.16em for controls, 0.18em for data-grid keys, 0.22em for plate eyebrows. Chips are the one mono element outside this range: 12px at 0.08em, because a chip is a tappable object rather than marginalia, and tight tracking keeps a three-chip row from sprawling.
+- **Control** (500, 14px): the shadcn `Button` and `Input` — Newsreader at body weight+1, sentence case. This is the role for a *shadcn* control; the site's own bespoke controls are set in **Label** instead (see below).
+
+Controls therefore split by provenance, and both halves are intentional. A shadcn `Button`/`Input` takes **Control**. A hand-rolled control that lives among marginalia takes **Label** — mono, uppercase, tracked: the shelf's Clear / Compare / Select, the fixed resume-reading pill, the labeled `SaveButton`, and the filter bar. The test is where it sits, not what it does: a control surrounded by mono metadata is set in mono so it reads as part of that layer.
+
+### Named Rules
+
+**The Marginalia Rule.** Mono is always uppercase and never used for anything a reader reads in sequence. As marginalia it is tracked ≥0.12em and never above 11px; the chip is the single exception, at 12px / 0.08em, because it is an object on the page rather than a note in the margin. If a mono string needs to be a sentence, it is the wrong font.
+
+**The Tightened Display Rule.** Fraunces is never set at default tracking. Larger means tighter: -0.012em at 19px, -0.015em at 27px, -0.03em at 72px and on numerals.
+
+**The Essay-Only Drop Cap Rule.** Drop-caps are derived from article kind, not authored per file: Essays get one, Concepts and Entities never do. It is 4.2em of Fraunces at 600 in Plate Red, stepping to 3.3em below 480px.
+
+## Layout
+
+Every plate renders through one shell, `PlatePage`, which owns three things no page may set for itself: the content width, the horizontal gutter, and the page-enter animation. Home, `/articles`, the domain/tag indexes, `/questions`, `/shelf`, and the article reader (via `ArticleLayout`, in both locales) all go through it.
+
+Two routes do not, and are known exceptions rather than precedent: `/compare` is a `noindex` URL-driven tool, not a plate, so it has no `plate-meta.ts` entry and renders `CompareView` (or its empty state) directly; `/zh-TW/articles` is a stopgap translation index with its own hand-rolled header. Both still set a width stop and `px-gutter` by hand; only the translation index also carries `hw-page-enter`, so `/compare` enters without the page fade. Closing the second exception means giving it a plate number and the shell; the first is deliberate.
+
+**Three width stops, no raw pixels.** `--container-read: 720px` is the reading column and every single-column view. `--container-index: 1120px` seats the reading column plus its 320px navigation rail — the article reader and `/shelf`. `--container-wide: 1320px` frames everything that lays plates out across the page: the home masthead, `/articles`, the domain / tag / tagged indexes, `/questions`, and `/compare`'s three columns. The article reader is not a fourth width — it is *read* widening to *index* at the `rail` breakpoint (80rem), where the sticky TOC and backlinks rail appears beside the column.
+
+**One gutter.** `--spacing-gutter: clamp(20px, 5vw, 72px)`, applied once on the shell as `px-gutter`. Pages that need full-bleed banded sections pass `bleed` and the shell gutters only the header, letting the body run edge to edge.
+
+**Vertical rhythm.** Index rows are 14px vertical padding at comfortable density, 10px at compact, separated by 1px rules — the first row in a list gets a 2px rule in the list's accent instead. Full plate headers sit on a 3px double rule with 12px below it and 32px of air before the title. Compact headers use a 3px accent-colored `double` top rule with 10px below it, a 1px `double` bottom rule, and 40px of air under that. Pages end with 80px of bottom padding.
+
+**Banding.** Alternating *sections* take the `plate` background (`position % 2 === 0` on `KindPlate`) to keep a long stack of plates scannable across the full width. Index rows themselves are always transparent — the banding is one fill behind a whole plate, never a zebra stripe per row.
+
+**Responsive.** Domain labels drop out of index rows below `sm`. The data grid stacks label-over-value below 480px when asked. Desktop nav is a pill above `md`; below it, a top sheet. The rail appears only at 80rem.
+
+### Named Rules
+
+**The Three Stops Rule.** `max-w-read`, `max-w-index`, `max-w-wide` are the only *page-frame* widths in the app. A `max-w-[1120px]` or a per-page `px-8` is a bug, not a variation. A raw max-width capping a paragraph's measure inside the frame is a different thing and is allowed.
+
+## Elevation & Depth
+
+The system is flat and ruled. Depth comes from two places: hairline rules in `--border`, and a single tonal step between `--background` (the page) and `--card` (a sheet on it). Nothing in the content area lifts but a `Card`. Shadows are otherwise reserved for chrome that genuinely floats above the page and needs to be read as detached — the desktop nav pill, the fixed resume-reading pill, the sticky shelf control bar, and shadcn cards and popovers.
+
+Both shadow tokens lead with a 1px warm bottom edge rather than a blur, so the effect reads as one sheet resting on another rather than an object hovering in space.
+
+### Shadow Vocabulary
+
+- **`--shadow-paper`** (`0 1px 0 oklch(0.85 0.02 70 / 0.6), 0 4px 12px -6px oklch(0.3 0.05 50 / 0.15)`): Resting floating chrome — the nav pill, cards.
+- **`--shadow-paper-lg`** (`0 1px 0 oklch(0.85 0.02 70 / 0.6), 0 10px 30px -12px oklch(0.3 0.05 50 / 0.18)`): Fixed overlays anchored to a viewport edge.
+
+### Named Rules
+
+**The Hairline Rule.** If two regions need separating, the answer is a 1px `--border` rule — not a shadow, not a gap, not a filled panel. Weight escalates only for meaning: 1px separates, 2px opens a list in its accent, 3px double-rules a masthead.
+
+**The Flat Content Rule.** Nothing inside the content column casts a shadow *except* a `Card`, which always carries `shadow-paper` — that one resting shadow is what makes it read as a sheet laid on the page, and the article reader's "About this piece" card uses it mid-column. Anything else that appears to float must be `position: fixed` or `sticky` and genuinely above the page.
+
+## Shapes
+
+Two form languages, split by role and never mixed.
+
+**Content structure is unrounded.** Index rows, plate headers, rules, tables, the reading column, banded sections — all square. This is print geometry; a rounded corner on a plate would break the metaphor.
+
+**Chrome is rounded, and rounds harder the more it floats.** The radius scale derives from `--radius: 0.625rem` (10px): controls and inputs at 10px (`lg`), small controls at 6–8px, cards at 18px (`2xl`), and anything pill-shaped — nav links, icon buttons, chips, the nav container, the domain dot — fully round.
+
+**The half-disc** is the system's one piece of geometry that is neither: a 2:1 rectangle clipped to a 999px top (or bottom) radius, filled with a three-stop radial gradient derived from the accent hue via `oklch(from …)` and overlaid with grain at 60% opacity in `mix-blend-overlay`. It is a printed illustration on the plate, not a UI shape.
+
+## Components
+
+### Buttons
+
+- **Shape:** Softly rounded (10px), or fully round for icon-only. Square corners are for content, never for controls.
+- **Primary:** Ink fill on paper text (`bg-primary text-primary-foreground`), 32px tall, 10px horizontal padding. Hover drops the fill to 80% opacity. This is the only filled button in the general vocabulary.
+- **The one red fill:** the shelf's compare affordance — `bg-brand text-white` on the Compare action and on Select once compare mode is armed (`shelf-tabs.tsx`). It is a mode toggle whose *on* state has to be unmissable, and it is the single sanctioned exception to the no-red-fill rule. Do not extend it to a second surface.
+- **Ghost / Outline:** The default in this system. Ghost is transparent until hover, when it takes the muted wash and ink text. Outline adds a `--border` stroke over the page.
+- **Hover / Focus:** All transitions are `transition-all` at the browser default duration. Focus is a 3px `--ring` ring at 50% opacity plus a ring-colored border; the ring is the brand hue, which is the one place the red touches a control. Active state translates 1px down.
+- **Icon buttons:** 36px round (`size-9`), muted until hover, then the hover wash. Header controls (theme, menu, search, reader settings) are all this. The one smaller case is `SaveButton`'s icon-only variant at 28px (`size-7`), sized to sit inside an index row without stretching it — still a full round hit area, never a bare glyph.
+
+### Chips
+
+- **Style:** Fully round, `--card` at 60% opacity, `--input` stroke, mono uppercase at 0.08em tracking, with a 6px Plate Red dot as a `::before` (`before:size-1.5`) — the chip's only color. The tighter index-row variant drops the dot to 5px.
+- **State:** Navigable chips (a subject tag that has its own page) link and shift border and text to Plate Red on hover. Rare singleton tags render inert with no hover. Lists cap at 3 visible.
+
+### Cards / Containers
+
+- **Corner Style:** 18px (`2xl`).
+- **Background:** `--card`, the one tonal step above the page.
+- **Shadow Strategy:** `--shadow-paper` — cards are one of the four sanctioned floating surfaces.
+- **Border:** 1px `--border`, always.
+- **Internal Padding:** 16px vertical, 16px horizontal (12px at `size="sm"`).
+
+### Inputs / Fields
+
+- **Style:** 10px radius, transparent background over the page, 1px `--input` stroke. In dark mode the fill becomes `--input/30`.
+- **Focus:** Border shifts to `--ring` and a 3px `--ring/50` halo appears. No glow, no color change on the text.
+- **Error / Disabled:** `aria-invalid` swaps border and ring to `--destructive`. Disabled drops to 50% opacity with a filled `--input/50` background.
+
+### Navigation
+
+- **Style:** A floating pill above `md` — round, `--card` at 85%, `--border` stroke, `--shadow-paper`, `backdrop-blur-md`. Links are round, 16px × 8px, body font at 0.9rem.
+- **States:** Muted at rest; hover goes to full ink; the active route takes `brand/10` behind Plate Red text — the sanctioned wash exception to the Second Pass Rule.
+- **Mobile:** A top sheet at 24px radius with 32px padding, listing routes as full-width rows on hairline rules with a 48px minimum touch target.
+- **Scroll behavior:** The bar is sticky and condenses on scroll past 80px — padding tightens from 16px to 8px, the avatar shrinks 36→30px, the tagline drops, and a translucent blurred background with a bottom rule fades in. On article routes it grows reader controls (TOC, find, settings) separated from the global cluster by a 20px hairline, and the reading-progress bar becomes its bottom edge.
+
+### Index Row (signature)
+
+One row pattern renders an article in every *list* on the site — home plates, the articles index, domain pages, tag pages, and the shelf. It has two implementations: `IndexRow` for the site indexes, and `ShelfArticleRow` for the shelf, which keeps the same five facts and adds reading progress and a compare checkbox. The shelf's resume strip is deliberately not a list: `ContinueReading` renders its own `ResumeCard` as a horizontally snapping card carousel, because resuming is a glanceable jump-back-in, not something you scan in order. Five facts in a `[auto_1fr_auto]` grid, left to right:
+
+1. **Numeral marker** — Fraunces 300 at 28px, kind prefix plus zero-padded ordinal (`C01`), tinted with the row's accent (domain or kind color).
+2. **Title** — Fraunces 500 at 19px, hovering to Plate Red, with a hover preview card; up to three subject chips beneath.
+3. **Domain label** — dot plus name in mono, hidden below `sm` and on single-domain pages.
+4. **Date · reading** — `formatDateShort · {readingTime}′`, mono, tabular figures, right-aligned. One format across every index. The shelf is the exception and has to be: `ShelfArticleRow` is never handed a publication date, because what matters there is *when you touched it* — it renders a relative `lastReadAt` on History and `saved {relative}` on Saved, still followed by reading time.
+5. **Save button** — the one save affordance in the system, icon-only at 28px round.
+
+Rows separate on 1px `--border`; the first row in a list takes a 2px rule in the list accent instead. Comfortable (14px) and compact (10px) densities only.
+
+### Plate Header (signature)
+
+Every page's identity block, in two variants.
+
+- **Full** — a 3px double rule in `--foreground` under a mono eyebrow pair (`Howardism · Vol. 03` left, `Plate II · No. 02` right), then the display `h1` with an optional italic Plate Red accent word, then an optional mono data grid.
+- **Compact** — a 3px `double` top rule in the page's accent color over a 1px `double` bottom rule in `--border`, the eyebrow left side switching to `Plate II · {domain}` in that accent, and a 27px headline. Used by the article reader only; every other plate, the shelf included, takes the full variant, which is the shell's default. (`DiscPageHeader` also carries an accent-less compact branch with a dashed bottom rule, but nothing reaches it — the reader always passes an accent, falling back to `--brand`. Treat the double rule as the compact spec.)
+
+Both carry the `hw-grain` overlay, which adds grain to the header surface without re-stacking the body grain.
+
+### Domain Dot & Label
+
+A `size`-configurable round dot in the domain's hue, followed by the domain's display label. The system's smallest and most-repeated identity element — it appears in index rows, header eyebrows, filter bars, and the search palette, and it is the primary sanctioned use of a domain hue.
+
+## Do's and Don'ts
+
+### Do:
+
+- **Do** give every new page a plate number in `plate-meta.ts` and render it through `PlatePage`. A surface without a plate number is not part of the book.
+- **Do** use `max-w-read` / `max-w-index` / `max-w-wide` and `px-gutter`. Nothing else sets a page width or a horizontal page padding.
+- **Do** reach for a 1px `--border` rule before a shadow, a gap, or a filled panel.
+- **Do** set mono uppercase, tracked 0.12–0.22em, at 9.5–11px, for every label, eyebrow, and metadata string.
+- **Do** derive an article's accent from its domain and thread it through the whole view via `--article-accent`.
+- **Do** render every article list through `IndexRow` — or `ShelfArticleRow` on the shelf, where rows carry progress and selection — with one date format (`formatDateShort · {readingTime}′`). The shelf differs twice, both deliberate: it shows a relative read/saved time instead of a publication date, and its trailing control varies by list — `SaveButton` on every index and on Saved, `RemoveButton` on History, where the useful action is dismissing a row you've already read.
+- **Do** keep content structure square and chrome rounded (10px controls, 18px cards, full-round pills).
+- **Do** define new colors in OKLCH in `packages/ui/src/styles/globals.css` with a light and a dark value, and clamp accents to L ≤ 0.56 light / L ≈ 0.75 dark so they hold AA on `--card`.
+
+### Don't:
+
+- **Don't** fill anything with Plate Red. It is text, a mark, or a rule — plus washes at ≤10% (`brand/10`, `brand/5`). Never a button, badge, or panel background — the shelf's compare toggle is the one standing exception, not a precedent.
+- **Don't** let a domain hue become a surface. Dot, numeral, rule of ≤3px (3px only on the compact header), or text only — and one hue per view outside the masthead and cross-domain indexes.
+- **Don't** add a shadow to anything inside the content column. Shadows belong to `fixed`/`sticky` chrome, cards, and popovers.
+- **Don't** introduce a fourth content width: no raw page-container width (`max-w-[720px]`, `max-w-[1120px]`, `max-w-[1280px]`, `max-w-[1320px]`) anywhere, and no raw `px-4` / `px-8` gutter on a route entry. `src/__tests__/howardism/page-frame.test.ts` fails CI on both. A `max-w-[680px]` or `max-w-[60ch]` capping a *paragraph's* measure is not a page frame and is fine.
+- **Don't** set Fraunces at default tracking, or use Newsreader for labels, or JetBrains Mono for anything read in sequence.
+- **Don't** author drop-caps per article. They are an Essay-only rule derived from article kind.
+- **Don't** add a third way to render an article in a list. Extend `IndexRow`'s props, or `ShelfArticleRow`'s if the surface is the shelf. (`ResumeCard` is not a third row — it is the shelf's card carousel, and it stays that way.)
+- **Don't** reach for the four rejected worlds: neon-on-black SaaS chrome with gradient-mesh heroes and glassmorphism; a giant centered hero with a stock photo and a floating clap bar; a uniform rounded card grid with thumbnails; or sidebar-tree, breadcrumb, emoji-icon wiki-tool chrome.
+- **Don't** flatten the background to a solid color. The grain and the top accent bleed are the material.

--- a/apps/blog/PRODUCT.md
+++ b/apps/blog/PRODUCT.md
@@ -1,0 +1,154 @@
+# Product
+
+<!-- impeccable:product-schema 1 -->
+
+## Platform
+
+web
+
+## Users
+
+The primary user is Howard himself, reading and navigating his own corpus in
+public. The site is a second brain kept public so it stays honest and linkable;
+retrieval tools (`/shelf`, `/questions`, `/compare`, backlink graph, search) are
+built for the author's own use over time, not for a visiting audience's first
+session.
+
+Outside readers — peers in AI/engineering arriving from search or a shared link
+— are real but secondary. They land on a single article and may follow domain or
+backlink paths outward. Design serves the author's retrieval first; single-entry
+readability is the constraint that keeps that honest.
+
+## Product Purpose
+
+Publish a connected knowledge base about interaction-era AI. Every article is
+generated from a real Obsidian wiki vault by `apps/cli`'s importer, carrying that
+vault's structure with it: MOC-derived domains, a backlink/related graph, a
+per-article external source audit trail, and an open-questions backlog.
+
+Success is that the published corpus stays a faithful, navigable projection of
+the vault — nothing invented at the blog layer, nothing lost in transit.
+
+## Positioning
+
+The corpus is vault-derived and whole. A neighboring AI blog can copy the topics
+but cannot truthfully copy the artifacts: real backlinks between 275 notes, a
+source ledger per article, domains resolved from Map-of-Content membership rather
+than assigned by hand, and a live worklist of unanswered questions harvested from
+every concept. It publishes a knowledge base, not a stream of posts.
+
+## Operating Context
+
+- Content originates in an Obsidian vault (`WIKI_PATH`), never authored in the
+  blog repo. A full `bun run --cwd apps/cli import:wiki` emits MDX plus four
+  committed manifests — `article-graph.json`, `wiki-sources.json`,
+  `open-questions.json`, and `search-index.json`, which it rebuilds at the end
+  of every run that isn't scoped to one slug via `--only`. `build:search-index`
+  regenerates that index on its own when articles change without a re-import;
+  `translate` maintains the fifth, `translations.json`. The blog reads four of
+  them at build time. `search-index.json` is the exception: it is bundled at
+  build but *fetched in the browser* — a ~488KB chunk dynamically imported the
+  first time the search palette opens, then cached for the session. So search
+  carries a real lazy payload cost, and changing the index still needs a
+  redeploy.
+- `bun run --cwd apps/cli content:check` gates content integrity in CI: missing
+  hero images, broken slug references, missing `title`/`description`/`imageAlt`.
+- Every content command in this document lives in `apps/cli/package.json`, not
+  the root — run it with `--cwd apps/cli` or from inside that workspace.
+- Routes: home, `/articles`, `/articles/[slug]`, `/articles/domain/[domain]`,
+  `/articles/tag/[tag]`, `/articles/tagged/[tag]`, `/compare`, `/shelf`,
+  `/questions`, RSS (`/rss/feed.xml`, `/rss/feed.json`), `/llms.txt`,
+  `/robots.txt`, `/sitemap.xml`, and a `zh-TW` locale
+  mirror at `/[locale]/articles` and `/[locale]/articles/[slug]`.
+  `/photos`, `/about`, and `/thank-you` were removed and permanently redirect to `/`.
+
+## Capabilities and Constraints
+
+- Next.js 16 App Router, React 19, Tailwind v4, static-first. **No auth, no
+  database, no API routes.** Any feature that needs per-user server state is out
+  of scope by construction.
+- Rendering is three-tier, by design, and the article bodies are *not* in the
+  prerendered tier:
+  - **Prerendered at build:** home, `/articles`, the domain/tag/tagged indexes,
+    `/questions`, `/shelf`. The enumerable-param ones pin it with
+    `dynamic = "error"` and `dynamicParams = false`.
+  - **On demand, then cached until the next deploy** (`revalidate = false`):
+    every article reader — `/articles/[slug]` and `/zh-TW/articles/[slug]`, both
+    of which add `dynamicParams = true` and a `generateStaticParams` returning
+    `[]` — plus `/zh-TW/articles`, which inherits on-demand rendering from its
+    dynamic `[locale]` parent. This deliberately skips the build-time prerender
+    of all 275 articles to keep builds fast; the first request per article pays
+    the render, later ones hit cache. It buys build time, *not* content
+    freshness — see below.
+  - **Per request:** `/compare` only, because it reads `searchParams`. It is
+    `noindex` — a tool view, not content.
+- New or changed content always needs a rebuild and redeploy. MDX is imported
+  through a build-time webpack require-context and `translations.json` is a
+  static import, so a translation or article added after the current build is
+  not in the deployed bundle and 404s until the next one. `dynamicParams` defers
+  *rendering* to first request; it does not defer bundling.
+- `/shelf` reading history and the tweaks panel are browser-local
+  (`localStorage`) — they do not survive a device change and there is no account
+  to sync them to.
+- Three orthogonal content axes, all set by the importer and not editable at the
+  blog layer: `tag` (article kind — Concept/Entity/Essay/Index) and `domain`
+  (one of 15 curated knowledge domains, 14 from vault MOCs plus a `syntheses`
+  catch-all) are both *derived* — the kind from the note's folder and shape (with
+  a curated per-slug override list in the CLI), the domain from its MOC
+  membership. Free-form `tags` (subject labels) are not: they are authored
+  in the vault note's own frontmatter and only normalized on the way through, so
+  tooling must preserve them rather than infer them.
+- 275 English articles, 274 with a zh-TW translation. Translation freshness is
+  tracked per slug and reported by `bun run --cwd apps/cli translate:check`.
+- Adding a domain is a three-file change that must agree: the contract package,
+  the blog's domain-meta, and the domain CSS.
+
+## Brand Commitments
+
+- Name: **Howardism**. Domain `howardism.dev`. Author Howard Tai
+  (`howard@howardism.dev`, `@howard86_`).
+- Identity is *both* the person and the notes: a Taiwan-based software engineer
+  and mathematician, whose site now holds a working AI knowledge base. Neither
+  half replaces the other — the shipped `SITE_DESCRIPTION` ("sharing personal
+  thoughts and journeys") under-describes the corpus and the home-page framing
+  ("Working notes on interaction-era AI, kept publicly") under-describes the
+  person. Both are in scope; the site must not read as a pure AI-topic
+  publication that erases its author.
+- Existing visual language is incumbent authority and is deliberately not
+  re-decided here: the plate motif, oklch token set in `@howardism/ui`, and
+  Fraunces / Newsreader / JetBrains Mono. A structural refactor brief against
+  that language is open, but it is an external working document and is not
+  committed to this repo — do not expect to find it here.
+
+## Evidence on Hand
+
+- 275 MDX articles under `src/content/articles/`, 274 under
+  `src/content/articles-zh-TW/`, hero PNGs under `src/content/assets/`.
+- `src/data/wiki-sources.json` — real external sources per article, with URLs.
+- `src/data/article-graph.json` — real backlink/related edges.
+- `src/data/open-questions.json` — the vault's actual open-questions backlog.
+- A 16 Jul 2026 PageSpeed Insights run of the production home page, desktop
+  emulation: FCP 0.3s, LCP 1.4s, CLS 0, TBT 300ms, Speed Index 1.1s. The report
+  itself was not kept; re-run it rather than trusting these numbers indefinitely.
+- **No** testimonials, customers, benchmarks, pricing, or usage metrics exist.
+  Future work must not fabricate any.
+
+## Product Principles
+
+1. **The vault is the source of truth.** The blog renders and navigates; it never
+   originates or edits content. Anything the blog shows must be traceable to an
+   importer manifest.
+2. **Connection over chronology.** Domain, backlink, and source relationships are
+   the primary way through the corpus; date is a secondary fact.
+3. **Publish the unknowns.** Open questions and source ledgers are first-class
+   content, not appendices.
+4. **Static by construction.** No auth, no database, no server state — features
+   are designed within that, not around it.
+5. **The author is a user.** Retrieval affordances for repeat visits earn their
+   place even when they help no first-time reader.
+
+## Accessibility & Inclusion
+
+No product-specific standard has been established beyond the repo's general
+Ultracite/Biome a11y lint rules. Bilingual EN / zh-TW parity is a maintained
+product commitment.


### PR DESCRIPTION
Establishes the two reference documents future design work reads from. **Docs only — no source, config, or content files change, and nothing visual changes.**

## Why

The blog has a coherent, deliberate visual system (plate motif, OKLCH token set, three-serif pairing, fifteen domain hues) that lived only in the CSS and components. Every design task re-derived it by reading `globals.css`, and every judgment call about *how far* a change may go had to be re-litigated. There was also no record of the product constraints that make the design correct — the no-auth/no-DB architecture, the vault-derived corpus, the fact that the author is the primary user.

There is an open structural refactor brief in `design_handoff_blog_unification/` that touches all six page templates. Capturing the current state first makes that refactor checkable against something.

## What's here

**`apps/blog/PRODUCT.md`** — durable, non-visual product truth. Primary user is the author reading his own corpus in public; positioning is the vault-derived whole corpus; identity is both the person and the notes. Records the structural constraints (no auth/DB/API routes, localStorage-only shelf and tweaks, three importer-assigned content axes) and states explicitly which evidence exists and which does not, so downstream work cannot fabricate testimonials or metrics.

**`apps/blog/DESIGN.md`** — the incumbent visual system, extracted. Frontmatter carries 27 OKLCH colors, 7 type roles, the radius and spacing scales, and 13 component token entries; the body follows the eight canonical DESIGN.md sections under the "Plate Book" north star, treating the `plate-meta.ts` numbering as literal information architecture.

**`apps/blog/.impeccable/design.json`** — sidecar for what the frontmatter schema cannot hold: 8-step tonal ramps and dark-mode values per color, shadow/motion/breakpoint/container/surface tokens, and 10 self-contained component snippets including the three signatures (plate header, index row, half disc).

## Named rules worth a look

These are the parts most likely to constrain future PRs, so they are the parts worth disagreeing with now:

- **The Second Pass Rule** — the terracotta is text, a mark, or a rule; never a fill. The shipped `brand/10` active-nav and `brand/5` blockquote washes are documented as the sanctioned ≤10% exception rather than papered over.
- **One Hue Per View** + **Marker-Never-Surface** — together, what keeps fifteen saturated domain hues from reading as a rainbow.
- **The Three Stops Rule** — `read` / `index` / `wide` are the only content widths. This matches the lint guard the unification brief proposes in its Phase 5 but which has not shipped.
- **The Hairline Rule** / **Flat Content Rule** — depth is rules and tonal steps; shadows belong to `fixed` / `sticky` chrome, cards, and popovers only.

Four anti-references are named explicitly (SaaS dark, Medium-style blog, card-grid feed, wiki-tool chrome) so the Don'ts are enforceable rather than tasteful.

`--brand-2` (one usage) and `--brand-soft` (zero usages) are recorded as near-unused rather than promoted into a palette they have not earned.

## Verification

No build, test, or type-check gates were run — this PR adds two Markdown files and one JSON file and touches no code. What was checked: the sidecar parses as valid JSON with all 27 color entries and 10 components after the pre-commit `ultracite fix` pass, DESIGN.md's YAML frontmatter is intact, and every token value in both files was read from `packages/ui/src/styles/globals.css` or the component source rather than inferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L73PDGhPbXGtyCMbWpHVf5
