### PR TITLE
✨ feat(wiki-import): weight and quote backlinks instead of listing slugs

### DIFF
--- a/apps/blog/src/__tests__/articles/backlinks-disclosure.test.tsx
+++ b/apps/blog/src/__tests__/articles/backlinks-disclosure.test.tsx
@@ -131,3 +131,48 @@ describe("BacklinksDisclosureView — list rendering", () => {
     expect(text.length).toBeLessThan(longDescription.length);
   });
 });
+
+describe("BacklinksDisclosureView — citation context", () => {
+  it("quotes the citing line instead of the target's description", () => {
+    render(
+      <BacklinksDisclosureView
+        backlinks={[
+          {
+            ...makeLink("anthropic"),
+            citedIn: "Claude Code ships from the same incubator.",
+            citedCount: 1,
+          },
+        ]}
+        related={[]}
+      />
+    );
+    expect(
+      screen.getByText("Claude Code ships from the same incubator.")
+    ).toBeDefined();
+    expect(screen.queryByText("Description for anthropic.")).toBeNull();
+  });
+
+  it("falls back to the description when the citation has no prose context", () => {
+    render(
+      <BacklinksDisclosureView
+        backlinks={[{ ...makeLink("anthropic"), citedCount: 1 }]}
+        related={[]}
+      />
+    );
+    expect(screen.getByText("Description for anthropic.")).toBeDefined();
+  });
+
+  it("shows a repeat-count badge only for articles that cite more than once", () => {
+    render(
+      <BacklinksDisclosureView
+        backlinks={[
+          { ...makeLink("anthropic"), citedCount: 4 },
+          { ...makeLink("cowork"), citedCount: 1 },
+        ]}
+        related={[]}
+      />
+    );
+    expect(screen.getByText("×4")).toBeDefined();
+    expect(screen.queryByText("×1")).toBeNull();
+  });
+});

--- a/apps/blog/src/app/(blog)/articles/[slug]/article-link-row.tsx
+++ b/apps/blog/src/app/(blog)/articles/[slug]/article-link-row.tsx
@@ -11,7 +11,7 @@ interface ArticleLinkRowProps {
 }
 
 export function ArticleLinkRow({ link }: ArticleLinkRowProps) {
-  const { slug, meta } = link;
+  const { slug, meta, citedIn, citedCount } = link;
   return (
     <li className="flex flex-col gap-0.5">
       <span className="leading-[1.25]">
@@ -23,10 +23,24 @@ export function ArticleLinkRow({ link }: ArticleLinkRowProps) {
         >
           {meta.title}
         </InternalLink>
+        {citedCount !== undefined && citedCount > 1 && (
+          <span
+            className="ml-1.5 font-mono text-[0.7rem] text-muted-foreground"
+            title={`Links here ${citedCount} times`}
+          >
+            ×{citedCount}
+          </span>
+        )}
       </span>
-      <p className="m-0 font-body text-muted-foreground text-xs leading-[1.45]">
-        {truncate(meta.description, ARTICLE_LINK_DESCRIPTION_MAX)}
-      </p>
+      {citedIn ? (
+        <p className="m-0 border-border border-l-2 pl-2 font-body text-muted-foreground text-xs italic leading-[1.45]">
+          {citedIn}
+        </p>
+      ) : (
+        <p className="m-0 font-body text-muted-foreground text-xs leading-[1.45]">
+          {truncate(meta.description, ARTICLE_LINK_DESCRIPTION_MAX)}
+        </p>
+      )}
     </li>
   );
 }

--- a/apps/blog/src/app/(blog)/articles/service.ts
+++ b/apps/blog/src/app/(blog)/articles/service.ts
@@ -9,7 +9,10 @@ import {
   type WikiDomain,
   type WikiTag,
 } from "@howardism/article-contract";
-import { parseArticleGraph } from "@howardism/article-contract/manifests/graph";
+import {
+  type BacklinkEdge,
+  parseArticleGraph,
+} from "@howardism/article-contract/manifests/graph";
 import {
   type OpenQuestionConcept,
   parseOpenQuestions,
@@ -71,6 +74,10 @@ export interface SiblingNav {
 }
 
 export interface ArticleLink {
+  /** How many times the citing article links here. Backlinks only. */
+  citedCount?: number;
+  /** The citing line, quoted verbatim, when the citation sits in prose. */
+  citedIn?: string;
   meta: ArticleMeta;
   slug: string;
 }
@@ -108,6 +115,33 @@ const toArticleLinks = (
     const entity = visible.entities[slug];
     if (entity) {
       links.push({ slug, meta: entity.meta });
+    }
+  }
+  return links;
+};
+
+/**
+ * Backlink edges as links, keeping the manifest's weight ordering and carrying
+ * the citing sentence through so the reader can tell a discussion from a
+ * one-line mention without opening either.
+ */
+const toBacklinks = (
+  edges: readonly BacklinkEdge[] | undefined,
+  visible: Normalise<ArticleEntity>
+): ArticleLink[] => {
+  if (!edges) {
+    return [];
+  }
+  const links: ArticleLink[] = [];
+  for (const edge of edges) {
+    const entity = visible.entities[edge.slug];
+    if (entity) {
+      links.push({
+        slug: edge.slug,
+        meta: entity.meta,
+        citedCount: edge.count,
+        ...(edge.context === undefined ? {} : { citedIn: edge.context }),
+      });
     }
   }
   return links;
@@ -206,7 +240,7 @@ export const getArticleConnections = cache(
   async (slug: string): Promise<ArticleConnections> => {
     const visible = await getVisibleArticles();
     return {
-      backlinks: toArticleLinks(graph.backlinks[slug], visible),
+      backlinks: toBacklinks(graph.backlinks[slug], visible),
       related: toArticleLinks(graph.related[slug], visible),
     };
   }

--- a/apps/cli/src/__tests__/content-check.test.ts
+++ b/apps/cli/src/__tests__/content-check.test.ts
@@ -109,7 +109,7 @@ describe("checkGraphSlugRefs", () => {
 
   it("passes when all keys and values are real articles", () => {
     const graph: ArticleGraph = {
-      backlinks: { a: ["b"], b: ["a"] },
+      backlinks: { a: [{ slug: "b", count: 1 }], b: [{ slug: "a", count: 1 }] },
       outgoing: { a: ["b"] },
       related: { b: ["a"] },
       generatedOn: "2026-01-01",
@@ -119,7 +119,7 @@ describe("checkGraphSlugRefs", () => {
 
   it("flags a dangling value slug and a dangling key slug", () => {
     const graph: ArticleGraph = {
-      backlinks: { a: ["ghost"] },
+      backlinks: { a: [{ slug: "ghost", count: 1 }] },
       outgoing: { phantom: ["a"] },
       related: {},
       generatedOn: "2026-01-01",

--- a/apps/cli/src/__tests__/graph.test.ts
+++ b/apps/cli/src/__tests__/graph.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { mkdtemp, readFile, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { parseArticleGraph } from "@howardism/article-contract/manifests/graph";
 import {
   buildArticleGraph,
   emitArticleGraph,
@@ -71,9 +72,12 @@ describe("buildArticleGraph", () => {
       c: ["b"],
     });
     expect(graph.backlinks).toEqual({
-      a: ["b"],
-      b: ["a", "c"],
-      c: ["a"],
+      a: [{ slug: "b", count: 1 }],
+      b: [
+        { slug: "a", count: 1 },
+        { slug: "c", count: 1 },
+      ],
+      c: [{ slug: "a", count: 1 }],
     });
   });
 
@@ -93,7 +97,8 @@ describe("buildArticleGraph", () => {
 
     expect(graph.outgoing.a).toEqual(["b"]);
     expect(graph.outgoing.b).toEqual([]);
-    expect(graph.backlinks.b).toEqual(["a"]);
+    // Three live links to b (two bare, one anchored) collapse to one weighted edge.
+    expect(graph.backlinks.b).toEqual([{ slug: "a", count: 3 }]);
   });
 
   it("excludes archived nodes entirely from outgoing, backlinks, and related", () => {
@@ -117,8 +122,8 @@ describe("buildArticleGraph", () => {
     expect(Object.keys(graph.related).sort()).toEqual(["a", "b"]);
     expect(graph.outgoing.a).toEqual(["b"]);
     expect(graph.outgoing.b).toEqual(["a"]);
-    expect(graph.backlinks.a).toEqual(["b"]);
-    expect(graph.backlinks.b).toEqual(["a"]);
+    expect(graph.backlinks.a).toEqual([{ slug: "b", count: 1 }]);
+    expect(graph.backlinks.b).toEqual([{ slug: "a", count: 1 }]);
   });
 
   it("ranks related[] by combined neighbor overlap, capped at 5", () => {
@@ -146,6 +151,29 @@ describe("buildArticleGraph", () => {
     expect(graph.related.s6).toEqual(["s1", "s2", "s3", "s4", "s5"]);
     // hub has no other node with overlapping outgoing or backlinks.
     expect(graph.related.hub).toEqual([]);
+  });
+
+  it("ranks backlinks by citation weight and quotes the citing prose", () => {
+    const prose =
+      "The harness shrinks as models improve, which is exactly what [[b]] argues once you stop treating scaffolding as permanent.";
+    const parsed = [
+      makeParsed("light", "- [[b]]"),
+      makeParsed("heavy", `${prose}\nAnd again, [[b]] twice over: [[b]].`),
+      makeParsed("b", ""),
+    ];
+
+    const graph = buildArticleGraph({ parsed, generatedOn: "2026-05-14" });
+
+    expect(graph.backlinks.b).toEqual([
+      {
+        slug: "heavy",
+        count: 3,
+        context:
+          "The harness shrinks as models improve, which is exactly what B argues once you stop treating scaffolding as permanent.",
+      },
+      // A bare list entry carries no prose, so it gets no quote.
+      { slug: "light", count: 1 },
+    ]);
   });
 
   it("breaks related ties alphabetically by slug", () => {
@@ -199,7 +227,10 @@ describe("emitArticleGraph", () => {
     const parsed = JSON.parse(await readFile(outputPath, "utf8"));
     expect(parsed.generatedOn).toBe("2026-05-14");
     expect(parsed.outgoing).toEqual({ a: ["b"], b: ["a"] });
-    expect(parsed.backlinks).toEqual({ a: ["b"], b: ["a"] });
+    expect(parsed.backlinks).toEqual({
+      a: [{ slug: "b", count: 1 }],
+      b: [{ slug: "a", count: 1 }],
+    });
   });
 
   it("dry-run skips the write but returns the intended path", async () => {
@@ -216,5 +247,20 @@ describe("emitArticleGraph", () => {
     });
     expect(written).toBe(outputPath);
     await expect(stat(outputPath)).rejects.toThrow();
+  });
+});
+
+describe("parseArticleGraph", () => {
+  it("normalises pre-weighting manifests that store bare backlink slugs", () => {
+    const graph = parseArticleGraph({
+      backlinks: { a: ["b", { slug: "c", count: 2, context: "prose" }] },
+      outgoing: {},
+      related: {},
+      generatedOn: "2026-05-14",
+    });
+    expect(graph.backlinks.a).toEqual([
+      { slug: "b", count: 1 },
+      { slug: "c", count: 2, context: "prose" },
+    ]);
   });
 });

--- a/apps/cli/src/content-check.ts
+++ b/apps/cli/src/content-check.ts
@@ -25,7 +25,10 @@ import { readdir, readFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 
 import { WIKI_DOMAINS } from "@howardism/article-contract";
-import type { ArticleGraph } from "@howardism/article-contract/manifests/graph";
+import {
+  type ArticleGraph,
+  parseArticleGraph,
+} from "@howardism/article-contract/manifests/graph";
 import type { OpenQuestionsManifest } from "@howardism/article-contract/manifests/open-questions";
 import type { WikiSourcesManifest } from "@howardism/article-contract/manifests/wiki-sources";
 import matter from "gray-matter";
@@ -108,8 +111,21 @@ export function checkGraphSlugRefs(
   articleSlugs: Set<string>
 ): string[] {
   const failures: string[] = [];
-  for (const relation of ["backlinks", "outgoing", "related"] as const) {
-    for (const [source, targets] of Object.entries(graph[relation] ?? {})) {
+  const relations: [string, Record<string, string[]>][] = [
+    [
+      "backlinks",
+      Object.fromEntries(
+        Object.entries(graph.backlinks ?? {}).map(([source, edges]) => [
+          source,
+          edges.map((edge) => edge.slug),
+        ])
+      ),
+    ],
+    ["outgoing", graph.outgoing ?? {}],
+    ["related", graph.related ?? {}],
+  ];
+  for (const [relation, edges] of relations) {
+    for (const [source, targets] of Object.entries(edges)) {
       if (!articleSlugs.has(source)) {
         failures.push(`graph.${relation} key "${source}" has no article`);
       }
@@ -237,7 +253,7 @@ export function checkEmptyDomains(articles: ArticleRecord[]): string[] {
  */
 export function findOrphanArticles(
   articles: ArticleRecord[],
-  backlinks: Record<string, string[]>
+  backlinks: Record<string, readonly unknown[]>
 ): string[] {
   const orphans: string[] = [];
   for (const { slug } of articles) {
@@ -342,7 +358,7 @@ async function main(): Promise<void> {
     await Promise.all([
       loadArticles(),
       loadAssetFilenames(),
-      loadJson<ArticleGraph>("article-graph.json"),
+      loadJson<unknown>("article-graph.json").then(parseArticleGraph),
       loadJson<OpenQuestionsManifest>("open-questions.json"),
       loadJson<WikiSourcesManifest>("wiki-sources.json"),
     ]);

--- a/apps/cli/src/import-wiki/pages/graph.ts
+++ b/apps/cli/src/import-wiki/pages/graph.ts
@@ -4,10 +4,11 @@ import { dirname } from "node:path";
 import {
   type ArticleGraph,
   ArticleGraphSchema,
+  type BacklinkEdge,
 } from "@howardism/article-contract/manifests/graph";
 
 import type { ParsedWikiFile } from "../parse.ts";
-import { extractInternalSlugs } from "../wikilink.ts";
+import { extractLinkOccurrences, type LinkOccurrence } from "../wikilink.ts";
 
 const RELATED_LIMIT = 5;
 
@@ -31,42 +32,71 @@ export function buildArticleGraph(args: BuildArticleGraphArgs): ArticleGraph {
   const live = parsed.filter((p) => !isArchivedFn(p));
   const liveSlugs = new Set(live.map((p) => p.source.slug));
 
-  const outgoingSets = buildOutgoingSets(live, liveSlugs);
+  const occurrences = buildOccurrences(live, liveSlugs);
+  const outgoingSets = new Map(
+    [...occurrences].map(([slug, links]) => [
+      slug,
+      new Set(links.map((link) => link.slug)),
+    ])
+  );
   const backlinkSets = buildBacklinkSets(outgoingSets, liveSlugs);
 
   const sortedSlugs = [...liveSlugs].sort();
   const related = computeRelated(sortedSlugs, outgoingSets, backlinkSets);
+  const backlinks = buildBacklinks(occurrences, sortedSlugs);
 
   const outgoing: Record<string, string[]> = {};
-  const backlinks: Record<string, string[]> = {};
   for (const slug of sortedSlugs) {
     outgoing[slug] = [...(outgoingSets.get(slug) ?? new Set())].sort();
-    backlinks[slug] = [...(backlinkSets.get(slug) ?? new Set())].sort();
   }
 
   return { generatedOn, outgoing, backlinks, related };
 }
 
-function buildOutgoingSets(
+/** Per-source links to live articles — self-links and dangling targets dropped. */
+function buildOccurrences(
   live: ParsedWikiFile[],
   liveSlugs: Set<string>
-): Map<string, Set<string>> {
-  const out = new Map<string, Set<string>>();
+): Map<string, LinkOccurrence[]> {
+  const out = new Map<string, LinkOccurrence[]>();
   for (const file of live) {
     const slug = file.source.slug;
-    const targets = new Set<string>();
-    for (const target of extractInternalSlugs(file.body)) {
-      if (target === slug) {
-        continue;
-      }
-      if (!liveSlugs.has(target)) {
-        continue;
-      }
-      targets.add(target);
-    }
-    out.set(slug, targets);
+    out.set(
+      slug,
+      extractLinkOccurrences(file.body).filter(
+        (link) => link.slug !== slug && liveSlugs.has(link.slug)
+      )
+    );
   }
   return out;
+}
+
+/**
+ * Inbound citations per article, heaviest first: an article that links here
+ * four times outranks one that lists the slug in a table of contents. Ties
+ * break alphabetically so the manifest stays deterministic.
+ */
+function buildBacklinks(
+  occurrences: Map<string, LinkOccurrence[]>,
+  sortedSlugs: string[]
+): Record<string, BacklinkEdge[]> {
+  const backlinks: Record<string, BacklinkEdge[]> = {};
+  for (const slug of sortedSlugs) {
+    backlinks[slug] = [];
+  }
+  for (const [source, links] of occurrences) {
+    for (const link of links) {
+      backlinks[link.slug]?.push({
+        slug: source,
+        count: link.count,
+        ...(link.context === null ? {} : { context: link.context }),
+      });
+    }
+  }
+  for (const edges of Object.values(backlinks)) {
+    edges.sort((a, b) => b.count - a.count || a.slug.localeCompare(b.slug));
+  }
+  return backlinks;
 }
 
 function buildBacklinkSets(

--- a/apps/cli/src/import-wiki/wikilink.ts
+++ b/apps/cli/src/import-wiki/wikilink.ts
@@ -78,6 +78,82 @@ export function extractInternalSlugs(
   return slugs;
 }
 
+/**
+ * Below this, the citing line is a bare index entry (`- [[foo]]`, a MOC table
+ * row) with no prose worth quoting — the backlink shows the target's own
+ * description instead.
+ */
+const MIN_CONTEXT_CHARS = 60;
+const MAX_CONTEXT_CHARS = 160;
+
+const HEADING_MARKER_RE = /^#{1,6}\s+/;
+const LIST_MARKER_RE = /^[>\s]*(?:[-*+]|\d+\.)\s+/;
+const MD_LINK_RE = /\[([^\]]+)\]\([^)]*\)/g;
+const TABLE_CELL_RE = /\s*\\?\|\s*/g;
+const EMPHASIS_RE = /[*`]+/g;
+const TRIM_SEPARATORS_RE = /^[·\s]+|[·\s]+$/g;
+
+export interface LinkOccurrence {
+  /** The citing line as plain text, or null when it carries no real prose. */
+  context: string | null;
+  /** How many times this body links the target. */
+  count: number;
+  slug: string;
+}
+
+/**
+ * Internal links with their repeat count and the best line they appear in —
+ * one entry per distinct target. "Best" is the longest qualifying line, which
+ * favours prose over the bare list entries a target usually also appears in.
+ */
+export function extractLinkOccurrences(input: string): LinkOccurrence[] {
+  const byTarget = new Map<string, LinkOccurrence>();
+  for (const line of input.split("\n")) {
+    const slugs = extractInternalSlugs(line);
+    if (slugs.length === 0) {
+      continue;
+    }
+    const context = lineContext(line);
+    for (const slug of slugs) {
+      const existing = byTarget.get(slug);
+      if (!existing) {
+        byTarget.set(slug, { slug, count: 1, context });
+        continue;
+      }
+      existing.count += 1;
+      if (
+        context &&
+        (existing.context === null || context.length > existing.context.length)
+      ) {
+        existing.context = context;
+      }
+    }
+  }
+  return [...byTarget.values()];
+}
+
+function lineContext(line: string): string | null {
+  const text = stripToText(line)
+    .replace(HEADING_MARKER_RE, "")
+    .replace(LIST_MARKER_RE, "")
+    .replace(MD_LINK_RE, "$1")
+    .replace(TABLE_CELL_RE, " · ")
+    .replace(EMPHASIS_RE, "")
+    .replace(WHITESPACE_RE, " ")
+    .replace(TRIM_SEPARATORS_RE, "");
+  if (text.length < MIN_CONTEXT_CHARS) {
+    return null;
+  }
+  if (text.length <= MAX_CONTEXT_CHARS) {
+    return text;
+  }
+  const cut = text.slice(0, MAX_CONTEXT_CHARS);
+  const lastSpace = cut.lastIndexOf(" ");
+  const clipped =
+    lastSpace > MAX_CONTEXT_CHARS / 2 ? cut.slice(0, lastSpace) : cut;
+  return `${clipped.trimEnd()}…`;
+}
+
 /** Raw slugs (kind==="raw"), source order, ORIGINAL case + sub-paths. */
 export function extractRawSlugs(
   input: string,

--- a/packages/article-contract/src/manifests/graph.ts
+++ b/packages/article-contract/src/manifests/graph.ts
@@ -8,8 +8,33 @@ import { z } from "zod";
  */
 const slugList = z.array(z.string());
 
+const BacklinkEdgeObject = z.object({
+  /**
+   * The citing line as plain text, when the citation sits in prose. Absent for
+   * bare index entries (a MOC list item, a table row) — nothing worth quoting.
+   */
+  context: z.string().optional(),
+  /** How many times the citing article links here. Drives the sort order. */
+  count: z.number().int().positive(),
+  slug: z.string(),
+});
+
+export type BacklinkEdge = z.infer<typeof BacklinkEdgeObject>;
+
+/**
+ * Backlink entries, ranked by citation weight. Manifests written before the
+ * edges carried weight/context store a bare slug; those normalise to a single
+ * context-free citation so every reader sees one shape.
+ */
+const backlinkList = z.array(
+  z.union([
+    BacklinkEdgeObject,
+    z.string().transform((slug): BacklinkEdge => ({ count: 1, slug })),
+  ])
+);
+
 export const ArticleGraphSchema = z.object({
-  backlinks: z.record(z.string(), slugList),
+  backlinks: z.record(z.string(), backlinkList),
   generatedOn: z.string(),
   outgoing: z.record(z.string(), slugList),
   related: z.record(z.string(), slugList),


### PR DESCRIPTION
Stacked on #902 — review that one first; this branch only touches the link graph.

## Problem

`article-graph.json` stored `backlinks[slug]` as a bare alphabetical slug list. Across the committed corpus that is 275 nodes and 4,138 edges, median 13 backlinks per article, top article 79. So a well-cited page rendered "Cited by 79" as an unranked wall of titles, with no way to tell a paragraph of real discussion from a table-of-contents row.

The importer already parsed each link's line and repeat count, then discarded both.

## Change

Backlink entries become `{ slug, count, context? }`:

- **`count`** — how many times the citing article links here. Ranks the list heaviest-first; ties break alphabetically so the manifest stays deterministic.
- **`context`** — the citing line as plain text (wikilinks resolved to their display text, list/heading/table markers stripped, clipped at 160 chars on a word boundary). The blog quotes it in place of the target's own description. Lines under 60 chars carry no prose worth quoting — a MOC list item, a table row — and stay bare, so the description still shows.

`outgoing` and `related` are unchanged.

Read side: `ArticleLinkRow` renders the quote as a left-ruled italic line, plus a `×N` badge when an article cites more than once.

## Backwards compatibility

`ArticleGraphSchema` accepts both shapes and normalises a bare slug to `{ slug, count: 1 }`. **The committed `article-graph.json` is still in the old shape and stays that way until someone runs `bun run import:wiki` against the vault** — which I could not do here, the vault is not on this machine. Until then the blog renders exactly as before (no ranking, no quotes), just via the normalised path.

## Measured, not estimated

I reconstructed vault-syntax bodies from the 275 committed MDX articles (`[label](/articles/slug)` → `[[slug|label]]`) and ran `buildArticleGraph` over them:

| | |
|---|---|
| edges | 4,138 |
| with prose context | 4,011 (97%) |
| repeat citations (count > 1) | 1,854 (45%), max 13 |
| manifest size | 355 KB → ~983 KB |

The manifest is a build-time, `server-only` import, so the growth costs nothing on the client — it is git churn per import.

Sample of the real output for `claude-code`:

```
anthropic ×7
  2026-06-16 — Anthropic Economic Research published Agentic coding and persistent
  returns to expertise (Hitzig, Massenkoff, Lyubich, Heller, McCrory): a…
boris-cherny ×6
  Creator and tech lead of Claude Code at Anthropic. Engineer-by-background,
  author of Programming TypeScript. Joined Anthropic late 2024 via…
```

## Verification

Run this session: `bun run lint`, `bun run type-check`, `bun run test` (470 CLI + 218 blog, 0 fail), and `bun run content:check` against the **existing old-shape manifest** — PASS, 0 failures, 2 pre-existing warnings. New tests cover weight ranking, prose-vs-bare context selection, the legacy-shape normalisation, and the three render paths.

Not run: `bun run import:wiki` (no vault on this machine), so the regenerated manifest is not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019LFKT1JKA26HkKrLasHkVh
