### PR TITLE
📝 chore: git-history shrink runbook + script (641MB → 48MB, measured)

### DIFF
--- a/scripts/shrink-git-history.md
+++ b/scripts/shrink-git-history.md
@@ -1,0 +1,94 @@
+# Shrinking the repository history
+
+`.git` is ~640MB. 91% of that is hero-image PNGs that no longer exist in the
+tree — the WebP migration replaced them, but every historical revision is still
+carried in the pack forever.
+
+Stripping those blobs from history takes the repo **641MB → 48MB (13.4x)**,
+measured on a real dry run, with all 1889 commits, 35 branches and 198 tags
+preserved and `main`'s tree byte-identical.
+
+This is a one-time operation. Delete this file and the script once it is done.
+
+## Before you decide
+
+A history rewrite changes **every commit SHA in the repository**. It invalidates
+every clone, every open pull request, and every link to a commit. If the goal is
+only "make cloning cheap", the cheaper option needs no rewrite at all:
+
+```bash
+git clone --filter=blob:none git@github.com:howard86/howardism.git
+```
+
+That fetches blobs on demand and gives a small working clone today, with zero
+coordination cost. Rewrite only if you want the history genuinely gone — e.g. to
+shrink the repository GitHub actually stores.
+
+## What gets removed
+
+Only large raster files. **No source code, and no file currently in the tree.**
+
+| bytes in history | path |
+|---|---|
+| 565.2MB | `apps/blog/src/content/assets/*.png` — hero art, superseded by WebP |
+| 11.5MB | `apps/blog/src/app/(blog)/articles/[slug]/(docs)/(assets)` — dead route |
+| 12.1MB | four unreferenced stock photos + `public/cover.jpg` |
+| 2.9MB | `apps/recipe/public/assets/*` — assets of a removed workspace |
+
+Explicitly **kept**: every favicon, `android-chrome-*`, `apple-touch-icon`,
+`mstile-150x150`, `profile.jpeg`, `assets/texture.png` and the five
+`assets/icons/*.jpg`. All are live; all are small. An early draft used
+`--path-glob 'apps/blog/public/assets/*.jpg'` and the `*` matched across the
+`/`, which would have silently deleted those five icons — the script now lists
+each file explicitly.
+
+## Preconditions
+
+1. **The WebP migration (PR #900) must be merged first.** Until it is, `main`'s
+   heroes are still PNGs, so the rewrite would strip them out of the live tree
+   and every article would lose its image. The script enforces this: it compares
+   `main`'s tree hash before and after and aborts, naming every file at risk, if
+   they differ.
+2. **Merge or close every other open PR.** There were 13 at the time of writing.
+   Their branches are rewritten too, but a PR's merge-base is not, so GitHub will
+   show them as wildly conflicted. The Renovate ones are disposable — close them
+   and let the bot reopen against the new history.
+3. Install the tool: `brew install git-filter-repo`.
+
+## Running it
+
+```bash
+./scripts/shrink-git-history.sh /tmp/howardism-rewrite
+```
+
+It mirror-clones from GitHub, rewrites, repacks, verifies `main` is unchanged,
+and prints the resulting size. **It does not push.** Expected output ends with
+`main tree unchanged: <hash>` and a non-zero exit if anything is off.
+
+Then publish, deliberately:
+
+```bash
+# 1. Lift branch protection on main (Settings → Branches) — force-push is blocked otherwise.
+# 2. Push every ref, including the 198 rewritten tags:
+git -C /tmp/howardism-rewrite/howardism.git push --force --mirror git@github.com:howard86/howardism.git
+# 3. Re-enable branch protection.
+```
+
+## Afterwards
+
+- **Re-clone.** Every existing clone and `git worktree` is now based on dead
+  SHAs; do not try to rebase them. Delete and clone fresh.
+- **Forks.** Two exist. They keep the old history and are unaffected — but a PR
+  from a stale fork will be unmergeable until it re-forks.
+- **Releases.** GitHub Releases attach to tag *names*, which survive; the commit
+  each points at gets a new SHA.
+- **Vercel** redeploys from the new `main`. Previous deployments reference SHAs
+  that no longer exist, which is harmless.
+- **GitHub's stored size may lag.** New clones are small immediately, but
+  unreachable objects can linger server-side; ask GitHub Support to run `gc` if
+  the repository size on their end matters.
+- Sanity-check a fresh clone:
+  ```bash
+  git clone git@github.com:howard86/howardism.git && cd howardism
+  du -sh .git && bun install && bun run build && cd apps/cli && bun run content:check
+  ```

--- a/scripts/shrink-git-history.sh
+++ b/scripts/shrink-git-history.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+#
+# One-time history rewrite: drop the large raster blobs the repo no longer uses.
+# Measured 641MB -> 48MB (13.4x) across 1886 commits, 34 branches, 198 tags.
+#
+# Read scripts/shrink-git-history.md BEFORE running this. It rewrites every
+# commit SHA in the repository, which breaks every existing clone, every open
+# pull request, and every fork. This script deliberately stops before the push —
+# it prepares a rewritten mirror and prints the command that would publish it.
+#
+#   ./scripts/shrink-git-history.sh /tmp/howardism-rewrite
+#
+set -euo pipefail
+
+WORKDIR="${1:-}"
+if [[ -z "$WORKDIR" ]]; then
+  echo "usage: $0 <empty-working-directory>" >&2
+  exit 64
+fi
+if [[ -e "$WORKDIR" ]]; then
+  echo "error: $WORKDIR already exists — point at a fresh path" >&2
+  exit 64
+fi
+
+if ! command -v git-filter-repo >/dev/null 2>&1; then
+  cat >&2 <<'MSG'
+error: git-filter-repo not found.
+  brew install git-filter-repo   (or: pipx install git-filter-repo)
+MSG
+  exit 69
+fi
+
+REMOTE="${REMOTE:-git@github.com:howard86/howardism.git}"
+MIRROR="$WORKDIR/howardism.git"
+
+# Paths stripped from every commit. All of these are either already deleted from
+# the tree or belong to an app that no longer exists, so the rewritten HEAD is
+# byte-identical to today's — verify that with the check at the end.
+#
+# Deliberately NOT stripped: apps/blog/public/{favicon*,android-chrome*,
+# apple-touch-icon,mstile}*, profile.jpeg, assets/texture.png and
+# assets/icons/*.jpg. They are live, and small. An earlier draft used
+# `--path-glob 'apps/blog/public/assets/*.jpg'`, which matched across the `/`
+# and would have deleted the five live icons — hence the explicit list.
+FILTER_ARGS=(
+  --invert-paths
+  # 565MB — the hero illustrations, replaced by WebP twins (see PR #900).
+  --path-glob 'apps/blog/src/content/assets/*.png'
+  # 11.5MB — hero assets under an article route that no longer exists.
+  --path 'apps/blog/src/app/(blog)/articles/[slug]/(docs)/(assets)'
+  # 12.1MB — unreferenced stock photography, deleted from the tree in PR #900.
+  --path 'apps/blog/public/assets/alexandre-debieve-chip.jpg'
+  --path 'apps/blog/public/assets/thisisengineering-raeng-desk.jpg'
+  --path 'apps/blog/public/assets/carl-heyerdahl-desk.jpg'
+  --path 'apps/blog/public/assets/john-morgan-sudoku.jpg'
+  --path 'apps/blog/public/cover.jpg'
+  # 2.9MB — assets of the removed `apps/recipe` workspace.
+  --path 'apps/recipe/public/assets/demo.jpg'
+  --path 'apps/recipe/public/assets/background.jpg'
+)
+
+mkdir -p "$WORKDIR"
+echo "==> mirror-cloning $REMOTE"
+# A local REMOTE (handy for rehearsing against a checkout) would otherwise be
+# hardlinked into the mirror, which filter-repo rejects as "not a fresh clone".
+CLONE_OPTS=()
+[[ -d "$REMOTE" ]] && CLONE_OPTS+=(--no-local)
+git clone --mirror "${CLONE_OPTS[@]}" "$REMOTE" "$MIRROR"
+before=$(du -sh "$MIRROR" | cut -f1)
+tree_before=$(git -C "$MIRROR" rev-parse main^{tree})
+# filter-repo prunes the pre-rewrite objects, so snapshot the file list now —
+# it is what makes the failure message below able to name the lost files.
+git -C "$MIRROR" ls-tree -r --name-only main | sort >"$WORKDIR/main-files-before.txt"
+
+echo "==> rewriting history"
+git -C "$MIRROR" filter-repo "${FILTER_ARGS[@]}"
+
+echo "==> repacking"
+git -C "$MIRROR" reflog expire --expire=now --all
+git -C "$MIRROR" gc --prune=now --quiet
+after=$(du -sh "$MIRROR" | cut -f1)
+
+echo
+echo "size:     $before -> $after"
+echo "branches: $(git -C "$MIRROR" for-each-ref --format='%(refname)' refs/heads | wc -l | tr -d ' ')"
+echo "tags:     $(git -C "$MIRROR" tag | wc -l | tr -d ' ')"
+echo "commits:  $(git -C "$MIRROR" rev-list --count main) on main"
+echo "==> verifying main's working tree is byte-identical"
+# The entire safety argument in one assertion: commit SHAs are expected to
+# change, but the *content* of main must not. A mismatch means main still
+# references one of the stripped paths — which is true until the WebP migration
+# (PR #900) is merged, since main's heroes are still PNGs at that point.
+tree_after=$(git -C "$MIRROR" rev-parse main^{tree})
+if [[ "$tree_before" != "$tree_after" ]]; then
+  echo >&2
+  echo "ABORT: the rewrite changed main's content." >&2
+  echo "  before: $tree_before" >&2
+  echo "  after:  $tree_after" >&2
+  echo "Files that would be lost from main:" >&2
+  git -C "$MIRROR" ls-tree -r --name-only main | sort \
+    | comm -23 "$WORKDIR/main-files-before.txt" - | sed 's/^/  /' >&2
+  echo >&2
+  echo "Merge the WebP migration (PR #900) before rewriting, then re-run." >&2
+  exit 1
+fi
+echo "main tree unchanged: $tree_after"
+echo
+cat <<MSG
+Nothing has been pushed. Publishing is a separate, deliberate step:
+
+  git -C "$MIRROR" push --force --mirror "$REMOTE"
+
+Do not run that until scripts/shrink-git-history.md's checklist is done —
+in particular, every open PR must be merged or closed first.
+MSG


### PR DESCRIPTION
Follow-up to #900. `.git` is ~640MB; **91% of the blob bytes are hero PNGs**
that no longer exist in the tree — the WebP migration replaced them, but every
historical revision still carries them forever.

## Read this first: a rewrite cannot be delivered by merging a PR

Rewriting history changes **every commit SHA in the repository**. It is
published by force-pushing all refs, not by merging a branch. So this PR adds
the *tooling and the runbook*; the rewrite itself stays a deliberate manual step
you trigger. I have not rewritten or pushed anything.

If the goal is only cheap clones, there is an option needing no rewrite at all,
covered in the doc:

```bash
git clone --filter=blob:none git@github.com:howard86/howardism.git
```

## Measured, not estimated

I ran the real thing against a mirror clone in a scratch directory:

| | before | after |
|---|---|---|
| repository | 641MB | **48MB** (13.4×) |
| all blobs in history | 632.6MB | 45.3MB |
| commits on `main` | 1889 | 1889 |
| branches / tags | 35 / 198 | 35 / 198 |
| `main` tree hash | — | **byte-identical** |

Blob composition that motivated the path list:

| bytes in history | path |
|---|---|
| 565.2MB | `apps/blog/src/content/assets/*.png` |
| 11.5MB | `apps/blog/src/app/(blog)/articles/[slug]/(docs)/(assets)` (dead route) |
| 12.1MB | four unreferenced stock photos + `public/cover.jpg` |
| 2.9MB | `apps/recipe/public/assets/*` (removed workspace) |

No source file is touched, and nothing currently in the tree is removed.

## What the dry run caught

Two things that would have been silent damage if I had estimated instead of run it:

1. **`--path-glob 'apps/blog/public/assets/*.jpg'` matched across the `/`** and
   deleted the five live `assets/icons/*.jpg`. The script now lists those five
   files explicitly as kept, alongside every favicon, `texture.png` and
   `profile.jpeg` — verified present in the rewritten tree.
2. **The rewrite must not run before #900 merges.** `main`'s heroes are still
   PNGs today, so stripping PNGs would empty `content/assets/` on `main` and
   every article would lose its image. This is now an enforced precondition, not
   a note: the script diffs `main`'s tree hash before and after and aborts,
   naming every file at risk.

Both paths are exercised — the guard aborts correctly against today's `main`,
and against a simulated post-#900 `main` it exits 0 with the tree hash matching.

## What's in the PR

- `scripts/shrink-git-history.sh` — mirror-clone, rewrite, repack, assert
  `main` is unchanged, report. **It does not push**; it prints the publish
  command for a human.
- `scripts/shrink-git-history.md` — the decision context, the exact keep/remove
  list, preconditions (merge #900; clear the other 12 open PRs), the force-push
  steps, and the aftermath: re-clone, the 2 forks, the 198 tags, Releases,
  Vercel, and the fact that GitHub's stored size can lag even after a clean
  force-push.

Both are one-time artifacts — the doc says to delete them once the rewrite is done.

## Verified this session

- `bash -n` clean; usage and existing-directory guards behave
- Full end-to-end run against a staged mirror, both the abort path and the
  success path, with the numbers in the table above
- Live rasters confirmed present, and 0 `.png` remaining under
  `content/assets/`, in the rewritten repo

Not done: nothing was pushed to any real ref, and no rewrite of the actual
repository was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQUvbJ4FwFDzAcUj65XHkF
