### PR TITLE
🐛 fix(blog): keep the shelf domain filter inside the page

### DIFF
--- a/apps/blog/src/app/(blog)/shelf/shelf-tabs.tsx
+++ b/apps/blog/src/app/(blog)/shelf/shelf-tabs.tsx
@@ -495,9 +495,11 @@ export function ShelfTabs({ manifest }: { manifest: ShelfManifestEntry[] }) {
               ))}
             </fieldset>
           </div>
+          {/* min-w-0 beats the UA `fieldset { min-inline-size: min-content }`,
+              without which the chips widen the box instead of scrolling in it. */}
           <fieldset
             aria-label="Filter by domain"
-            className="flex gap-2 overflow-x-auto pb-3"
+            className="flex min-w-0 gap-2 overflow-x-auto pb-3"
           >
             <button
               aria-pressed={domain === null}


### PR DESCRIPTION
## What

The `/shelf` domain filter chip bar overflowed the page: at 15 domains the chips ran off the right edge and the whole document picked up a horizontal scrollbar.

## Why

The bar is a `<fieldset>`, and the UA stylesheet applies `min-inline-size: min-content` to fieldsets. With `shrink-0` nowrap chips inside, min-content is the full chip row — so the box itself grew to 2856px and `overflow-x-auto` had nothing left to clip. `min-w-0` overrides it, matching the pattern the `/questions` filter bars already use.

## Verification

Headless Chrome at 1440px against a shelf seeded with 15 reads across 15 domains:

| | before | after |
|---|---|---|
| filter `clientWidth` | 2856px | 976px |
| filter `scrollWidth` | 2856px | 2856px (scrolls in place) |
| document `scrollWidth` | 3088px | 1440px |
| page overflows | yes | no |

Also green: `bun run type-check`, `bun test src/__tests__/shelf` (47 pass), `ultracite check`.

Row-level subject tag chips are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MhXu72TBy389zTxpPaq38v