### PR TITLE
✨ feat(wiki-import): carry question triage and resolved answers to the blog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,5 @@ apps/blog/public/rss
 
 # antigravity (gemini) ide local cache
 .antigravitycli/
+# impeccable design-hook cache
+.impeccable/

--- a/apps/blog/src/__tests__/articles/backlinks-disclosure.test.tsx
+++ b/apps/blog/src/__tests__/articles/backlinks-disclosure.test.tsx
@@ -131,3 +131,48 @@ describe("BacklinksDisclosureView — list rendering", () => {
     expect(text.length).toBeLessThan(longDescription.length);
   });
 });
+
+describe("BacklinksDisclosureView — citation context", () => {
+  it("quotes the citing line instead of the target's description", () => {
+    render(
+      <BacklinksDisclosureView
+        backlinks={[
+          {
+            ...makeLink("anthropic"),
+            citedIn: "Claude Code ships from the same incubator.",
+            citedCount: 1,
+          },
+        ]}
+        related={[]}
+      />
+    );
+    expect(
+      screen.getByText("Claude Code ships from the same incubator.")
+    ).toBeDefined();
+    expect(screen.queryByText("Description for anthropic.")).toBeNull();
+  });
+
+  it("falls back to the description when the citation has no prose context", () => {
+    render(
+      <BacklinksDisclosureView
+        backlinks={[{ ...makeLink("anthropic"), citedCount: 1 }]}
+        related={[]}
+      />
+    );
+    expect(screen.getByText("Description for anthropic.")).toBeDefined();
+  });
+
+  it("shows a repeat-count badge only for articles that cite more than once", () => {
+    render(
+      <BacklinksDisclosureView
+        backlinks={[
+          { ...makeLink("anthropic"), citedCount: 4 },
+          { ...makeLink("cowork"), citedCount: 1 },
+        ]}
+        related={[]}
+      />
+    );
+    expect(screen.getByText("×4")).toBeDefined();
+    expect(screen.queryByText("×1")).toBeNull();
+  });
+});

--- a/apps/blog/src/__tests__/articles/questions-worklist.test.tsx
+++ b/apps/blog/src/__tests__/articles/questions-worklist.test.tsx
@@ -94,6 +94,55 @@ describe("QuestionsWorklist", () => {
     expect(lines()).toContain("Does the loop terminate");
   });
 
+  it("renders the vault's inline markup as elements, not as characters", () => {
+    const marked: OpenQuestionConcept[] = [
+      {
+        domain: "agent-systems",
+        slug: "agent-loop-pattern",
+        title: "Agent Loop Pattern",
+        questions: [
+          {
+            kind: null,
+            text: "Do gains hold when **normalized for size**, or is `churn` the *real* signal? See [the paper](/articles/eval-drift).",
+          },
+        ],
+        resolved: [],
+      },
+    ];
+    render(<QuestionsWorklist concepts={marked} />);
+
+    expect(document.querySelector("li li strong")?.textContent).toBe(
+      "normalized for size"
+    );
+    expect(document.querySelector("li li em")?.textContent).toBe("real");
+    expect(document.querySelector("li li code")?.textContent).toBe("churn");
+    const link = document.querySelector<HTMLAnchorElement>(
+      'li li a[href="/articles/eval-drift"]'
+    );
+    expect(link?.textContent).toBe("the paper");
+    // The markers themselves must not survive into the rendered prose.
+    expect(lines()).not.toContain("**");
+    expect(lines()).not.toContain("`");
+  });
+
+  it("searches the prose, not the markup around it", () => {
+    const marked: OpenQuestionConcept[] = [
+      {
+        domain: "agent-systems",
+        slug: "agent-loop-pattern",
+        title: "Agent Loop Pattern",
+        questions: [{ kind: null, text: "Does **normalization** hold?" }],
+        resolved: [],
+      },
+    ];
+    render(<QuestionsWorklist concepts={marked} />);
+    fireEvent.change(searchBox(), { target: { value: "normalization" } });
+    expect(lines()).toContain("Does normalization hold?");
+    expect(document.querySelector("strong mark")?.textContent).toBe(
+      "normalization"
+    );
+  });
+
   it("keeps working when the manifest carries no triage tags", () => {
     const untagged: OpenQuestionConcept[] = [
       {

--- a/apps/blog/src/__tests__/articles/questions-worklist.test.tsx
+++ b/apps/blog/src/__tests__/articles/questions-worklist.test.tsx
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { OpenQuestionConcept } from "@/app/(blog)/articles/service";
+import { QuestionsWorklist } from "@/app/(blog)/questions/questions-worklist";
+
+const concepts: OpenQuestionConcept[] = [
+  {
+    domain: "agent-systems",
+    slug: "agent-loop-pattern",
+    title: "Agent Loop Pattern",
+    questions: [
+      {
+        kind: "now",
+        text: "Does the loop terminate on a partial tool result?",
+      },
+      { kind: "source", text: "Who first published the harness benchmark?" },
+    ],
+    resolved: ["Retries are capped at three."],
+  },
+  {
+    domain: "evals-and-benchmarks",
+    slug: "eval-drift",
+    title: "Eval Drift",
+    questions: [{ kind: "wait", text: "Will the benchmark be rerun in 2027?" }],
+    resolved: [],
+  },
+];
+
+const FOUR_LINES = /4 lines/;
+const TWO_OF_FOUR = /2 of 4/;
+const NO_MATCH = /Nothing in the backlog matches/;
+const CLEAR = /Clear filters/;
+
+const searchBox = () => screen.getByLabelText("Search open questions");
+
+/**
+ * Line text, read off the rendered rows. Search wraps every match in a `mark`,
+ * so a question's text is split across elements and only reads back whole here.
+ */
+const lines = (): string =>
+  [...document.querySelectorAll("li li")]
+    .map((node) => node.textContent ?? "")
+    .join("\n");
+
+afterEach(cleanup);
+
+describe("QuestionsWorklist", () => {
+  it("renders every line and tallies each triage bucket", () => {
+    render(<QuestionsWorklist concepts={concepts} />);
+    expect(lines()).toContain("Does the loop terminate");
+    expect(lines()).toContain("Will the benchmark be rerun");
+    expect(lines()).toContain("Retries are capped at three.");
+    // Four lines across two concepts.
+    expect(screen.getByText(FOUR_LINES)).toBeDefined();
+    expect(screen.getByText("Answerable now")).toBeDefined();
+    expect(screen.getByLabelText("Filter by triage")).toBeDefined();
+  });
+
+  it("narrows to the lines matching every search token", () => {
+    render(<QuestionsWorklist concepts={concepts} />);
+    fireEvent.change(searchBox(), { target: { value: "benchmark" } });
+    expect(lines()).toContain("Who first published");
+    expect(lines()).toContain("Will the benchmark be rerun");
+    expect(lines()).not.toContain("Does the loop terminate");
+    expect(screen.getByText(TWO_OF_FOUR)).toBeDefined();
+    expect(document.querySelectorAll("mark").length).toBe(2);
+  });
+
+  it("matches a line through its concept title", () => {
+    render(<QuestionsWorklist concepts={concepts} />);
+    fireEvent.change(searchBox(), { target: { value: "eval drift" } });
+    expect(lines()).toContain("Will the benchmark be rerun");
+    expect(lines()).not.toContain("Who first published");
+  });
+
+  it("filters to one triage bucket and back", () => {
+    render(<QuestionsWorklist concepts={concepts} />);
+    const now = screen.getByText("Answerable now");
+    fireEvent.click(now);
+    expect(lines()).toContain("Does the loop terminate");
+    expect(lines()).not.toContain("Who first published");
+    expect(lines()).not.toContain("Retries are capped at three.");
+    fireEvent.click(now);
+    expect(lines()).toContain("Who first published");
+  });
+
+  it("filters by domain and offers a way out of an empty result", () => {
+    render(<QuestionsWorklist concepts={concepts} />);
+    fireEvent.click(screen.getByText("Evals & Benchmarks"));
+    expect(lines()).not.toContain("Does the loop terminate");
+    fireEvent.change(searchBox(), { target: { value: "zzzz" } });
+    expect(screen.getByText(NO_MATCH)).toBeDefined();
+    fireEvent.click(screen.getByText(CLEAR));
+    expect(lines()).toContain("Does the loop terminate");
+  });
+
+  it("keeps working when the manifest carries no triage tags", () => {
+    const untagged: OpenQuestionConcept[] = [
+      {
+        domain: "agent-systems",
+        slug: "agent-loop-pattern",
+        title: "Agent Loop Pattern",
+        questions: [{ kind: null, text: "An untagged bullet." }],
+        resolved: [],
+      },
+    ];
+    render(<QuestionsWorklist concepts={untagged} />);
+    expect(screen.getByText("An untagged bullet.")).toBeDefined();
+    // A single bucket carries no distribution, so the tally band stays hidden.
+    expect(screen.queryByLabelText("Filter by triage")).toBeNull();
+  });
+});

--- a/apps/blog/src/app/(blog)/_shell/plate-page.tsx
+++ b/apps/blog/src/app/(blog)/_shell/plate-page.tsx
@@ -48,6 +48,11 @@ interface PlatePageProps {
  * content width (one of three semantic stops), the responsive page gutter, the
  * page-enter animation, and — unless `header="none"` — the shared
  * `DiscPageHeader`, numbered from the plate taxonomy.
+ *
+ * The shell is a flex item of `main`, so its automatic minimum size is its
+ * min-content width; `min-w-0` is what keeps one wide child (a nowrap filter
+ * row, a long unbreakable token) from stretching the whole page frame past the
+ * viewport instead of scrolling or wrapping inside it.
  */
 export function PlatePage({
   width,
@@ -101,7 +106,10 @@ export function PlatePage({
 
   if (bleed) {
     return (
-      <div className={cn("hw-page-enter mx-auto", widthClass)} style={style}>
+      <div
+        className={cn("hw-page-enter mx-auto w-full min-w-0", widthClass)}
+        style={style}
+      >
         {headerNode && <div className="px-gutter">{headerNode}</div>}
         {children}
       </div>
@@ -110,7 +118,10 @@ export function PlatePage({
 
   return (
     <div
-      className={cn("hw-page-enter mx-auto px-gutter pb-20", widthClass)}
+      className={cn(
+        "hw-page-enter mx-auto w-full min-w-0 px-gutter pb-20",
+        widthClass
+      )}
       style={style}
     >
       {headerNode}

--- a/apps/blog/src/app/(blog)/articles/[slug]/article-link-row.tsx
+++ b/apps/blog/src/app/(blog)/articles/[slug]/article-link-row.tsx
@@ -11,7 +11,7 @@ interface ArticleLinkRowProps {
 }
 
 export function ArticleLinkRow({ link }: ArticleLinkRowProps) {
-  const { slug, meta } = link;
+  const { slug, meta, citedIn, citedCount } = link;
   return (
     <li className="flex flex-col gap-0.5">
       <span className="leading-[1.25]">
@@ -23,10 +23,24 @@ export function ArticleLinkRow({ link }: ArticleLinkRowProps) {
         >
           {meta.title}
         </InternalLink>
+        {citedCount !== undefined && citedCount > 1 && (
+          <span
+            className="ml-1.5 font-mono text-[0.7rem] text-muted-foreground"
+            title={`Links here ${citedCount} times`}
+          >
+            ×{citedCount}
+          </span>
+        )}
       </span>
-      <p className="m-0 font-body text-muted-foreground text-xs leading-[1.45]">
-        {truncate(meta.description, ARTICLE_LINK_DESCRIPTION_MAX)}
-      </p>
+      {citedIn ? (
+        <p className="m-0 border-border border-l-2 pl-2 font-body text-muted-foreground text-xs italic leading-[1.45]">
+          {citedIn}
+        </p>
+      ) : (
+        <p className="m-0 font-body text-muted-foreground text-xs leading-[1.45]">
+          {truncate(meta.description, ARTICLE_LINK_DESCRIPTION_MAX)}
+        </p>
+      )}
     </li>
   );
 }

--- a/apps/blog/src/app/(blog)/articles/open-questions-section.tsx
+++ b/apps/blog/src/app/(blog)/articles/open-questions-section.tsx
@@ -1,6 +1,137 @@
+import type { OpenQuestion } from "@howardism/article-contract/manifests/open-questions";
+import type { ReactNode } from "react";
+
 import { InternalLink } from "@/components/internal-link";
 
 import type { OpenQuestionConcept } from "./service";
+import { bucketOf, TRIAGE_META, type TriageBucket } from "./triage-meta";
+
+/** One ledger line: the question text plus the bucket it was filed under. */
+export interface QuestionLine {
+  bucket: TriageBucket;
+  text: string;
+}
+
+/** Flatten a concept into ledger lines, open questions first, settled last. */
+export const linesOf = (concept: OpenQuestionConcept): QuestionLine[] => [
+  ...concept.questions.map((question: OpenQuestion) => ({
+    bucket: bucketOf(question),
+    text: question.text,
+  })),
+  ...concept.resolved.map((text) => ({
+    bucket: "resolved" as TriageBucket,
+    text,
+  })),
+];
+
+/**
+ * Wrap every match of `pattern` in a `<mark>`. The pattern must carry exactly
+ * one capture group, so `split` returns match and non-match parts alternating.
+ */
+function Highlighted({
+  pattern,
+  text,
+}: {
+  pattern: RegExp | null;
+  text: string;
+}): ReactNode {
+  if (!pattern) {
+    return text;
+  }
+  const parts = text.split(pattern);
+  if (parts.length === 1) {
+    return text;
+  }
+  // Odd indices are the captured matches. Keys are the part's offset in the
+  // source string, which stays unique when the same word matches twice.
+  const nodes: ReactNode[] = [];
+  let offset = 0;
+  for (const [index, part] of parts.entries()) {
+    if (index % 2 === 1) {
+      nodes.push(
+        <mark
+          className="rounded-[3px] bg-brand/15 px-0.5 font-medium text-foreground"
+          key={`${offset}-${part}`}
+        >
+          {part}
+        </mark>
+      );
+    } else {
+      nodes.push(part);
+    }
+    offset += part.length;
+  }
+  return nodes;
+}
+
+interface ConceptStanzaProps {
+  /** Accent for the 2px rule that opens the stanza's line list. */
+  color: string;
+  /** Pre-filtered lines; the stanza renders exactly what it is handed. */
+  lines: QuestionLine[];
+  /** Highlight pattern from the worklist's search field. */
+  pattern?: RegExp | null;
+  slug: string;
+  title: string;
+}
+
+/**
+ * One concept's ledger stanza — the note that raised the questions, then its
+ * lines on hairline rules. Shared by the domain pages and the `/questions`
+ * worklist so a question reads the same way wherever it surfaces.
+ */
+export function ConceptStanza({
+  color,
+  lines,
+  pattern = null,
+  slug,
+  title,
+}: ConceptStanzaProps) {
+  const open = lines.filter((line) => line.bucket !== "resolved").length;
+
+  return (
+    <li>
+      <div className="flex items-baseline justify-between gap-4">
+        <InternalLink
+          className="font-display font-medium text-[18px] text-foreground no-underline transition-colors hover:text-brand"
+          href={`/articles/${slug}#open-questions`}
+        >
+          <Highlighted pattern={pattern} text={title} />
+        </InternalLink>
+        <span className="shrink-0 font-mono text-[10.5px] text-foreground-subtle uppercase tabular-nums tracking-[0.12em]">
+          {open} open
+        </span>
+      </div>
+      <ul
+        className="m-0 mt-2.5 list-none border-t-2 p-0"
+        style={{ borderColor: color }}
+      >
+        {lines.map((line) => {
+          const meta = TRIAGE_META[line.bucket];
+          const settled = line.bucket === "resolved";
+          return (
+            <li
+              className={`border-border border-b py-2.5 font-body text-[15px] leading-[1.55] last:border-b-0 ${
+                settled ? "text-foreground-subtle" : "text-muted-foreground"
+              }`}
+              key={`${line.bucket}-${line.text}`}
+            >
+              {meta.code && (
+                <span
+                  className="mr-2 font-mono text-[10px] uppercase tracking-[0.14em]"
+                  style={{ color: meta.tone }}
+                >
+                  {meta.code}
+                </span>
+              )}
+              <Highlighted pattern={pattern} text={line.text} />
+            </li>
+          );
+        })}
+      </ul>
+    </li>
+  );
+}
 
 interface OpenQuestionsSectionProps {
   /** Accent color token for the rule + concept markers. */
@@ -11,9 +142,9 @@ interface OpenQuestionsSectionProps {
 }
 
 /**
- * Renders a grouped open-questions list: one block per concept (title links to
- * that article's inline `## Open Questions`), with the unanswered questions as
- * a bullet list. Shared by domain pages and the standalone `/questions` backlog.
+ * A grouped open-questions list — one stanza per concept. Used by the domain
+ * pages, where the list is short enough to read straight through; `/questions`
+ * renders the same stanzas behind its own search and triage controls.
  */
 export function OpenQuestionsSection({
   concepts,
@@ -41,37 +172,13 @@ export function OpenQuestionsSection({
       )}
       <ul className="m-0 mt-6 flex list-none flex-col gap-7 p-0">
         {concepts.map((concept) => (
-          <li key={concept.slug}>
-            <InternalLink
-              className="font-display font-medium text-[18px] text-foreground no-underline transition-colors hover:text-brand"
-              href={`/articles/${concept.slug}#open-questions`}
-            >
-              {concept.title}
-            </InternalLink>
-            <ul className="m-0 mt-2 flex list-none flex-col gap-2 p-0">
-              {concept.questions.map((question) => (
-                <li
-                  className="border-l-2 pl-3 font-body text-[15px] text-muted-foreground leading-[1.5]"
-                  key={question.text}
-                  style={{ borderColor: color }}
-                >
-                  {question.text}
-                </li>
-              ))}
-              {concept.resolved.map((answer) => (
-                <li
-                  className="border-l-2 border-dashed pl-3 font-body text-[15px] text-foreground-subtle leading-[1.5]"
-                  key={answer}
-                  style={{ borderColor: color }}
-                >
-                  <span className="mr-2 font-mono text-[11px] uppercase tracking-[0.12em]">
-                    Resolved
-                  </span>
-                  {answer}
-                </li>
-              ))}
-            </ul>
-          </li>
+          <ConceptStanza
+            color={color}
+            key={concept.slug}
+            lines={linesOf(concept)}
+            slug={concept.slug}
+            title={concept.title}
+          />
         ))}
       </ul>
     </section>

--- a/apps/blog/src/app/(blog)/articles/open-questions-section.tsx
+++ b/apps/blog/src/app/(blog)/articles/open-questions-section.tsx
@@ -52,10 +52,22 @@ export function OpenQuestionsSection({
               {concept.questions.map((question) => (
                 <li
                   className="border-l-2 pl-3 font-body text-[15px] text-muted-foreground leading-[1.5]"
-                  key={question}
+                  key={question.text}
                   style={{ borderColor: color }}
                 >
-                  {question}
+                  {question.text}
+                </li>
+              ))}
+              {concept.resolved.map((answer) => (
+                <li
+                  className="border-l-2 border-dashed pl-3 font-body text-[15px] text-foreground-subtle leading-[1.5]"
+                  key={answer}
+                  style={{ borderColor: color }}
+                >
+                  <span className="mr-2 font-mono text-[11px] uppercase tracking-[0.12em]">
+                    Resolved
+                  </span>
+                  {answer}
                 </li>
               ))}
             </ul>

--- a/apps/blog/src/app/(blog)/articles/open-questions-section.tsx
+++ b/apps/blog/src/app/(blog)/articles/open-questions-section.tsx
@@ -1,4 +1,9 @@
 import type { OpenQuestion } from "@howardism/article-contract/manifests/open-questions";
+import {
+  type InlineSegment,
+  parseInline,
+  segmentsToText,
+} from "@howardism/article-contract/markup";
 import type { ReactNode } from "react";
 
 import { InternalLink } from "@/components/internal-link";
@@ -6,22 +11,28 @@ import { InternalLink } from "@/components/internal-link";
 import type { OpenQuestionConcept } from "./service";
 import { bucketOf, TRIAGE_META, type TriageBucket } from "./triage-meta";
 
-/** One ledger line: the question text plus the bucket it was filed under. */
+/**
+ * One ledger line. `segments` is what renders — the vault's inline markup,
+ * already parsed — and `text` is the same line stripped to plain prose, which
+ * is what search matches and what keys the row.
+ */
 export interface QuestionLine {
   bucket: TriageBucket;
+  segments: InlineSegment[];
   text: string;
 }
 
+const toLine = (bucket: TriageBucket, raw: string): QuestionLine => {
+  const segments = parseInline(raw);
+  return { bucket, segments, text: segmentsToText(segments) };
+};
+
 /** Flatten a concept into ledger lines, open questions first, settled last. */
 export const linesOf = (concept: OpenQuestionConcept): QuestionLine[] => [
-  ...concept.questions.map((question: OpenQuestion) => ({
-    bucket: bucketOf(question),
-    text: question.text,
-  })),
-  ...concept.resolved.map((text) => ({
-    bucket: "resolved" as TriageBucket,
-    text,
-  })),
+  ...concept.questions.map((question: OpenQuestion) =>
+    toLine(bucketOf(question), question.text)
+  ),
+  ...concept.resolved.map((raw) => toLine("resolved", raw)),
 ];
 
 /**
@@ -62,6 +73,86 @@ function Highlighted({
     offset += part.length;
   }
   return nodes;
+}
+
+/**
+ * Only these schemes become anchors. Manifest strings are authored in the vault
+ * rather than in this repo, so the href is content, and content does not get to
+ * choose the scheme it navigates with.
+ */
+const isSafeHref = (href: string): boolean =>
+  href.startsWith("/") ||
+  href.startsWith("https://") ||
+  href.startsWith("http://");
+
+const LINK_CLASS = "text-brand underline-offset-2 hover:underline";
+
+/**
+ * Render one parsed line: markup as elements, the search match still marked.
+ * Emphasis nests, so this recurses with the parser — which is what puts a
+ * highlight inside a bold run rather than around it.
+ */
+function InlineText({
+  pattern,
+  segments,
+}: {
+  pattern: RegExp | null;
+  segments: readonly InlineSegment[];
+}): ReactNode {
+  return segments.map((segment, index) => {
+    const key = `${index}-${segment.kind}`;
+
+    if (segment.kind === "text") {
+      return <Highlighted key={key} pattern={pattern} text={segment.text} />;
+    }
+    if (segment.kind === "code") {
+      return (
+        <code
+          className="rounded-[3px] bg-secondary px-1 py-0.5 font-mono text-[0.85em]"
+          key={key}
+        >
+          <Highlighted pattern={pattern} text={segment.text} />
+        </code>
+      );
+    }
+
+    const children = (
+      <InlineText key={key} pattern={pattern} segments={segment.children} />
+    );
+
+    if (segment.kind === "strong") {
+      return (
+        <strong className="font-medium text-foreground" key={key}>
+          {children}
+        </strong>
+      );
+    }
+    if (segment.kind === "em") {
+      return (
+        <em className="italic" key={key}>
+          {children}
+        </em>
+      );
+    }
+    if (!isSafeHref(segment.href)) {
+      return <span key={key}>{children}</span>;
+    }
+    return segment.href.startsWith("/") ? (
+      <InternalLink className={LINK_CLASS} href={segment.href} key={key}>
+        {children}
+      </InternalLink>
+    ) : (
+      <a
+        className={LINK_CLASS}
+        href={segment.href}
+        key={key}
+        rel="noreferrer"
+        target="_blank"
+      >
+        {children}
+      </a>
+    );
+  });
 }
 
 interface ConceptStanzaProps {
@@ -124,7 +215,7 @@ export function ConceptStanza({
                   {meta.code}
                 </span>
               )}
-              <Highlighted pattern={pattern} text={line.text} />
+              <InlineText pattern={pattern} segments={line.segments} />
             </li>
           );
         })}

--- a/apps/blog/src/app/(blog)/articles/service.ts
+++ b/apps/blog/src/app/(blog)/articles/service.ts
@@ -9,7 +9,10 @@ import {
   type WikiDomain,
   type WikiTag,
 } from "@howardism/article-contract";
-import { parseArticleGraph } from "@howardism/article-contract/manifests/graph";
+import {
+  type BacklinkEdge,
+  parseArticleGraph,
+} from "@howardism/article-contract/manifests/graph";
 import {
   type OpenQuestionConcept,
   parseOpenQuestions,
@@ -71,6 +74,10 @@ export interface SiblingNav {
 }
 
 export interface ArticleLink {
+  /** How many times the citing article links here. Backlinks only. */
+  citedCount?: number;
+  /** The citing line, quoted verbatim, when the citation sits in prose. */
+  citedIn?: string;
   meta: ArticleMeta;
   slug: string;
 }
@@ -108,6 +115,33 @@ const toArticleLinks = (
     const entity = visible.entities[slug];
     if (entity) {
       links.push({ slug, meta: entity.meta });
+    }
+  }
+  return links;
+};
+
+/**
+ * Backlink edges as links, keeping the manifest's weight ordering and carrying
+ * the citing sentence through so the reader can tell a discussion from a
+ * one-line mention without opening either.
+ */
+const toBacklinks = (
+  edges: readonly BacklinkEdge[] | undefined,
+  visible: Normalise<ArticleEntity>
+): ArticleLink[] => {
+  if (!edges) {
+    return [];
+  }
+  const links: ArticleLink[] = [];
+  for (const edge of edges) {
+    const entity = visible.entities[edge.slug];
+    if (entity) {
+      links.push({
+        slug: edge.slug,
+        meta: entity.meta,
+        citedCount: edge.count,
+        ...(edge.context === undefined ? {} : { citedIn: edge.context }),
+      });
     }
   }
   return links;
@@ -206,7 +240,7 @@ export const getArticleConnections = cache(
   async (slug: string): Promise<ArticleConnections> => {
     const visible = await getVisibleArticles();
     return {
-      backlinks: toArticleLinks(graph.backlinks[slug], visible),
+      backlinks: toBacklinks(graph.backlinks[slug], visible),
       related: toArticleLinks(graph.related[slug], visible),
     };
   }

--- a/apps/blog/src/app/(blog)/articles/triage-meta.ts
+++ b/apps/blog/src/app/(blog)/articles/triage-meta.ts
@@ -1,0 +1,60 @@
+import type { OpenQuestion } from "@howardism/article-contract/manifests/open-questions";
+
+/**
+ * The buckets the `/questions` worklist filters by: the vault's four `#oq/*`
+ * triage tags, plus the two states the tags cannot express — a bullet the vault
+ * never tagged, and a question it has since settled.
+ */
+export type TriageBucket =
+  | "now"
+  | "source"
+  | "wait"
+  | "note"
+  | "untriaged"
+  | "resolved";
+
+export interface TriageMeta {
+  /** Marginal code stamped on the line; empty means the line carries none. */
+  code: string;
+  label: string;
+  /**
+   * Ink for the code and the tally rule. One red for the answerable bucket,
+   * the ink ramp for the parked ones, verdigris for the settled counterweight.
+   */
+  tone: string;
+}
+
+export const TRIAGE_META: Record<TriageBucket, TriageMeta> = {
+  now: { code: "Now", label: "Answerable now", tone: "var(--brand)" },
+  source: {
+    code: "Source",
+    label: "Needs a source",
+    tone: "var(--foreground)",
+  },
+  wait: {
+    code: "Wait",
+    label: "Awaiting the event",
+    tone: "var(--muted-foreground)",
+  },
+  note: {
+    code: "Note",
+    label: "Unfiled note",
+    tone: "var(--foreground-subtle)",
+  },
+  untriaged: { code: "", label: "Untriaged", tone: "var(--foreground-subtle)" },
+  resolved: { code: "Resolved", label: "Resolved", tone: "var(--brand-2)" },
+};
+
+/** Display order of the buckets, live work first and settled work last. */
+export const TRIAGE_ORDER: TriageBucket[] = [
+  "now",
+  "source",
+  "wait",
+  "note",
+  "untriaged",
+  "resolved",
+];
+
+/** An untagged bullet is recorded as untriaged rather than guessed into a tag. */
+export const bucketOf = (question: OpenQuestion): TriageBucket =>
+  question.kind ?? "untriaged";

--- a/apps/blog/src/app/(blog)/questions/page.tsx
+++ b/apps/blog/src/app/(blog)/questions/page.tsx
@@ -3,9 +3,8 @@ import type { Metadata } from "next";
 import { env } from "@/config/env";
 
 import { PlatePage } from "../_shell/plate-page";
-import { DOMAIN_META, DOMAIN_ORDER } from "../articles/domain-meta";
-import { OpenQuestionsSection } from "../articles/open-questions-section";
 import { getOpenQuestions } from "../articles/service";
+import { QuestionsWorklist } from "./questions-worklist";
 
 const QUESTIONS_URL = `${env.NEXT_PUBLIC_DOMAIN_NAME}/questions`;
 
@@ -14,70 +13,39 @@ export const dynamic = "error";
 export const metadata: Metadata = {
   title: "Open Questions — Howardism",
   description:
-    "The live worklist: unanswered questions harvested from every concept in the Howardism wiki, grouped by domain.",
+    "The live worklist: unanswered questions harvested from every concept in the Howardism wiki, searchable and filterable by triage and domain.",
   alternates: { canonical: QUESTIONS_URL },
   openGraph: { url: QUESTIONS_URL },
 };
 
 export default function QuestionsPage() {
   const concepts = getOpenQuestions();
-  const questions = concepts.flatMap((c) => c.questions);
-
-  // The vault's own triage, carried through by the importer. Reporting one
-  // undifferentiated total implies every entry is equally live, when most are
-  // parked waiting on evidence that does not exist yet.
-  //
-  // A manifest emitted before the importer carried the tag has no triage at
-  // all; fall back to the plain total there rather than claiming nothing is
-  // answerable. The breakdown appears on the next `bun run import:wiki`.
-  const triaged = questions.some((q) => q.kind !== null);
-  const answerable = questions.filter((q) => q.kind === "now").length;
+  const open = concepts.reduce((sum, c) => sum + c.questions.length, 0);
   const resolved = concepts.reduce((sum, c) => sum + c.resolved.length, 0);
-
-  const byDomain = DOMAIN_ORDER.map((domain) => ({
-    domain,
-    concepts: concepts.filter((c) => c.domain === domain),
-  })).filter((group) => group.concepts.length > 0);
-
-  const headerData: [string, string][] = triaged
-    ? [
-        ["Answerable now", String(answerable)],
-        ["Awaiting evidence", String(questions.length - answerable)],
-        ["Resolved", String(resolved)],
-        ["Concepts", String(concepts.length)],
-      ]
-    : [
-        ["Questions", String(questions.length)],
-        ["Concepts", String(concepts.length)],
-        ["Domains", String(byDomain.length)],
-      ];
+  const domains = new Set(concepts.map((c) => c.domain));
 
   return (
     <PlatePage
       headerChildren={
         <p className="mt-6 max-w-[680px] font-body text-[clamp(16px,2.2vw,18px)] text-muted-foreground leading-[1.55]">
-          The live worklist, harvested from the wiki&apos;s concept notes and
-          grouped by domain. Most entries are parked until the evidence exists;
-          the ones already settled are marked resolved. Each links back to the
-          note that raised it.
+          The live worklist, harvested from the wiki&apos;s concept notes.
+          Search it, narrow it to one domain, or pull out only the questions the
+          vault thinks are answerable today — the tally moves with whatever you
+          type. Each line links back to the note that raised it.
         </p>
       }
-      headerData={headerData}
+      headerData={[
+        ["Open", String(open)],
+        ["Resolved", String(resolved)],
+        ["Concepts", String(concepts.length)],
+        ["Domains", String(domains.size)],
+      ]}
       plate="questions"
       title="Open questions,"
       titleAccent="unresolved."
       width="wide"
     >
-      <div className="mt-4">
-        {byDomain.map(({ domain, concepts: group }) => (
-          <OpenQuestionsSection
-            color={DOMAIN_META[domain].color}
-            concepts={group}
-            heading={DOMAIN_META[domain].label}
-            key={domain}
-          />
-        ))}
-      </div>
+      <QuestionsWorklist concepts={concepts} />
     </PlatePage>
   );
 }

--- a/apps/blog/src/app/(blog)/questions/page.tsx
+++ b/apps/blog/src/app/(blog)/questions/page.tsx
@@ -21,27 +21,48 @@ export const metadata: Metadata = {
 
 export default function QuestionsPage() {
   const concepts = getOpenQuestions();
-  const total = concepts.reduce((sum, c) => sum + c.questions.length, 0);
+  const questions = concepts.flatMap((c) => c.questions);
+
+  // The vault's own triage, carried through by the importer. Reporting one
+  // undifferentiated total implies every entry is equally live, when most are
+  // parked waiting on evidence that does not exist yet.
+  //
+  // A manifest emitted before the importer carried the tag has no triage at
+  // all; fall back to the plain total there rather than claiming nothing is
+  // answerable. The breakdown appears on the next `bun run import:wiki`.
+  const triaged = questions.some((q) => q.kind !== null);
+  const answerable = questions.filter((q) => q.kind === "now").length;
+  const resolved = concepts.reduce((sum, c) => sum + c.resolved.length, 0);
 
   const byDomain = DOMAIN_ORDER.map((domain) => ({
     domain,
     concepts: concepts.filter((c) => c.domain === domain),
   })).filter((group) => group.concepts.length > 0);
 
+  const headerData: [string, string][] = triaged
+    ? [
+        ["Answerable now", String(answerable)],
+        ["Awaiting evidence", String(questions.length - answerable)],
+        ["Resolved", String(resolved)],
+        ["Concepts", String(concepts.length)],
+      ]
+    : [
+        ["Questions", String(questions.length)],
+        ["Concepts", String(concepts.length)],
+        ["Domains", String(byDomain.length)],
+      ];
+
   return (
     <PlatePage
       headerChildren={
         <p className="mt-6 max-w-[680px] font-body text-[clamp(16px,2.2vw,18px)] text-muted-foreground leading-[1.55]">
-          The live worklist. Every unanswered question harvested from the
-          wiki&apos;s concept notes, grouped by domain. Each links back to the
+          The live worklist, harvested from the wiki&apos;s concept notes and
+          grouped by domain. Most entries are parked until the evidence exists;
+          the ones already settled are marked resolved. Each links back to the
           note that raised it.
         </p>
       }
-      headerData={[
-        ["Questions", String(total)],
-        ["Concepts", String(concepts.length)],
-        ["Domains", String(byDomain.length)],
-      ]}
+      headerData={headerData}
       plate="questions"
       title="Open questions,"
       titleAccent="unresolved."

--- a/apps/blog/src/app/(blog)/questions/questions-worklist.tsx
+++ b/apps/blog/src/app/(blog)/questions/questions-worklist.tsx
@@ -1,0 +1,441 @@
+"use client";
+
+import type { WikiDomain } from "@howardism/article-contract";
+import { cn } from "@howardism/ui/lib/utils";
+import {
+  type CSSProperties,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import { useKeyboardShortcut } from "@/hooks/use-keyboard-shortcut";
+
+import { DOMAIN_META, DOMAIN_ORDER } from "../articles/domain-meta";
+import {
+  ConceptStanza,
+  linesOf,
+  type QuestionLine,
+} from "../articles/open-questions-section";
+import type { OpenQuestionConcept } from "../articles/service";
+import {
+  TRIAGE_META,
+  TRIAGE_ORDER,
+  type TriageBucket,
+} from "../articles/triage-meta";
+
+type Sort = "concept" | "weight";
+
+/** A concept with its lines pre-flattened once, so filtering stays cheap. */
+interface Stanza {
+  domain: WikiDomain;
+  /** Lowercased title, searched alongside every line under it. */
+  haystack: string;
+  lines: QuestionLine[];
+  slug: string;
+  title: string;
+}
+
+const CHIP_CLASS =
+  "flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full border px-3 py-1.5 font-mono text-[10.5px] uppercase tracking-[0.1em] transition-colors";
+const SEG_BUTTON_CLASS =
+  "border-border border-r px-3 py-1.5 font-mono text-[10.5px] uppercase tracking-[0.1em] transition-colors last:border-r-0";
+const META_CLASS =
+  "font-mono text-[10.5px] text-foreground-subtle uppercase tabular-nums tracking-[0.16em]";
+
+const SORTS: [Sort, string][] = [
+  ["concept", "Filed"],
+  ["weight", "Most open"],
+];
+
+const WHITESPACE = /\s+/;
+const REGEX_SPECIALS = /[.*+?^${}()|[\]\\]/g;
+
+/** A line matches only when its concept title or its text holds every token. */
+const tokenize = (query: string): string[] =>
+  query.toLowerCase().split(WHITESPACE).filter(Boolean);
+
+const escapeToken = (token: string): string =>
+  token.replace(REGEX_SPECIALS, "\\$&");
+
+export function QuestionsWorklist({
+  concepts,
+}: {
+  concepts: OpenQuestionConcept[];
+}) {
+  const [query, setQuery] = useState("");
+  const [bucket, setBucket] = useState<TriageBucket | null>(null);
+  const [domain, setDomain] = useState<WikiDomain | null>(null);
+  const [sort, setSort] = useState<Sort>("concept");
+  const inputRef = useRef<HTMLInputElement>(null);
+  // Guards the URL writer so it cannot blank the query string on first commit,
+  // before the reader below has restored the state a shared link carried in.
+  const hydrated = useRef(false);
+
+  const stanzas = useMemo<Stanza[]>(
+    () =>
+      concepts.map((concept) => ({
+        domain: concept.domain,
+        haystack: concept.title.toLowerCase(),
+        lines: linesOf(concept),
+        slug: concept.slug,
+        title: concept.title,
+      })),
+    [concepts]
+  );
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const nextQuery = params.get("q");
+    const nextBucket = params.get("kind");
+    const nextDomain = params.get("domain");
+    const nextSort = params.get("sort");
+    if (nextQuery) {
+      setQuery(nextQuery);
+    }
+    if (nextBucket && TRIAGE_ORDER.includes(nextBucket as TriageBucket)) {
+      setBucket(nextBucket as TriageBucket);
+    }
+    if (nextDomain && DOMAIN_ORDER.includes(nextDomain as WikiDomain)) {
+      setDomain(nextDomain as WikiDomain);
+    }
+    if (nextSort === "weight") {
+      setSort("weight");
+    }
+    hydrated.current = true;
+  }, []);
+
+  // Filters live in the URL so a worked-down view stays linkable and survives a
+  // reload — the page is prerendered, so this is a client-side replace only.
+  useEffect(() => {
+    if (!hydrated.current) {
+      return;
+    }
+    const params = new URLSearchParams();
+    if (query) {
+      params.set("q", query);
+    }
+    if (bucket) {
+      params.set("kind", bucket);
+    }
+    if (domain) {
+      params.set("domain", domain);
+    }
+    if (sort !== "concept") {
+      params.set("sort", sort);
+    }
+    const search = params.toString();
+    window.history.replaceState(
+      null,
+      "",
+      search ? `?${search}` : window.location.pathname
+    );
+  }, [query, bucket, domain, sort]);
+
+  const focusSearch = useCallback(() => inputRef.current?.focus(), []);
+  useKeyboardShortcut("/", focusSearch);
+
+  const tokens = useMemo(() => tokenize(query), [query]);
+  const pattern = useMemo(
+    () =>
+      tokens.length === 0
+        ? null
+        : new RegExp(`(${tokens.map(escapeToken).join("|")})`, "gi"),
+    [tokens]
+  );
+
+  // Text and domain narrow the corpus; the bucket filter is applied after, so
+  // the tally can keep showing what the other buckets hold under this search.
+  const scoped = useMemo(
+    () =>
+      stanzas
+        .filter((stanza) => domain === null || stanza.domain === domain)
+        .map((stanza) => ({
+          ...stanza,
+          lines: stanza.lines.filter((line) =>
+            tokens.every(
+              (token) =>
+                stanza.haystack.includes(token) ||
+                line.text.toLowerCase().includes(token)
+            )
+          ),
+        }))
+        .filter((stanza) => stanza.lines.length > 0),
+    [stanzas, domain, tokens]
+  );
+
+  const counts = useMemo(() => {
+    const tally = new Map<TriageBucket, number>();
+    for (const stanza of scoped) {
+      for (const line of stanza.lines) {
+        tally.set(line.bucket, (tally.get(line.bucket) ?? 0) + 1);
+      }
+    }
+    return tally;
+  }, [scoped]);
+
+  const domainCounts = useMemo(() => {
+    const tally = new Map<WikiDomain, number>();
+    for (const stanza of stanzas) {
+      const open = stanza.lines.filter(
+        (line) => line.bucket !== "resolved"
+      ).length;
+      tally.set(stanza.domain, (tally.get(stanza.domain) ?? 0) + open);
+    }
+    return tally;
+  }, [stanzas]);
+
+  const results = useMemo(() => {
+    const filtered = scoped
+      .map((stanza) => ({
+        ...stanza,
+        lines:
+          bucket === null
+            ? stanza.lines
+            : stanza.lines.filter((line) => line.bucket === bucket),
+      }))
+      .filter((stanza) => stanza.lines.length > 0);
+    if (sort === "weight") {
+      filtered.sort(
+        (a, b) =>
+          b.lines.length - a.lines.length || a.title.localeCompare(b.title)
+      );
+    }
+    return filtered;
+  }, [scoped, bucket, sort]);
+
+  const shownLines = results.reduce(
+    (sum, stanza) => sum + stanza.lines.length,
+    0
+  );
+  const totalLines = stanzas.reduce(
+    (sum, stanza) => sum + stanza.lines.length,
+    0
+  );
+  const filtered = Boolean(query || bucket || domain);
+
+  const activeBuckets = TRIAGE_ORDER.filter(
+    (key) => (counts.get(key) ?? 0) > 0 || key === bucket
+  );
+  // With a single bucket in play there is no distribution to read, so the tally
+  // band would be a decorative full-width bar. It appears once the vault's
+  // triage tags actually split the backlog.
+  const showTally =
+    TRIAGE_ORDER.filter((key) => (counts.get(key) ?? 0) > 0).length > 1;
+  const peak = Math.max(1, ...activeBuckets.map((key) => counts.get(key) ?? 0));
+
+  const clearAll = () => {
+    setQuery("");
+    setBucket(null);
+    setDomain(null);
+  };
+
+  return (
+    <>
+      <div className="sticky top-20 z-30 -mx-3 mt-8 border-border border-b bg-background/85 px-3 backdrop-blur-md">
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-2 pt-3 pb-2.5">
+          <div className="flex min-w-[220px] flex-1 items-center gap-2 rounded-lg border border-border px-3 py-1.5 focus-within:border-ring">
+            <span aria-hidden="true" className={META_CLASS}>
+              Find
+            </span>
+            <input
+              aria-label="Search open questions"
+              className="min-w-0 flex-1 bg-transparent font-body text-[15px] text-foreground outline-none placeholder:text-foreground-subtle"
+              onChange={(event) => setQuery(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Escape") {
+                  setQuery("");
+                }
+              }}
+              placeholder="a word in the question, or a concept…"
+              ref={inputRef}
+              type="search"
+              value={query}
+            />
+            {query.length === 0 && (
+              <kbd
+                className="hidden rounded border border-border px-1.5 py-0.5 font-mono text-[10px] text-foreground-subtle sm:block"
+                title="Press / to search"
+              >
+                /
+              </kbd>
+            )}
+          </div>
+          <span className={META_CLASS}>
+            {filtered
+              ? `${shownLines} of ${totalLines}`
+              : `${totalLines} lines`}
+            <span className="mx-1.5 opacity-50">·</span>
+            {results.length} concepts
+          </span>
+          <fieldset
+            aria-label="Sort concepts"
+            className="flex overflow-hidden rounded-lg border border-border bg-card"
+          >
+            {SORTS.map(([key, label]) => (
+              <button
+                aria-pressed={sort === key}
+                className={cn(
+                  SEG_BUTTON_CLASS,
+                  sort === key
+                    ? "bg-accent text-foreground"
+                    : "text-foreground-subtle hover:bg-secondary hover:text-foreground"
+                )}
+                key={key}
+                onClick={() => setSort(key)}
+                type="button"
+              >
+                {label}
+              </button>
+            ))}
+          </fieldset>
+        </div>
+
+        {showTally && (
+          <fieldset aria-label="Filter by triage" className="min-w-0">
+            <div className="flex min-w-0 gap-x-6 gap-y-3 overflow-x-auto pb-3">
+              {activeBuckets.map((key) => {
+                const meta = TRIAGE_META[key];
+                const count = counts.get(key) ?? 0;
+                const active = bucket === key;
+                return (
+                  <button
+                    aria-pressed={active}
+                    className={cn(
+                      "group min-w-[112px] flex-1 shrink-0 text-left transition-opacity",
+                      bucket !== null && !active && "opacity-45"
+                    )}
+                    key={key}
+                    onClick={() => setBucket(active ? null : key)}
+                    type="button"
+                  >
+                    <span
+                      className={cn(
+                        "flex items-baseline justify-between gap-2 font-mono text-[10.5px] uppercase tabular-nums tracking-[0.14em] transition-colors",
+                        active
+                          ? "text-foreground"
+                          : "text-foreground-subtle group-hover:text-foreground"
+                      )}
+                    >
+                      <span>{meta.label}</span>
+                      <span>{count}</span>
+                    </span>
+                    <span
+                      aria-hidden="true"
+                      className="mt-1.5 block h-[3px] w-full bg-border"
+                    >
+                      <span
+                        className="block h-full bg-[var(--tone)] transition-[width] duration-500 ease-out motion-reduce:transition-none"
+                        style={
+                          {
+                            "--tone": meta.tone,
+                            width: `${(count / peak) * 100}%`,
+                          } as CSSProperties
+                        }
+                      />
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </fieldset>
+        )}
+
+        {/* Chrome propagates a fieldset's content min-size to its ancestors even
+            when the fieldset is a `min-width: 0` scroll container, so fourteen
+            chips would push the whole page frame wider than the viewport. The
+            scroll container has to be an ordinary element inside it. Above `sm`
+            they wrap instead: a domain you cannot see is a filter you never use. */}
+        <fieldset aria-label="Filter by domain" className="min-w-0">
+          <div className="flex min-w-0 gap-2 overflow-x-auto pb-3 sm:flex-wrap sm:overflow-visible">
+            <button
+              aria-pressed={domain === null}
+              className={cn(
+                CHIP_CLASS,
+                domain === null
+                  ? "border-foreground-subtle text-foreground"
+                  : "border-border text-muted-foreground hover:text-foreground"
+              )}
+              onClick={() => setDomain(null)}
+              type="button"
+            >
+              All domains
+            </button>
+            {DOMAIN_ORDER.filter((key) => (domainCounts.get(key) ?? 0) > 0).map(
+              (key) => (
+                <button
+                  aria-pressed={domain === key}
+                  className={cn(
+                    CHIP_CLASS,
+                    domain === key
+                      ? "border-[var(--dc)] bg-card text-foreground"
+                      : "border-border text-muted-foreground hover:text-foreground"
+                  )}
+                  key={key}
+                  onClick={() =>
+                    setDomain((current) => (current === key ? null : key))
+                  }
+                  style={{ "--dc": DOMAIN_META[key].color } as CSSProperties}
+                  type="button"
+                >
+                  <span
+                    aria-hidden="true"
+                    className="size-2 rounded-full bg-[var(--dc)]"
+                  />
+                  {DOMAIN_META[key].label}
+                  <span className="text-foreground-subtle">
+                    {domainCounts.get(key)}
+                  </span>
+                </button>
+              )
+            )}
+          </div>
+        </fieldset>
+      </div>
+
+      {results.length > 0 ? (
+        <ul className="m-0 mt-8 flex list-none flex-col gap-7 p-0">
+          {results.map((stanza) => (
+            <ConceptStanza
+              color={DOMAIN_META[stanza.domain].color}
+              key={stanza.slug}
+              lines={stanza.lines}
+              pattern={pattern}
+              slug={stanza.slug}
+              title={stanza.title}
+            />
+          ))}
+        </ul>
+      ) : (
+        <div className="mt-10">
+          <p className="m-0 max-w-[56ch] font-body text-[15px] text-muted-foreground leading-[1.6]">
+            Nothing in the backlog matches{" "}
+            {query && <b className="font-medium text-foreground">“{query}”</b>}
+            {query && (bucket || domain) ? " under " : null}
+            {bucket && (
+              <b className="font-medium text-foreground">
+                {TRIAGE_META[bucket].label}
+              </b>
+            )}
+            {bucket && domain ? " in " : null}
+            {domain && (
+              <b className="font-medium text-foreground">
+                {DOMAIN_META[domain].label}
+              </b>
+            )}
+            . Widen it, or clear the filters and read the whole worklist.
+          </p>
+          <button
+            className="mt-5 inline-block font-mono text-[11px] text-brand uppercase tracking-[0.16em] transition-colors hover:text-foreground"
+            onClick={clearAll}
+            type="button"
+          >
+            Clear filters →
+          </button>
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/cli/src/__tests__/content-check.test.ts
+++ b/apps/cli/src/__tests__/content-check.test.ts
@@ -110,7 +110,7 @@ describe("checkGraphSlugRefs", () => {
 
   it("passes when all keys and values are real articles", () => {
     const graph: ArticleGraph = {
-      backlinks: { a: ["b"], b: ["a"] },
+      backlinks: { a: [{ slug: "b", count: 1 }], b: [{ slug: "a", count: 1 }] },
       outgoing: { a: ["b"] },
       related: { b: ["a"] },
       generatedOn: "2026-01-01",
@@ -120,7 +120,7 @@ describe("checkGraphSlugRefs", () => {
 
   it("flags a dangling value slug and a dangling key slug", () => {
     const graph: ArticleGraph = {
-      backlinks: { a: ["ghost"] },
+      backlinks: { a: [{ slug: "ghost", count: 1 }] },
       outgoing: { phantom: ["a"] },
       related: {},
       generatedOn: "2026-01-01",

--- a/apps/cli/src/__tests__/content-check.test.ts
+++ b/apps/cli/src/__tests__/content-check.test.ts
@@ -136,12 +136,19 @@ describe("checkOpenQuestionSlugRefs", () => {
   it("flags a concept slug with no article", () => {
     const manifest: OpenQuestionsManifest = {
       byConcept: [
-        { slug: "a", title: "A", domain: "agent-systems", questions: ["q"] },
+        {
+          slug: "a",
+          title: "A",
+          domain: "agent-systems",
+          questions: [{ kind: "now", text: "q" }],
+          resolved: [],
+        },
         {
           slug: "missing",
           title: "M",
           domain: "agent-systems",
           questions: [],
+          resolved: [],
         },
       ],
       generatedOn: "2026-01-01",

--- a/apps/cli/src/__tests__/graph.test.ts
+++ b/apps/cli/src/__tests__/graph.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { mkdtemp, readFile, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { parseArticleGraph } from "@howardism/article-contract/manifests/graph";
 import {
   buildArticleGraph,
   emitArticleGraph,
@@ -71,9 +72,12 @@ describe("buildArticleGraph", () => {
       c: ["b"],
     });
     expect(graph.backlinks).toEqual({
-      a: ["b"],
-      b: ["a", "c"],
-      c: ["a"],
+      a: [{ slug: "b", count: 1 }],
+      b: [
+        { slug: "a", count: 1 },
+        { slug: "c", count: 1 },
+      ],
+      c: [{ slug: "a", count: 1 }],
     });
   });
 
@@ -93,7 +97,8 @@ describe("buildArticleGraph", () => {
 
     expect(graph.outgoing.a).toEqual(["b"]);
     expect(graph.outgoing.b).toEqual([]);
-    expect(graph.backlinks.b).toEqual(["a"]);
+    // Three live links to b (two bare, one anchored) collapse to one weighted edge.
+    expect(graph.backlinks.b).toEqual([{ slug: "a", count: 3 }]);
   });
 
   it("excludes archived nodes entirely from outgoing, backlinks, and related", () => {
@@ -117,8 +122,8 @@ describe("buildArticleGraph", () => {
     expect(Object.keys(graph.related).sort()).toEqual(["a", "b"]);
     expect(graph.outgoing.a).toEqual(["b"]);
     expect(graph.outgoing.b).toEqual(["a"]);
-    expect(graph.backlinks.a).toEqual(["b"]);
-    expect(graph.backlinks.b).toEqual(["a"]);
+    expect(graph.backlinks.a).toEqual([{ slug: "b", count: 1 }]);
+    expect(graph.backlinks.b).toEqual([{ slug: "a", count: 1 }]);
   });
 
   it("ranks related[] by combined neighbor overlap, capped at 5", () => {
@@ -146,6 +151,29 @@ describe("buildArticleGraph", () => {
     expect(graph.related.s6).toEqual(["s1", "s2", "s3", "s4", "s5"]);
     // hub has no other node with overlapping outgoing or backlinks.
     expect(graph.related.hub).toEqual([]);
+  });
+
+  it("ranks backlinks by citation weight and quotes the citing prose", () => {
+    const prose =
+      "The harness shrinks as models improve, which is exactly what [[b]] argues once you stop treating scaffolding as permanent.";
+    const parsed = [
+      makeParsed("light", "- [[b]]"),
+      makeParsed("heavy", `${prose}\nAnd again, [[b]] twice over: [[b]].`),
+      makeParsed("b", ""),
+    ];
+
+    const graph = buildArticleGraph({ parsed, generatedOn: "2026-05-14" });
+
+    expect(graph.backlinks.b).toEqual([
+      {
+        slug: "heavy",
+        count: 3,
+        context:
+          "The harness shrinks as models improve, which is exactly what B argues once you stop treating scaffolding as permanent.",
+      },
+      // A bare list entry carries no prose, so it gets no quote.
+      { slug: "light", count: 1 },
+    ]);
   });
 
   it("breaks related ties alphabetically by slug", () => {
@@ -199,7 +227,10 @@ describe("emitArticleGraph", () => {
     const parsed = JSON.parse(await readFile(outputPath, "utf8"));
     expect(parsed.generatedOn).toBe("2026-05-14");
     expect(parsed.outgoing).toEqual({ a: ["b"], b: ["a"] });
-    expect(parsed.backlinks).toEqual({ a: ["b"], b: ["a"] });
+    expect(parsed.backlinks).toEqual({
+      a: [{ slug: "b", count: 1 }],
+      b: [{ slug: "a", count: 1 }],
+    });
   });
 
   it("dry-run skips the write but returns the intended path", async () => {
@@ -216,5 +247,20 @@ describe("emitArticleGraph", () => {
     });
     expect(written).toBe(outputPath);
     await expect(stat(outputPath)).rejects.toThrow();
+  });
+});
+
+describe("parseArticleGraph", () => {
+  it("normalises pre-weighting manifests that store bare backlink slugs", () => {
+    const graph = parseArticleGraph({
+      backlinks: { a: ["b", { slug: "c", count: 2, context: "prose" }] },
+      outgoing: {},
+      related: {},
+      generatedOn: "2026-05-14",
+    });
+    expect(graph.backlinks.a).toEqual([
+      { slug: "b", count: 1 },
+      { slug: "c", count: 2, context: "prose" },
+    ]);
   });
 });

--- a/apps/cli/src/__tests__/manifests.test.ts
+++ b/apps/cli/src/__tests__/manifests.test.ts
@@ -79,7 +79,10 @@ describe("buildManifests", () => {
     expect(set.openQuestions.byConcept[0]).toMatchObject({
       slug: "agent-loop-pattern",
       domain: "syntheses",
-      questions: ["Who owns the budget?", "Still need a backlog?"],
+      questions: [
+        { kind: null, text: "Who owns the budget?" },
+        { kind: null, text: "Still need a backlog?" },
+      ],
     });
   });
 
@@ -115,7 +118,7 @@ describe("buildManifests", () => {
     expect(set.openQuestions.byConcept).toHaveLength(1);
     expect(set.openQuestions.byConcept[0]).toMatchObject({
       slug: "agent-loop-pattern",
-      questions: ["Who owns the budget?"],
+      questions: [{ kind: "source", text: "Who owns the budget?" }],
     });
   });
 

--- a/apps/cli/src/__tests__/markup.test.ts
+++ b/apps/cli/src/__tests__/markup.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  type InlineSegment,
+  parseInline,
+  segmentsToText,
+  titleFromSlug,
+} from "@howardism/article-contract/markup";
+
+const kinds = (segments: InlineSegment[]) => segments.map((s) => s.kind);
+
+describe("parseInline", () => {
+  it("leaves unmarked prose as a single text segment", () => {
+    expect(parseInline("A plain question?")).toEqual([
+      { kind: "text", text: "A plain question?" },
+    ]);
+  });
+
+  it("reads emphasis, code spans, and links", () => {
+    const segments = parseInline(
+      "Do gains persist when **normalized for PR size**, or is `churn` the *real* signal? See [the paper](https://example.com/p)."
+    );
+    expect(kinds(segments)).toEqual([
+      "text",
+      "strong",
+      "text",
+      "code",
+      "text",
+      "em",
+      "text",
+      "link",
+      "text",
+    ]);
+    expect(segmentsToText(segments)).toBe(
+      "Do gains persist when normalized for PR size, or is churn the real signal? See the paper."
+    );
+  });
+
+  it("does not read a bold run as an empty italic", () => {
+    expect(parseInline("**bold**")).toEqual([
+      { kind: "strong", children: [{ kind: "text", text: "bold" }] },
+    ]);
+  });
+
+  it("keeps an internal link's href so the blog can route it", () => {
+    const segments = parseInline("Unlike [Prompt Injection](/articles/pi).");
+    expect(kinds(segments)).toEqual(["text", "link", "text"]);
+    expect(segments[1]).toEqual({
+      kind: "link",
+      href: "/articles/pi",
+      children: [{ kind: "text", text: "Prompt Injection" }],
+    });
+  });
+
+  // Emphasis nests in the vault's prose. A flat parser swallows whatever sits
+  // inside a run, which is how `[[slug]]` and backticks used to reach the page
+  // as raw characters.
+  it("parses markup nested inside an emphasis run", () => {
+    const segments = parseInline(
+      "**Which instrument for the *frontier* set?**"
+    );
+    expect(kinds(segments)).toEqual(["strong"]);
+    expect(segmentsToText(segments)).toBe(
+      "Which instrument for the frontier set?"
+    );
+    const strong = segments[0];
+    expect(strong.kind === "strong" && kinds(strong.children)).toEqual([
+      "text",
+      "em",
+      "text",
+    ]);
+  });
+
+  it("resolves a wikilink written inside an italic aside", () => {
+    const segments = parseInline(
+      "Answered. *(Partly informed: [[emergent]].)*"
+    );
+    expect(segmentsToText(segments)).toBe(
+      "Answered. (Partly informed: Emergent.)"
+    );
+  });
+
+  it("does not re-parse the inside of a code span", () => {
+    expect(parseInline("`a *b* c`")).toEqual([
+      { kind: "code", text: "a *b* c" },
+    ]);
+  });
+
+  // The committed manifest predates the importer resolving its wikilinks, so
+  // the parser has to render a raw one readably — as text, never as a link.
+  it("renders an unresolved wikilink as its title, not as brackets", () => {
+    const segments = parseInline("Unlike [[out-of-band-prompt-injection]] it…");
+    expect(kinds(segments)).toEqual(["text"]);
+    expect(segmentsToText(segments)).toBe(
+      "Unlike Out Of Band Prompt Injection it…"
+    );
+  });
+
+  it("prefers a wikilink's alias, and humanises a raw target", () => {
+    expect(segmentsToText(parseInline("[[some-slug|the alias]]"))).toBe(
+      "the alias"
+    );
+    expect(segmentsToText(parseInline("[[raw/some_paper.pdf]]"))).toBe(
+      "some paper pdf"
+    );
+  });
+
+  it("drops a wikilink's folder path and anchor", () => {
+    expect(
+      segmentsToText(parseInline("[[wiki/concepts/eval-drift#why]]"))
+    ).toBe("Eval Drift");
+  });
+
+  it("leaves a lone asterisk alone", () => {
+    expect(parseInline("3 * 4 is 12")).toEqual([
+      { kind: "text", text: "3 * 4 is 12" },
+    ]);
+  });
+});
+
+describe("titleFromSlug", () => {
+  it("title-cases a hyphenated slug", () => {
+    expect(titleFromSlug("agent-loop-pattern")).toBe("Agent Loop Pattern");
+  });
+});

--- a/apps/cli/src/__tests__/open-questions.test.ts
+++ b/apps/cli/src/__tests__/open-questions.test.ts
@@ -111,6 +111,46 @@ describe("buildOpenQuestions", () => {
     expect(delta?.resolved).toEqual(["All done."]);
   });
 
+  it("resolves a wikilink in a bullet to a link, so the blog can render it", () => {
+    const manifest = build([
+      file(
+        "open-questions",
+        "#### [[beta]]\n\n- Unlike [[alpha]], does it hold under load?\n"
+      ),
+    ]);
+
+    expect(manifest.byConcept[0].questions).toEqual([
+      {
+        kind: null,
+        text: "Unlike [Alpha](/articles/alpha), does it hold under load?",
+      },
+    ]);
+  });
+
+  it("renders an unpublished wikilink as plain title rather than a dead link", () => {
+    const manifest = build([
+      file(
+        "open-questions",
+        "#### [[beta]]\n\n- Compare with [[never-published-note]].\n"
+      ),
+    ]);
+
+    expect(manifest.byConcept[0].questions[0].text).toBe(
+      "Compare with Never Published Note."
+    );
+  });
+
+  it("resolves wikilinks in resolved answers too", () => {
+    const manifest = build([
+      file("open-questions", BACKLOG),
+      file("delta", "## Resolved Questions\n\n- Settled by [[alpha]].\n"),
+    ]);
+
+    expect(
+      manifest.byConcept.find((c) => c.slug === "delta")?.resolved
+    ).toEqual(["Settled by [Alpha](/articles/alpha)."]);
+  });
+
   it("reads the pre-triage manifest shape as untagged", () => {
     const legacy = parseOpenQuestions({
       byConcept: [

--- a/apps/cli/src/__tests__/open-questions.test.ts
+++ b/apps/cli/src/__tests__/open-questions.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "bun:test";
+
+import { parseOpenQuestions } from "@howardism/article-contract/manifests/open-questions";
+
+import { buildOpenQuestions } from "../import-wiki/pages/open-questions.ts";
+import type { ParsedWikiFile } from "../import-wiki/parse.ts";
+
+function file(slug: string, body: string): ParsedWikiFile {
+  return {
+    body,
+    frontmatter: {},
+    mtime: new Date(0),
+    source: {
+      absolutePath: `/vault/${slug}.md`,
+      relativePath: `${slug}.md`,
+      slug,
+    },
+  } as unknown as ParsedWikiFile;
+}
+
+const BACKLOG = `# Open Questions Backlog
+
+## Actionable by domain
+
+### agent-systems (2 open)
+
+#### [[alpha]]
+
+- Can this be answered from the wiki? #oq/now
+- Needs a paper that does not exist. #oq/source
+
+#### [[beta]]
+
+- A prediction about the next model. #oq/wait
+
+## Predictions — \`#oq/wait\` (1)
+
+- [[gamma]]: A flat bullet that belongs to no concept.
+`;
+
+const build = (parsed: ParsedWikiFile[]) =>
+  buildOpenQuestions({
+    generatedOn: "2026-01-01",
+    membership: new Map(),
+    parsed,
+    slugTitleMap: new Map([["alpha", "Alpha"]]),
+  });
+
+describe("buildOpenQuestions", () => {
+  it("carries the #oq triage tag through and strips it from the text", () => {
+    const manifest = build([file("open-questions", BACKLOG)]);
+    const alpha = manifest.byConcept.find((c) => c.slug === "alpha");
+
+    expect(alpha?.questions).toEqual([
+      { kind: "now", text: "Can this be answered from the wiki?" },
+      { kind: "source", text: "Needs a paper that does not exist." },
+    ]);
+    expect(alpha?.title).toBe("Alpha");
+  });
+
+  it("does not attribute the trailing flat sections to the last concept", () => {
+    const manifest = build([file("open-questions", BACKLOG)]);
+
+    expect(manifest.byConcept.map((c) => c.slug).sort()).toEqual([
+      "alpha",
+      "beta",
+    ]);
+    expect(
+      manifest.byConcept.find((c) => c.slug === "beta")?.questions
+    ).toEqual([{ kind: "wait", text: "A prediction about the next model." }]);
+  });
+
+  it("reads a tag written mid-bullet, ahead of a trailing parenthetical", () => {
+    const manifest = build([
+      file(
+        "open-questions",
+        "#### [[alpha]]\n\n- Does it cause or correlate? #oq/source (Not addressed by the paper.)\n"
+      ),
+    ]);
+
+    expect(manifest.byConcept[0].questions).toEqual([
+      {
+        kind: "source",
+        text: "Does it cause or correlate? (Not addressed by the paper.)",
+      },
+    ]);
+  });
+
+  it("harvests Resolved Questions from concept pages", () => {
+    const manifest = build([
+      file("open-questions", BACKLOG),
+      file(
+        "alpha",
+        "## Open Questions\n\n- still open #oq/now\n\n## Resolved Questions\n\n- Settled by a source. **Answered:** yes\n\n## Sources\n\n- not a question\n"
+      ),
+    ]);
+
+    expect(
+      manifest.byConcept.find((c) => c.slug === "alpha")?.resolved
+    ).toEqual(["Settled by a source. **Answered:** yes"]);
+  });
+
+  it("keeps a concept whose questions are all resolved", () => {
+    const manifest = build([
+      file("open-questions", BACKLOG),
+      file("delta", "## Resolved Questions\n\n- All done.\n"),
+    ]);
+
+    const delta = manifest.byConcept.find((c) => c.slug === "delta");
+    expect(delta?.questions).toEqual([]);
+    expect(delta?.resolved).toEqual(["All done."]);
+  });
+
+  it("reads the pre-triage manifest shape as untagged", () => {
+    const legacy = parseOpenQuestions({
+      byConcept: [
+        {
+          domain: "agent-systems",
+          questions: ["a bare string from an older import"],
+          slug: "alpha",
+          title: "Alpha",
+        },
+      ],
+      generatedOn: "2026-01-01",
+    });
+
+    expect(legacy.byConcept[0].questions).toEqual([
+      { kind: null, text: "a bare string from an older import" },
+    ]);
+    expect(legacy.byConcept[0].resolved).toEqual([]);
+  });
+});

--- a/apps/cli/src/__tests__/parse.test.ts
+++ b/apps/cli/src/__tests__/parse.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { titleFromSlug } from "@howardism/article-contract/markup";
 
 import {
   buildSlugTitleMap,
@@ -14,7 +15,6 @@ import {
   resolveDate,
   stripWikilinksToText,
 } from "../import-wiki/parse.ts";
-import { titleFromSlug } from "../import-wiki/wikilink.ts";
 
 async function tempFile(content: string, filename: string): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), "wiki-test-"));

--- a/apps/cli/src/__tests__/wikilink.test.ts
+++ b/apps/cli/src/__tests__/wikilink.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { titleFromSlug } from "@howardism/article-contract/markup";
 
 import {
   extractInternalSlugs,
@@ -6,7 +7,6 @@ import {
   humanize,
   rewriteToMarkdown,
   stripToText,
-  titleFromSlug,
   tokenizeWikilinks,
   type WikiToken,
 } from "../import-wiki/wikilink.ts";

--- a/apps/cli/src/content-check.ts
+++ b/apps/cli/src/content-check.ts
@@ -25,7 +25,10 @@ import { readdir, readFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 
 import { WIKI_DOMAINS } from "@howardism/article-contract";
-import type { ArticleGraph } from "@howardism/article-contract/manifests/graph";
+import {
+  type ArticleGraph,
+  parseArticleGraph,
+} from "@howardism/article-contract/manifests/graph";
 import type { OpenQuestionsManifest } from "@howardism/article-contract/manifests/open-questions";
 import type { WikiSourcesManifest } from "@howardism/article-contract/manifests/wiki-sources";
 import matter from "gray-matter";
@@ -111,8 +114,21 @@ export function checkGraphSlugRefs(
   articleSlugs: Set<string>
 ): string[] {
   const failures: string[] = [];
-  for (const relation of ["backlinks", "outgoing", "related"] as const) {
-    for (const [source, targets] of Object.entries(graph[relation] ?? {})) {
+  const relations: [string, Record<string, string[]>][] = [
+    [
+      "backlinks",
+      Object.fromEntries(
+        Object.entries(graph.backlinks ?? {}).map(([source, edges]) => [
+          source,
+          edges.map((edge) => edge.slug),
+        ])
+      ),
+    ],
+    ["outgoing", graph.outgoing ?? {}],
+    ["related", graph.related ?? {}],
+  ];
+  for (const [relation, edges] of relations) {
+    for (const [source, targets] of Object.entries(edges)) {
       if (!articleSlugs.has(source)) {
         failures.push(`graph.${relation} key "${source}" has no article`);
       }
@@ -240,7 +256,7 @@ export function checkEmptyDomains(articles: ArticleRecord[]): string[] {
  */
 export function findOrphanArticles(
   articles: ArticleRecord[],
-  backlinks: Record<string, string[]>
+  backlinks: Record<string, readonly unknown[]>
 ): string[] {
   const orphans: string[] = [];
   for (const { slug } of articles) {
@@ -355,7 +371,7 @@ async function main(): Promise<void> {
     await Promise.all([
       loadArticles(),
       loadAssetFilenames(),
-      loadJson<ArticleGraph>("article-graph.json"),
+      loadJson<unknown>("article-graph.json").then(parseArticleGraph),
       loadJson<OpenQuestionsManifest>("open-questions.json"),
       loadJson<WikiSourcesManifest>("wiki-sources.json"),
     ]);

--- a/apps/cli/src/import-wiki/index.ts
+++ b/apps/cli/src/import-wiki/index.ts
@@ -1,6 +1,5 @@
 import { access, mkdir, readFile, rm } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
-
 import {
   type EntityType,
   type SourceRef,
@@ -8,6 +7,7 @@ import {
   type WikiDomain,
   type WikiTag,
 } from "@howardism/article-contract";
+import { titleFromSlug } from "@howardism/article-contract/markup";
 import { runWithConcurrency } from "../concurrency.ts";
 import { writeSearchIndex } from "../search-index.ts";
 import { pngToWebp } from "../webp.ts";
@@ -51,7 +51,6 @@ import {
   stripDuplicateLeadingHeading,
   stripHtmlComments,
 } from "./transform.ts";
-import { titleFromSlug } from "./wikilink.ts";
 
 interface RunOptions {
   blogArticlesPath: string;

--- a/apps/cli/src/import-wiki/pages/graph.ts
+++ b/apps/cli/src/import-wiki/pages/graph.ts
@@ -4,10 +4,11 @@ import { dirname } from "node:path";
 import {
   type ArticleGraph,
   ArticleGraphSchema,
+  type BacklinkEdge,
 } from "@howardism/article-contract/manifests/graph";
 
 import type { ParsedWikiFile } from "../parse.ts";
-import { extractInternalSlugs } from "../wikilink.ts";
+import { extractLinkOccurrences, type LinkOccurrence } from "../wikilink.ts";
 
 const RELATED_LIMIT = 5;
 
@@ -31,42 +32,71 @@ export function buildArticleGraph(args: BuildArticleGraphArgs): ArticleGraph {
   const live = parsed.filter((p) => !isArchivedFn(p));
   const liveSlugs = new Set(live.map((p) => p.source.slug));
 
-  const outgoingSets = buildOutgoingSets(live, liveSlugs);
+  const occurrences = buildOccurrences(live, liveSlugs);
+  const outgoingSets = new Map(
+    [...occurrences].map(([slug, links]) => [
+      slug,
+      new Set(links.map((link) => link.slug)),
+    ])
+  );
   const backlinkSets = buildBacklinkSets(outgoingSets, liveSlugs);
 
   const sortedSlugs = [...liveSlugs].sort();
   const related = computeRelated(sortedSlugs, outgoingSets, backlinkSets);
+  const backlinks = buildBacklinks(occurrences, sortedSlugs);
 
   const outgoing: Record<string, string[]> = {};
-  const backlinks: Record<string, string[]> = {};
   for (const slug of sortedSlugs) {
     outgoing[slug] = [...(outgoingSets.get(slug) ?? new Set())].sort();
-    backlinks[slug] = [...(backlinkSets.get(slug) ?? new Set())].sort();
   }
 
   return { generatedOn, outgoing, backlinks, related };
 }
 
-function buildOutgoingSets(
+/** Per-source links to live articles — self-links and dangling targets dropped. */
+function buildOccurrences(
   live: ParsedWikiFile[],
   liveSlugs: Set<string>
-): Map<string, Set<string>> {
-  const out = new Map<string, Set<string>>();
+): Map<string, LinkOccurrence[]> {
+  const out = new Map<string, LinkOccurrence[]>();
   for (const file of live) {
     const slug = file.source.slug;
-    const targets = new Set<string>();
-    for (const target of extractInternalSlugs(file.body)) {
-      if (target === slug) {
-        continue;
-      }
-      if (!liveSlugs.has(target)) {
-        continue;
-      }
-      targets.add(target);
-    }
-    out.set(slug, targets);
+    out.set(
+      slug,
+      extractLinkOccurrences(file.body).filter(
+        (link) => link.slug !== slug && liveSlugs.has(link.slug)
+      )
+    );
   }
   return out;
+}
+
+/**
+ * Inbound citations per article, heaviest first: an article that links here
+ * four times outranks one that lists the slug in a table of contents. Ties
+ * break alphabetically so the manifest stays deterministic.
+ */
+function buildBacklinks(
+  occurrences: Map<string, LinkOccurrence[]>,
+  sortedSlugs: string[]
+): Record<string, BacklinkEdge[]> {
+  const backlinks: Record<string, BacklinkEdge[]> = {};
+  for (const slug of sortedSlugs) {
+    backlinks[slug] = [];
+  }
+  for (const [source, links] of occurrences) {
+    for (const link of links) {
+      backlinks[link.slug]?.push({
+        slug: source,
+        count: link.count,
+        ...(link.context === null ? {} : { context: link.context }),
+      });
+    }
+  }
+  for (const edges of Object.values(backlinks)) {
+    edges.sort((a, b) => b.count - a.count || a.slug.localeCompare(b.slug));
+  }
+  return backlinks;
 }
 
 function buildBacklinkSets(

--- a/apps/cli/src/import-wiki/pages/open-questions.ts
+++ b/apps/cli/src/import-wiki/pages/open-questions.ts
@@ -3,6 +3,8 @@ import { dirname } from "node:path";
 
 import type { WikiDomain } from "@howardism/article-contract";
 import {
+  OPEN_QUESTION_KINDS,
+  type OpenQuestion,
   type OpenQuestionConcept,
   type OpenQuestionsManifest,
   OpenQuestionsManifestSchema,
@@ -21,6 +23,33 @@ export type {
 const HEADING_RE = /^#{1,6}\s/;
 const CONCEPT_HEADING_RE = /^#{2,6}\s+\[\[[^\]]+\]\]/;
 const BULLET_RE = /^-\s+(.+)$/;
+/**
+ * The tag usually trails its bullet, but the vault also writes it mid-line when
+ * a parenthetical follows ("… #oq/source (Not addressed by …)"), so it is
+ * matched anywhere. A backticked mention is the taxonomy being discussed rather
+ * than a tag, and is left alone.
+ */
+const OQ_TAG_RE = /(?<!`)#oq\/([a-z]+)\b/;
+const REPEATED_SPACE_RE = /\s{2,}/g;
+const RESOLVED_HEADING_RE = /^##\s+Resolved Questions\s*$/i;
+const H2_RE = /^##\s/;
+
+const KINDS: ReadonlySet<string> = new Set(OPEN_QUESTION_KINDS);
+
+/**
+ * Split a backlog bullet into its published text and its `#oq/*` triage tag.
+ * The tag is the signal that separates an answerable question from a standing
+ * request for evidence, so it is captured here before `stripAuthoringTags`
+ * removes it from the prose. An unrecognised or absent tag yields `null`
+ * rather than a guessed bucket.
+ */
+function toQuestion(raw: string): OpenQuestion {
+  const tag = OQ_TAG_RE.exec(raw)?.[1];
+  return {
+    kind: tag && KINDS.has(tag) ? (tag as OpenQuestion["kind"]) : null,
+    text: raw.replace(OQ_TAG_RE, "").replace(REPEATED_SPACE_RE, " ").trim(),
+  };
+}
 
 /**
  * Parse the backlog body into per-concept question lists. Concepts are
@@ -33,8 +62,8 @@ const BULLET_RE = /^-\s+(.+)$/;
  * `- [[slug]]: …` bullets with no concept heading of their own — from being
  * appended to whichever concept happened to come last.
  */
-function parseBacklog(body: string): Map<string, string[]> {
-  const byConcept = new Map<string, string[]>();
+function parseBacklog(body: string): Map<string, OpenQuestion[]> {
+  const byConcept = new Map<string, OpenQuestion[]>();
   let current: string | null = null;
 
   for (const rawLine of body.split("\n")) {
@@ -50,10 +79,46 @@ function parseBacklog(body: string): Map<string, string[]> {
     }
     const bullet = BULLET_RE.exec(line);
     if (current && bullet) {
-      byConcept.get(current)?.push(stripAuthoringTags(bullet[1].trim()));
+      byConcept.get(current)?.push(toQuestion(bullet[1].trim()));
     }
   }
   return byConcept;
+}
+
+/**
+ * Harvest each concept page's `## Resolved Questions` bullets — the questions
+ * the vault has actually settled. They live on the concept pages, not in the
+ * generated backlog, so they are read straight from the parsed vault files.
+ */
+function parseResolved(
+  parsed: readonly ParsedWikiFile[]
+): Map<string, string[]> {
+  const bySlug = new Map<string, string[]>();
+
+  for (const file of parsed) {
+    const resolved: string[] = [];
+    let inSection = false;
+
+    for (const rawLine of file.body.split("\n")) {
+      const line = rawLine.trim();
+      if (RESOLVED_HEADING_RE.test(line)) {
+        inSection = true;
+        continue;
+      }
+      if (inSection && H2_RE.test(line)) {
+        break;
+      }
+      const bullet = inSection ? BULLET_RE.exec(line) : null;
+      if (bullet) {
+        resolved.push(stripAuthoringTags(bullet[1].trim()));
+      }
+    }
+
+    if (resolved.length > 0) {
+      bySlug.set(file.source.slug, resolved);
+    }
+  }
+  return bySlug;
 }
 
 export function buildOpenQuestions(args: {
@@ -71,9 +136,19 @@ export function buildOpenQuestions(args: {
     return { generatedOn, byConcept: [] };
   }
 
+  const resolvedBySlug = parseResolved(parsed);
+  const open = parseBacklog(backlog.body);
+
+  // A concept earns an entry if it has open questions *or* settled ones — a
+  // page whose questions have all been answered is the most useful thing the
+  // manifest can carry, so it must not be dropped for having an empty backlog.
+  const slugs = new Set([...open.keys(), ...resolvedBySlug.keys()]);
+
   const byConcept: OpenQuestionConcept[] = [];
-  for (const [slug, questions] of parseBacklog(backlog.body)) {
-    if (questions.length === 0) {
+  for (const slug of slugs) {
+    const questions = open.get(slug) ?? [];
+    const resolved = resolvedBySlug.get(slug) ?? [];
+    if (questions.length === 0 && resolved.length === 0) {
       continue;
     }
     byConcept.push({
@@ -81,6 +156,7 @@ export function buildOpenQuestions(args: {
       title: slugTitleMap.get(slug) ?? titleFromSlug(slug),
       domain: resolveDomain(slug, membership),
       questions,
+      resolved,
     });
   }
 

--- a/apps/cli/src/import-wiki/pages/open-questions.ts
+++ b/apps/cli/src/import-wiki/pages/open-questions.ts
@@ -1,6 +1,5 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
-
 import type { WikiDomain } from "@howardism/article-contract";
 import {
   OPEN_QUESTION_KINDS,
@@ -9,11 +8,12 @@ import {
   type OpenQuestionsManifest,
   OpenQuestionsManifestSchema,
 } from "@howardism/article-contract/manifests/open-questions";
+import { titleFromSlug } from "@howardism/article-contract/markup";
 
 import { OPEN_QUESTIONS_SLUG, resolveDomain } from "../domains.ts";
 import type { ParsedWikiFile } from "../parse.ts";
-import { stripAuthoringTags } from "../transform.ts";
-import { extractInternalSlugs, titleFromSlug } from "../wikilink.ts";
+import { rewriteWikilinks, stripAuthoringTags } from "../transform.ts";
+import { extractInternalSlugs } from "../wikilink.ts";
 
 export type {
   OpenQuestionConcept,
@@ -139,6 +139,15 @@ export function buildOpenQuestions(args: {
   const resolvedBySlug = parseResolved(parsed);
   const open = parseBacklog(backlog.body);
 
+  // Backlog bullets are prose lifted out of note bodies, so they carry the
+  // vault's own `[[wikilink]]`s. Resolve them through the same rewriter the
+  // article bodies use: a published slug becomes a markdown link to its
+  // article, an unpublished one becomes its plain title. Without this the blog
+  // has no way to tell a link from literal brackets, and renders neither.
+  const titles = new Map(slugTitleMap);
+  const resolveLinks = (text: string): string =>
+    rewriteWikilinks(text, titles).body;
+
   // A concept earns an entry if it has open questions *or* settled ones — a
   // page whose questions have all been answered is the most useful thing the
   // manifest can carry, so it must not be dropped for having an empty backlog.
@@ -155,8 +164,11 @@ export function buildOpenQuestions(args: {
       slug,
       title: slugTitleMap.get(slug) ?? titleFromSlug(slug),
       domain: resolveDomain(slug, membership),
-      questions,
-      resolved,
+      questions: questions.map((question) => ({
+        ...question,
+        text: resolveLinks(question.text),
+      })),
+      resolved: resolved.map(resolveLinks),
     });
   }
 

--- a/apps/cli/src/import-wiki/parse.ts
+++ b/apps/cli/src/import-wiki/parse.ts
@@ -1,5 +1,6 @@
 import { readdir, readFile, stat } from "node:fs/promises";
 import { basename, extname, join } from "node:path";
+import { titleFromSlug } from "@howardism/article-contract/markup";
 
 import matter from "gray-matter";
 
@@ -7,7 +8,6 @@ import {
   extractRawSlugs,
   humanize as humanizeSlug,
   stripToText,
-  titleFromSlug,
   tokenizeWikilinks,
 } from "./wikilink.ts";
 

--- a/apps/cli/src/import-wiki/transform.ts
+++ b/apps/cli/src/import-wiki/transform.ts
@@ -1,12 +1,8 @@
 import type { SourceRef } from "@howardism/article-contract";
+import { titleFromSlug } from "@howardism/article-contract/markup";
 
 import type { RawDoc } from "./parse.ts";
-import {
-  humanize,
-  rewriteToMarkdown,
-  titleFromSlug,
-  type WikiResolver,
-} from "./wikilink.ts";
+import { humanize, rewriteToMarkdown, type WikiResolver } from "./wikilink.ts";
 
 // Accepts both `[[target|label]]` and `[[target\|label]]` — the latter is the
 // Obsidian convention for embedding pipes inside markdown tables.

--- a/apps/cli/src/import-wiki/wikilink.ts
+++ b/apps/cli/src/import-wiki/wikilink.ts
@@ -1,3 +1,5 @@
+import { titleFromSlug } from "@howardism/article-contract/markup";
+
 /** Single source of truth for the [[wikilink]] grammar.
  *  Group 1 = target (incl. any wiki/ or raw/ prefix and #anchor).
  *  Group 2 = optional label, after `|` or Obsidian's table-escaped `\|`. */
@@ -34,14 +36,6 @@ export function humanize(raw: string): string {
     .replace(WHITESPACE_RE, " ")
     .trim();
   return decoded.length > 0 ? decoded : raw;
-}
-
-/** Title-case a hyphenated slug. */
-export function titleFromSlug(slug: string): string {
-  return slug
-    .split("-")
-    .map((part) => (part ? part[0].toUpperCase() + part.slice(1) : part))
-    .join(" ");
 }
 
 /** Scan once; classify every match. Source order. No dedup. */

--- a/apps/cli/src/import-wiki/wikilink.ts
+++ b/apps/cli/src/import-wiki/wikilink.ts
@@ -78,6 +78,82 @@ export function extractInternalSlugs(
   return slugs;
 }
 
+/**
+ * Below this, the citing line is a bare index entry (`- [[foo]]`, a MOC table
+ * row) with no prose worth quoting — the backlink shows the target's own
+ * description instead.
+ */
+const MIN_CONTEXT_CHARS = 60;
+const MAX_CONTEXT_CHARS = 160;
+
+const HEADING_MARKER_RE = /^#{1,6}\s+/;
+const LIST_MARKER_RE = /^[>\s]*(?:[-*+]|\d+\.)\s+/;
+const MD_LINK_RE = /\[([^\]]+)\]\([^)]*\)/g;
+const TABLE_CELL_RE = /\s*\\?\|\s*/g;
+const EMPHASIS_RE = /[*`]+/g;
+const TRIM_SEPARATORS_RE = /^[·\s]+|[·\s]+$/g;
+
+export interface LinkOccurrence {
+  /** The citing line as plain text, or null when it carries no real prose. */
+  context: string | null;
+  /** How many times this body links the target. */
+  count: number;
+  slug: string;
+}
+
+/**
+ * Internal links with their repeat count and the best line they appear in —
+ * one entry per distinct target. "Best" is the longest qualifying line, which
+ * favours prose over the bare list entries a target usually also appears in.
+ */
+export function extractLinkOccurrences(input: string): LinkOccurrence[] {
+  const byTarget = new Map<string, LinkOccurrence>();
+  for (const line of input.split("\n")) {
+    const slugs = extractInternalSlugs(line);
+    if (slugs.length === 0) {
+      continue;
+    }
+    const context = lineContext(line);
+    for (const slug of slugs) {
+      const existing = byTarget.get(slug);
+      if (!existing) {
+        byTarget.set(slug, { slug, count: 1, context });
+        continue;
+      }
+      existing.count += 1;
+      if (
+        context &&
+        (existing.context === null || context.length > existing.context.length)
+      ) {
+        existing.context = context;
+      }
+    }
+  }
+  return [...byTarget.values()];
+}
+
+function lineContext(line: string): string | null {
+  const text = stripToText(line)
+    .replace(HEADING_MARKER_RE, "")
+    .replace(LIST_MARKER_RE, "")
+    .replace(MD_LINK_RE, "$1")
+    .replace(TABLE_CELL_RE, " · ")
+    .replace(EMPHASIS_RE, "")
+    .replace(WHITESPACE_RE, " ")
+    .replace(TRIM_SEPARATORS_RE, "");
+  if (text.length < MIN_CONTEXT_CHARS) {
+    return null;
+  }
+  if (text.length <= MAX_CONTEXT_CHARS) {
+    return text;
+  }
+  const cut = text.slice(0, MAX_CONTEXT_CHARS);
+  const lastSpace = cut.lastIndexOf(" ");
+  const clipped =
+    lastSpace > MAX_CONTEXT_CHARS / 2 ? cut.slice(0, lastSpace) : cut;
+  return `${clipped.trimEnd()}…`;
+}
+
 /** Raw slugs (kind==="raw"), source order, ORIGINAL case + sub-paths. */
 export function extractRawSlugs(
   input: string,

--- a/packages/article-contract/package.json
+++ b/packages/article-contract/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "exports": {
     ".": "./src/index.ts",
+    "./markup": "./src/markup.ts",
     "./schema": "./src/schema.ts",
     "./search": "./src/search.ts",
     "./surface": "./src/surface.ts",

--- a/packages/article-contract/src/manifests/graph.ts
+++ b/packages/article-contract/src/manifests/graph.ts
@@ -8,8 +8,33 @@ import { z } from "zod";
  */
 const slugList = z.array(z.string());
 
+const BacklinkEdgeObject = z.object({
+  /**
+   * The citing line as plain text, when the citation sits in prose. Absent for
+   * bare index entries (a MOC list item, a table row) — nothing worth quoting.
+   */
+  context: z.string().optional(),
+  /** How many times the citing article links here. Drives the sort order. */
+  count: z.number().int().positive(),
+  slug: z.string(),
+});
+
+export type BacklinkEdge = z.infer<typeof BacklinkEdgeObject>;
+
+/**
+ * Backlink entries, ranked by citation weight. Manifests written before the
+ * edges carried weight/context store a bare slug; those normalise to a single
+ * context-free citation so every reader sees one shape.
+ */
+const backlinkList = z.array(
+  z.union([
+    BacklinkEdgeObject,
+    z.string().transform((slug): BacklinkEdge => ({ count: 1, slug })),
+  ])
+);
+
 export const ArticleGraphSchema = z.object({
-  backlinks: z.record(z.string(), slugList),
+  backlinks: z.record(z.string(), backlinkList),
   generatedOn: z.string(),
   outgoing: z.record(z.string(), slugList),
   related: z.record(z.string(), slugList),

--- a/packages/article-contract/src/manifests/open-questions.ts
+++ b/packages/article-contract/src/manifests/open-questions.ts
@@ -3,14 +3,51 @@ import { z } from "zod";
 import { WIKI_DOMAINS } from "../index";
 
 /**
+ * The vault's `#oq/*` triage tag, carried through to the blog so the reader can
+ * tell an answerable question from a standing request for evidence:
+ *
+ * - `now` — answerable today by synthesis over pages already in the wiki.
+ * - `source` — needs external evidence that does not exist in the vault yet.
+ * - `wait` — a prediction, falsifiable only by a future event.
+ * - `note` — an observation the vault has not yet folded into an article body.
+ *
+ * The vault tags every backlog bullet, but the tag is the author's own
+ * workflow marker and drifts; `null` records an untagged bullet rather than
+ * guessing a bucket for it.
+ */
+export const OPEN_QUESTION_KINDS = ["now", "source", "wait", "note"] as const;
+
+export const OpenQuestionSchema = z.object({
+  kind: z.enum(OPEN_QUESTION_KINDS).nullable(),
+  text: z.string(),
+});
+
+export type OpenQuestion = z.infer<typeof OpenQuestionSchema>;
+
+/**
+ * Questions were a bare `string[]` before the triage tag was carried through.
+ * The committed manifest only takes the new shape on the next `import:wiki`,
+ * so a legacy bullet is read as untagged rather than failing the blog build.
+ */
+const OpenQuestionEntrySchema = z.union([
+  OpenQuestionSchema,
+  z.string().transform((text): OpenQuestion => ({ kind: null, text })),
+]);
+
+/**
  * The open-questions backlog, harvested from the vault and regrouped under the
  * blog's domains. Each concept that still has unanswered questions becomes one
  * entry; the blog buckets these by `domain` for the `/questions` page and the
  * per-domain sections on domain pages.
+ *
+ * `resolved` carries the questions the vault has since settled (a concept
+ * page's `## Resolved Questions` section). They are the counterweight to the
+ * open list: without them the blog publishes only what is unsettled.
  */
 export const OpenQuestionConceptSchema = z.object({
   domain: z.enum(WIKI_DOMAINS),
-  questions: z.array(z.string()),
+  questions: z.array(OpenQuestionEntrySchema),
+  resolved: z.array(z.string()).default([]),
   slug: z.string(),
   title: z.string(),
 });

--- a/packages/article-contract/src/markup.ts
+++ b/packages/article-contract/src/markup.ts
@@ -1,0 +1,144 @@
+/**
+ * The inline-markup subset that survives the trip from the vault to a manifest
+ * string, and the parser that turns it into segments the blog can render.
+ *
+ * Manifest strings are single-line prose harvested out of note bodies, so they
+ * carry inline markdown — emphasis, code spans, links — but never block
+ * structure. Parsing them here, once, keeps the blog from shipping a markdown
+ * engine and keeps both sides of the contract agreeing on what a question
+ * says versus how it is marked up.
+ */
+
+export type InlineSegment =
+  | { kind: "text"; text: string }
+  | { kind: "code"; text: string }
+  | { kind: "strong"; children: InlineSegment[] }
+  | { kind: "em"; children: InlineSegment[] }
+  | { kind: "link"; href: string; children: InlineSegment[] };
+
+/**
+ * Alternation order is the grammar. `[text](href)` is tried before `[[wikilink]]`
+ * so a resolved link wins, and `**strong**` before `*em*` so a bold run is never
+ * read as an empty italic. Anything unmatched stays literal text.
+ *
+ * Emphasis bodies are lazy and unrestricted because they nest: the vault writes
+ * `**bold with *italic* inside**` and `*(an aside with a [[wikilink]])*`, and a
+ * body that refused to contain markers would leave that inner markup to leak
+ * through as raw characters. Code spans are the exception — their content is
+ * literal by definition and is never re-parsed.
+ */
+const INLINE_RE =
+  /\[([^\]\n]+)\]\(([^)\s]+)\)|\[\[([^\]\n]+)\]\]|\*\*([^\n]+?)\*\*|\*([^*\n]+)\*|`([^`\n]+)`/g;
+
+const HUMANIZE_RE = /[._-]+/g;
+const WHITESPACE_RE = /\s+/g;
+/** Obsidian writes an alias as `target|label`, table-escaped as `target\|label`. */
+const WIKILINK_ALIAS_RE = /\\?\|/;
+
+/**
+ * Emphasis nests, so parsing recurses. Each level strips its own delimiters and
+ * is therefore strictly shorter than its parent, which already terminates; the
+ * cap is a cheap backstop against pathological input, not a real limit — the
+ * vault's deepest observed nesting is two.
+ */
+const MAX_DEPTH = 4;
+
+/** Title-case a hyphenated slug. The one implementation; the CLI imports it. */
+export function titleFromSlug(slug: string): string {
+  return slug
+    .split("-")
+    .map((part) => (part ? part[0].toUpperCase() + part.slice(1) : part))
+    .join(" ");
+}
+
+/**
+ * Display text for a wikilink the importer did not resolve. A manifest written
+ * before the importer rewrote its links still carries raw `[[target]]`, so the
+ * parser renders it readable rather than leaking brackets — but as plain text,
+ * never a link: only the importer knows which slugs are actually published.
+ */
+function wikilinkText(target: string): string {
+  const [rawTarget, label] = target.split(WIKILINK_ALIAS_RE, 2);
+  if (label) {
+    return label.trim();
+  }
+  const bare = rawTarget.split("/").pop() ?? rawTarget;
+  const slug = (bare.split("#")[0] ?? bare).trim();
+  if (slug === "") {
+    return bare.trim();
+  }
+  return rawTarget.startsWith("raw/")
+    ? slug.replace(HUMANIZE_RE, " ").replace(WHITESPACE_RE, " ").trim()
+    : titleFromSlug(slug.toLowerCase());
+}
+
+function parseAt(input: string, depth: number): InlineSegment[] {
+  const segments: InlineSegment[] = [];
+  let cursor = 0;
+
+  const pushText = (text: string) => {
+    if (text.length === 0) {
+      return;
+    }
+    const last = segments.at(-1);
+    if (last?.kind === "text") {
+      last.text += text;
+      return;
+    }
+    segments.push({ kind: "text", text });
+  };
+
+  // A nested body is re-parsed, so its markers never reach the reader; at the
+  // depth cap it is kept as literal text instead of recursing further.
+  const inner = (body: string): InlineSegment[] =>
+    depth >= MAX_DEPTH
+      ? [{ kind: "text", text: body }]
+      : parseAt(body, depth + 1);
+
+  // `exec` on a /g regex is stateful, so each scan owns its own instance.
+  const scanner = new RegExp(INLINE_RE.source, "g");
+  let match = scanner.exec(input);
+  while (match !== null) {
+    pushText(input.slice(cursor, match.index));
+    const [whole, linkText, href, wikiTarget, strong, em, code] = match;
+
+    if (linkText !== undefined && href !== undefined) {
+      segments.push({ kind: "link", href, children: inner(linkText) });
+    } else if (wikiTarget !== undefined) {
+      pushText(wikilinkText(wikiTarget));
+    } else if (strong !== undefined) {
+      segments.push({ kind: "strong", children: inner(strong) });
+    } else if (em !== undefined) {
+      segments.push({ kind: "em", children: inner(em) });
+    } else if (code !== undefined) {
+      segments.push({ kind: "code", text: code });
+    }
+
+    cursor = match.index + whole.length;
+    match = scanner.exec(input);
+  }
+  pushText(input.slice(cursor));
+
+  return segments;
+}
+
+/** Split one line of manifest prose into renderable inline segments. */
+export function parseInline(input: string): InlineSegment[] {
+  return parseAt(input, 0);
+}
+
+/**
+ * The prose a reader actually sees, with every marker removed. This is what
+ * search should match against — typing "normalized" must find a question that
+ * writes it as `**normalized**`, and typing "*" must not match every emphasis.
+ */
+export function segmentsToText(segments: readonly InlineSegment[]): string {
+  let text = "";
+  for (const segment of segments) {
+    text +=
+      segment.kind === "text" || segment.kind === "code"
+        ? segment.text
+        : segmentsToText(segment.children);
+  }
+  return text;
+}


### PR DESCRIPTION
## Why

The `/questions` page reads as a wall of undecided, and the cause is in the importer, not the vault.

- `transform.ts` strips every `#oq/*` triage tag as "not published content", so all backlog entries reach the blog looking equally live. In the section the importer actually reads, the mix is **425 `#oq/source`** (waiting on evidence that does not exist yet) against **11 `#oq/now`** (answerable from the wiki today).
- `## Resolved Questions` — **30 bullets across 28 concept pages** — never reached the manifest, so the site publishes what is unsettled and nothing that is settled.

The vault is unchanged; all filtering is importer-side, and no route or section is removed.

## What

- `article-contract`: `questions` entries become `{ kind, text }` with `kind` one of `now | source | wait | note | null`; concepts gain `resolved: string[]`.
- `import-wiki`: capture the tag before stripping it; harvest each concept's `## Resolved Questions`; keep a concept whose questions are *all* resolved (previously dropped for having an empty backlog).
- The tag is matched anywhere in the bullet, not only trailing it — the vault also writes it ahead of a parenthetical, which previously leaked the raw `#oq/source` into published prose (1 live instance).
- `/questions`: header reports `Answerable now / Awaiting evidence / Resolved / Concepts` instead of one total. Resolved answers render beneath the open ones on both `/questions` and domain pages.

## Compatibility

`questions` was a bare `string[]`. The schema still accepts that shape and reads it as untagged, and the page falls back to the old plain total when no entry carries a tag — so this deploys against the currently committed manifest with **no visible change** (`Questions 455 / Concepts 177 / Domains 14`, identical to today). The breakdown appears on the next `bun run import:wiki`.

## Verification

Run in this worktree:

- `bun run type-check`, `bun run lint`, `bun run test` (659 tests), `bun run build` — all green.
- `bun run content:check` — PASS (0 failures; 2 pre-existing warnings: orphan `open-questions`, `syntheses` without MOC).
- Rendered `/questions` HTML re-checked after the change: still `455 / 177 / 14` on the legacy manifest.
- Ran `buildOpenQuestions` against the live vault to confirm the new path end-to-end: **451 questions → 425 source, 11 now, 14 wait, 1 note, 0 untagged; 30 resolved bullets across 28 concepts; 0 leaked tags.**

Not done here: demoting the article-body `## Open Questions` section out of peer-`h2`/TOC weight, and re-ranking `/questions` to lead with the answerable ones. Both are presentation-only follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019LFKT1JKA26HkKrLasHkVh
