### PR TITLE
💄 fix(blog): cap the desk at 24 sources and collapse long author lists

### DIFF
--- a/apps/blog/src/__tests__/components/desk.test.ts
+++ b/apps/blog/src/__tests__/components/desk.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "bun:test";
+import { formatAuthors } from "@/app/(blog)/desk";
+
+describe("formatAuthors", () => {
+  it("leaves a single author alone", () => {
+    expect(formatAuthors("Anthropic")).toBe("Anthropic");
+  });
+
+  it("keeps both names for a pair", () => {
+    expect(formatAuthors("Yuchen Zeng, Dimitris Papailiopoulos")).toBe(
+      "Yuchen Zeng & Dimitris Papailiopoulos"
+    );
+  });
+
+  it("collapses three or more to et al.", () => {
+    expect(formatAuthors("Guangzhi Sun, Xiao Zhan, Mark Gales")).toBe(
+      "Guangzhi Sun et al."
+    );
+  });
+
+  it("ignores commas inside parentheses", () => {
+    expect(
+      formatAuthors("Lenny's Podcast (Lenny Rachitsky, with guest Cat Wu)")
+    ).toBe("Lenny's Podcast (Lenny Rachitsky, with guest Cat Wu)");
+  });
+
+  it("splits on a top-level comma even when an aside follows", () => {
+    expect(
+      formatAuthors("Tim Genewein, Matija Franklin, Shane Legg (DeepMind)")
+    ).toBe("Tim Genewein et al.");
+  });
+});

--- a/apps/blog/src/app/(blog)/desk.tsx
+++ b/apps/blog/src/app/(blog)/desk.tsx
@@ -8,11 +8,51 @@ interface DeskProps {
 
 const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
+/** How many sources the homepage shows. The rest are counted, not listed. */
+const DESK_LIMIT = 24;
+
 function formatWhen(published: string | undefined): string | null {
   if (!published) {
     return null;
   }
   return ISO_DATE_RE.test(published) ? formatDateShort(published) : published;
+}
+
+/**
+ * Split an author credit on commas at paren depth 0, so a parenthesised aside
+ * ("Lenny's Podcast (Lenny Rachitsky, with guest Cat Wu)") stays one name.
+ */
+function splitAuthors(author: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < author.length; i++) {
+    const char = author[i];
+    if (char === "(") {
+      depth++;
+    } else if (char === ")") {
+      depth = Math.max(0, depth - 1);
+    } else if (char === "," && depth === 0) {
+      parts.push(author.slice(start, i).trim());
+      start = i + 1;
+    }
+  }
+  parts.push(author.slice(start).trim());
+  return parts.filter(Boolean);
+}
+
+/**
+ * Papers here run to 20+ credited authors (544 chars at the extreme), which
+ * blows a row out to a dozen lines. Keep both names for a pair, `et al.` beyond.
+ */
+export function formatAuthors(author: string): string {
+  const names = splitAuthors(author);
+  if (names.length <= 1) {
+    return author;
+  }
+  return names.length === 2
+    ? `${names[0]} & ${names[1]}`
+    : `${names[0]} et al.`;
 }
 
 /**
@@ -28,6 +68,8 @@ export function Desk({ sources }: DeskProps) {
     acc[s.kind] = (acc[s.kind] ?? 0) + 1;
     return acc;
   }, {});
+
+  const shown = sources.slice(0, DESK_LIMIT);
 
   return (
     <section className="border-border border-b px-gutter py-10">
@@ -49,11 +91,19 @@ export function Desk({ sources }: DeskProps) {
                 <dd className="m-0 text-muted-foreground">{n}</dd>
               </div>
             ))}
+            {sources.length > shown.length && (
+              <div className="contents">
+                <dt>Shown</dt>
+                <dd className="m-0 text-muted-foreground">
+                  {shown.length} / {sources.length}
+                </dd>
+              </div>
+            )}
           </dl>
         </div>
 
         <ul className="m-0 grid list-none grid-cols-1 gap-x-6 gap-y-0 p-0 sm:grid-cols-2 lg:grid-cols-3">
-          {sources.map((source) => {
+          {shown.map((source) => {
             const when = formatWhen(source.published);
             return (
               <li
@@ -83,7 +133,7 @@ export function Desk({ sources }: DeskProps) {
                 </div>
                 {source.author && (
                   <div className="mt-0.5 font-body text-[12.5px] text-foreground-subtle italic">
-                    {source.author}
+                    {formatAuthors(source.author)}
                   </div>
                 )}
               </li>


### PR DESCRIPTION
Stacked on #906 — review that one first; this PR's diff is one component plus a test.

## Problem

The wiki import in #906 takes `wiki-sources.json` from 76 to 160 entries, and the homepage desk renders every one of them in a flat three-column list. Two things break:

- **Unbounded list.** 160 rows at the bottom of the homepage, with no cap and no route to send them to.
- **Author overflow.** Papers credit up to 20 authors — 544 chars at the extreme — printed raw in italic, so one row spans a dozen lines and destroys the grid rhythm.

Both are visible on the #906 preview: https://howardism-git-worktree-wiki-import-howard-tais-projects.vercel.app

## Change

- Show the **24 most-cited** sources (38% of all citations in the corpus; the manifest is already ranked by citation count). The remaining 136 are counted, not listed — a `Shown 24 / 160` row joins the existing per-kind `dl` in the sidebar.
- Collapse author credits: `A & B` for a pair, `A et al.` for three or more. Splitting happens only on commas at **paren depth 0**, so a parenthesised aside like `Lenny's Podcast (Lenny Rachitsky, with guest Cat Wu)` survives intact rather than truncating mid-parenthesis.

No new route, no nav entry, no change to the manifest or the importer.

## Verification

Run this session:

- `bun test` in `apps/blog` — 241 pass, 0 fail, including 5 new cases covering the author-splitting edge cases (single, pair, 3+, comma-in-parens, aside-after-top-level-comma).
- `bun run type-check` — clean.
- `bun x ultracite check` on both changed files — clean.
- Rendered `Desk` against the real 160-source manifest in a throwaway test: **24 rows emitted, longest rendered author string 62 chars** (was 544). Removed the throwaway before committing.

Not run: a production `next build`, and no visual check of a deployed preview for this branch.

## Follow-up

If the full source list is worth browsing, a `/desk` route (Plate V) grouped by kind is the natural next step — deliberately skipped here as YAGNI until the cap actually feels limiting.
