### PR TITLE
wiki importer reads the vault's frontmatter instead of its generated digests

### DIFF
--- a/apps/cli/src/__tests__/domains.test.ts
+++ b/apps/cli/src/__tests__/domains.test.ts
@@ -9,6 +9,7 @@ import {
 import type { ParsedWikiFile } from "../import-wiki/parse.ts";
 
 const UNKNOWN_MOC_ERROR = /moc-nonsense/;
+const UNKNOWN_DOMAIN_ERROR = /nonsense-domain/;
 
 function moc(slug: string, body: string): ParsedWikiFile {
   return {
@@ -68,5 +69,23 @@ describe("buildDomainMembership + resolveDomain", () => {
     expect(() =>
       buildDomainMembership([moc("moc-nonsense", "- [[blast-radius]]\n")])
     ).toThrow(UNKNOWN_MOC_ERROR);
+  });
+
+  it("prefers a valid frontmatter domain over MOC membership", () => {
+    expect(resolveDomain("agent-loop-pattern", membership, "formal-math")).toBe(
+      "formal-math"
+    );
+  });
+
+  it("falls back to MOC membership when frontmatter domain is absent", () => {
+    expect(resolveDomain("agent-loop-pattern", membership, undefined)).toBe(
+      "agent-systems"
+    );
+  });
+
+  it("throws on an unrecognised frontmatter domain", () => {
+    expect(() =>
+      resolveDomain("agent-loop-pattern", membership, "nonsense-domain")
+    ).toThrow(UNKNOWN_DOMAIN_ERROR);
   });
 });

--- a/apps/cli/src/__tests__/entity-types.test.ts
+++ b/apps/cli/src/__tests__/entity-types.test.ts
@@ -3,10 +3,12 @@ import { describe, expect, it } from "bun:test";
 import {
   buildEntityTypeMembership,
   isEntityNote,
+  resolveEntityType,
 } from "../import-wiki/entity-types.ts";
 import type { ParsedWikiFile } from "../import-wiki/parse.ts";
 
 const UNKNOWN_HEADING_ERROR = /Nonsense/;
+const UNKNOWN_KIND_ERROR = /nonsense-kind/;
 
 function moc(body: string): ParsedWikiFile {
   return {
@@ -57,5 +59,33 @@ describe("isEntityNote", () => {
   it("is false when neither signal is present", () => {
     expect(isEntityNote("derived", false)).toBe(false);
     expect(isEntityNote(undefined, false)).toBe(false);
+  });
+});
+
+describe("resolveEntityType", () => {
+  const membership = new Map([["andrej-karpathy", "person" as const]]);
+
+  it("prefers a valid frontmatter kind over MOC membership", () => {
+    expect(
+      resolveEntityType("andrej-karpathy", membership, "organization")
+    ).toBe("organization");
+  });
+
+  it("falls back to MOC membership when frontmatter kind is absent", () => {
+    expect(resolveEntityType("andrej-karpathy", membership, undefined)).toBe(
+      "person"
+    );
+  });
+
+  it("returns undefined when neither frontmatter kind nor membership has it", () => {
+    expect(
+      resolveEntityType("unknown-slug", membership, undefined)
+    ).toBeUndefined();
+  });
+
+  it("throws on an unrecognised frontmatter kind", () => {
+    expect(() =>
+      resolveEntityType("andrej-karpathy", membership, "nonsense-kind")
+    ).toThrow(UNKNOWN_KIND_ERROR);
   });
 });

--- a/apps/cli/src/__tests__/entity-types.test.ts
+++ b/apps/cli/src/__tests__/entity-types.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "bun:test";
 
-import { buildEntityTypeMembership } from "../import-wiki/entity-types.ts";
+import {
+  buildEntityTypeMembership,
+  isEntityNote,
+} from "../import-wiki/entity-types.ts";
 import type { ParsedWikiFile } from "../import-wiki/parse.ts";
 
 const UNKNOWN_HEADING_ERROR = /Nonsense/;
@@ -39,5 +42,20 @@ describe("buildEntityTypeMembership", () => {
     expect(() =>
       buildEntityTypeMembership([moc("### Nonsense\n- [[blast-radius]]\n")])
     ).toThrow(UNKNOWN_HEADING_ERROR);
+  });
+});
+
+describe("isEntityNote", () => {
+  it("is true when frontmatter type is entity", () => {
+    expect(isEntityNote("entity", false)).toBe(true);
+  });
+
+  it("is true when the legacy inline marker is present", () => {
+    expect(isEntityNote(undefined, true)).toBe(true);
+  });
+
+  it("is false when neither signal is present", () => {
+    expect(isEntityNote("derived", false)).toBe(false);
+    expect(isEntityNote(undefined, false)).toBe(false);
   });
 });

--- a/apps/cli/src/__tests__/parse.test.ts
+++ b/apps/cli/src/__tests__/parse.test.ts
@@ -85,6 +85,33 @@ describe("parseWikiFile", () => {
     expect(parsed.body).toContain("Body content.");
   });
 
+  it("parses `summary`, `domain`, `kind`, and `date` frontmatter", async () => {
+    const content = [
+      "---",
+      'title: "Andrej Karpathy"',
+      "type: entity",
+      "kind: person",
+      "domain: agent-systems",
+      'summary: "Founding member of OpenAI and former Tesla AI lead."',
+      "date: 2026-05-06",
+      "---",
+      "",
+      "Body content.",
+    ].join("\n");
+    const path = await tempFile(content, "andrej-karpathy.md");
+    const parsed = await parseWikiFile({
+      slug: "andrej-karpathy",
+      folder: "concepts",
+      absolutePath: path,
+    });
+    expect(parsed.frontmatter.summary).toBe(
+      "Founding member of OpenAI and former Tesla AI lead."
+    );
+    expect(parsed.frontmatter.domain).toBe("agent-systems");
+    expect(parsed.frontmatter.kind).toBe("person");
+    expect(parsed.frontmatter.date).toBe("2026-05-06");
+  });
+
   it("drops a boolean `generated` flag so resolveDate falls back", async () => {
     const content = [
       "---",
@@ -122,6 +149,13 @@ describe("resolveDate", () => {
     };
   }
 
+  function derivedFixture(overrides: Partial<ParsedWikiFile>): ParsedWikiFile {
+    return fixture({
+      source: { slug: "x", folder: "derived", absolutePath: "/tmp/x.md" },
+      ...overrides,
+    });
+  }
+
   it("prefers `created` for concepts", () => {
     const date = resolveDate(
       fixture({
@@ -131,18 +165,45 @@ describe("resolveDate", () => {
     expect(date).toBe("2026-05-06");
   });
 
-  it("prefers `generated` for derived", () => {
+  it("does not consult `date` for concepts", () => {
     const date = resolveDate(
       fixture({
-        source: {
-          slug: "x",
-          folder: "derived",
-          absolutePath: "/tmp/x.md",
+        frontmatter: { date: "2026-01-01", created: "2026-05-06" },
+      })
+    );
+    expect(date).toBe("2026-05-06");
+  });
+
+  it("prefers `date` for derived", () => {
+    const date = resolveDate(
+      derivedFixture({
+        frontmatter: {
+          date: "2026-04-01",
+          generated: "2026-04-10",
+          created: "2026-03-01",
+          updated: "2026-04-15",
         },
+      })
+    );
+    expect(date).toBe("2026-04-01");
+  });
+
+  it("falls back to `generated` for derived when `date` is missing", () => {
+    const date = resolveDate(
+      derivedFixture({
         frontmatter: { generated: "2026-04-10", updated: "2026-04-15" },
       })
     );
     expect(date).toBe("2026-04-10");
+  });
+
+  it("falls back to `created` for derived when `date`/`generated` are missing", () => {
+    const date = resolveDate(
+      derivedFixture({
+        frontmatter: { created: "2026-03-01", updated: "2026-04-15" },
+      })
+    );
+    expect(date).toBe("2026-03-01");
   });
 
   it("falls back to `updated` when primary is missing", () => {

--- a/apps/cli/src/import-wiki/domains.ts
+++ b/apps/cli/src/import-wiki/domains.ts
@@ -85,12 +85,33 @@ export function buildDomainMembership(
 
 /**
  * Resolve a single note's domain. A MOC page belongs to its own domain; a
- * concept/entity inherits the domain of the MOC that lists it; everything else
- * (derived essays, unlisted concepts) falls back to `syntheses`.
+ * valid frontmatter `domain:` wins next; otherwise a concept/entity inherits
+ * the domain of the MOC that lists it; everything else (derived essays,
+ * unlisted concepts) falls back to `syntheses`.
+ *
+ * Throws on an unrecognised `domain:` value — same reasoning as
+ * `buildDomainMembership`'s `unknownMocs` guard.
  */
 export function resolveDomain(
   slug: string,
-  membership: ReadonlyMap<string, WikiDomain>
+  membership: ReadonlyMap<string, WikiDomain>,
+  frontmatterDomain?: string
 ): WikiDomain {
-  return mocSlugToDomain(slug) ?? membership.get(slug) ?? FALLBACK_DOMAIN;
+  const mocDomain = mocSlugToDomain(slug);
+  if (mocDomain) {
+    return mocDomain;
+  }
+  if (frontmatterDomain) {
+    if (!DOMAIN_SET.has(frontmatterDomain)) {
+      throw new Error(
+        `"${slug}" has domain: "${frontmatterDomain}", which isn't a known domain.\n` +
+          "The vault's domain taxonomy has drifted from the code. Add it to:\n" +
+          "  1. WIKI_DOMAINS   packages/article-contract/src/index.ts\n" +
+          "  2. DOMAIN_META    apps/blog/src/app/(blog)/articles/domain-meta.ts\n" +
+          "  3. --domain-<slug> (light + dark) packages/ui/src/styles/globals.css"
+      );
+    }
+    return frontmatterDomain as WikiDomain;
+  }
+  return membership.get(slug) ?? FALLBACK_DOMAIN;
 }

--- a/apps/cli/src/import-wiki/entity-types.ts
+++ b/apps/cli/src/import-wiki/entity-types.ts
@@ -87,3 +87,15 @@ export function buildEntityTypeMembership(
 
   return membership;
 }
+
+/**
+ * Is this note an Entity? The vault now sets `type: entity` in frontmatter;
+ * the old `_Entity._`/`*Entity.*` inline marker still lingers on a handful of
+ * pages, so either signal counts.
+ */
+export function isEntityNote(
+  frontmatterType: string | undefined,
+  hasEntityMarker: boolean
+): boolean {
+  return frontmatterType === "entity" || hasEntityMarker;
+}

--- a/apps/cli/src/import-wiki/entity-types.ts
+++ b/apps/cli/src/import-wiki/entity-types.ts
@@ -10,13 +10,14 @@
  * `EntityType` union and `ENTITY_TYPES` array. This file owns only the
  * derivation logic that maps entity slugs → types.
  */
-import type { EntityType } from "@howardism/article-contract";
+import { ENTITY_TYPES, type EntityType } from "@howardism/article-contract";
 
 import type { ParsedWikiFile } from "./parse.ts";
 import { extractInternalSlugs } from "./wikilink.ts";
 
 const ENTITIES_MOC_SLUG = "moc-entities";
 const SECTION_HEADING_RE = /^###\s+(.+)$/gm;
+const ENTITY_TYPE_SET: ReadonlySet<string> = new Set(ENTITY_TYPES);
 
 /** `### <Heading>` text -> `EntityType`, sourced from `moc-entities.md`. */
 const HEADING_TO_ENTITY_TYPE: Record<string, EntityType> = {
@@ -98,4 +99,31 @@ export function isEntityNote(
   hasEntityMarker: boolean
 ): boolean {
   return frontmatterType === "entity" || hasEntityMarker;
+}
+
+/**
+ * Resolve a single entity's type: a valid frontmatter `kind:` wins over
+ * `moc-entities.md` section membership, which remains the fallback for the
+ * pages that don't set it yet.
+ *
+ * Throws on an unrecognised `kind:` value — same reasoning as
+ * `buildEntityTypeMembership`'s `unknownHeadings` guard.
+ */
+export function resolveEntityType(
+  slug: string,
+  membership: ReadonlyMap<string, EntityType>,
+  frontmatterKind: string | undefined
+): EntityType | undefined {
+  if (frontmatterKind) {
+    if (!ENTITY_TYPE_SET.has(frontmatterKind)) {
+      throw new Error(
+        `"${slug}" has kind: "${frontmatterKind}", which isn't a known entity type.\n` +
+          "The vault's entity-type taxonomy has drifted from the code. Add it to:\n" +
+          "  1. ENTITY_TYPES           packages/article-contract/src/index.ts\n" +
+          "  2. HEADING_TO_ENTITY_TYPE apps/cli/src/import-wiki/entity-types.ts"
+      );
+    }
+    return frontmatterKind as EntityType;
+  }
+  return membership.get(slug);
 }

--- a/apps/cli/src/import-wiki/index.ts
+++ b/apps/cli/src/import-wiki/index.ts
@@ -310,8 +310,11 @@ async function processArticle(
   const mocDescription = isMocSlug(slug)
     ? stripWikilinksToText(firstBlockquote(parsed.body))
     : "";
+  const frontmatterSummary = frontmatter.summary?.trim();
+  const indexSummary = ctx.indexSummaries.get(slug);
   const rawDescription =
-    ctx.indexSummaries.get(slug) ||
+    frontmatterSummary ||
+    indexSummary ||
     mocDescription ||
     stripWikilinksToText(firstParagraph(parsed.body));
   const explicitOverride = ctx.overrides[slug];

--- a/apps/cli/src/import-wiki/index.ts
+++ b/apps/cli/src/import-wiki/index.ts
@@ -20,7 +20,11 @@ import {
   resolveDomain,
 } from "./domains.ts";
 import { type ArticleMeta, emitArticle } from "./emit.ts";
-import { buildEntityTypeMembership, isEntityNote } from "./entity-types.ts";
+import {
+  buildEntityTypeMembership,
+  isEntityNote,
+  resolveEntityType,
+} from "./entity-types.ts";
 import { buildManifests, writeManifests } from "./pages/manifests.ts";
 import {
   buildSlugTitleMap,
@@ -69,6 +73,10 @@ interface RunOptions {
 
 interface ImportSummary {
   articlesWritten: string[];
+  /** Slugs whose frontmatter `domain:` disagrees with their MOC membership. */
+  domainDisagreements: Map<string, { frontmatter: string; moc: string }>;
+  /** Slugs whose frontmatter `kind:` disagrees with `moc-entities.md`. */
+  entityTypeDisagreements: Map<string, { frontmatter: string; moc: string }>;
   graphPath: string | null;
   imagesCached: string[];
   imagesGenerated: string[];
@@ -247,6 +255,8 @@ async function buildImportContext(opts: RunOptions): Promise<ImportContext> {
 function createSummary(): ImportSummary {
   return {
     articlesWritten: [],
+    domainDisagreements: new Map(),
+    entityTypeDisagreements: new Map(),
     graphPath: null,
     imagesGenerated: [],
     imagesCached: [],
@@ -338,18 +348,43 @@ async function processArticle(
 
   const tags = normaliseTags(frontmatter.tags);
 
-  const domain = resolveDomain(slug, ctx.domainMembership);
+  // `syntheses` is a blog-side browse axis for essays, not a vault fact. The
+  // vault now files derived notes under a topical `domain:` as well, and
+  // adopting it here would refile all 38 essays and empty the axis — so
+  // concepts take their frontmatter domain, essays keep the fallback.
+  const frontmatterDomain =
+    source.folder === "derived" ? undefined : frontmatter.domain;
+  const domain = resolveDomain(slug, ctx.domainMembership, frontmatterDomain);
+  const mocDomain = ctx.domainMembership.get(slug);
+  if (frontmatterDomain && mocDomain && frontmatterDomain !== mocDomain) {
+    summary.domainDisagreements.set(slug, {
+      frontmatter: frontmatterDomain,
+      moc: mocDomain,
+    });
+  }
   // A concept the vault forgot to file under any MOC lands in `syntheses` by
   // fallback — flag it so the author can curate it into the right domain.
   if (
     source.folder === "concepts" &&
     !isMocSlug(slug) &&
-    !ctx.domainMembership.has(slug)
+    !ctx.domainMembership.has(slug) &&
+    !frontmatterDomain
   ) {
     summary.unmappedConcepts.add(slug);
   }
 
-  const entityType = ctx.entityTypeMembership.get(slug);
+  const entityType = resolveEntityType(
+    slug,
+    ctx.entityTypeMembership,
+    frontmatter.kind
+  );
+  const mocEntityType = ctx.entityTypeMembership.get(slug);
+  if (frontmatter.kind && mocEntityType && frontmatter.kind !== mocEntityType) {
+    summary.entityTypeDisagreements.set(slug, {
+      frontmatter: frontmatter.kind,
+      moc: mocEntityType,
+    });
+  }
 
   const meta: ArticleMeta = {
     date: resolveDate(parsed),
@@ -661,6 +696,25 @@ function printSummary(summary: ImportSummary): void {
     );
     for (const [slug, targets] of summary.missingRawSources) {
       console.log(`  ${slug} -> ${[...targets].join(", ")}`);
+    }
+  }
+  if (summary.domainDisagreements.size > 0) {
+    console.log(
+      "\nFrontmatter `domain:` disagrees with MOC membership (frontmatter wins):"
+    );
+    for (const [slug, { frontmatter, moc }] of summary.domainDisagreements) {
+      console.log(`  ${slug}: frontmatter=${frontmatter} moc=${moc}`);
+    }
+  }
+  if (summary.entityTypeDisagreements.size > 0) {
+    console.log(
+      "\nFrontmatter `kind:` disagrees with moc-entities.md (frontmatter wins):"
+    );
+    for (const [
+      slug,
+      { frontmatter, moc },
+    ] of summary.entityTypeDisagreements) {
+      console.log(`  ${slug}: frontmatter=${frontmatter} moc=${moc}`);
     }
   }
 }

--- a/apps/cli/src/import-wiki/index.ts
+++ b/apps/cli/src/import-wiki/index.ts
@@ -77,6 +77,12 @@ interface ImportSummary {
   domainDisagreements: Map<string, { frontmatter: string; moc: string }>;
   /** Slugs whose frontmatter `kind:` disagrees with `moc-entities.md`. */
   entityTypeDisagreements: Map<string, { frontmatter: string; moc: string }>;
+  /**
+   * Slugs whose description came from the first-paragraph fallback only — no
+   * `summary:` frontmatter, no index.md entry, no MOC blockquote. A spike
+   * here means a vault digest/frontmatter source went missing on import.
+   */
+  fallbackDescriptions: string[];
   graphPath: string | null;
   imagesCached: string[];
   imagesGenerated: string[];
@@ -193,6 +199,23 @@ async function main(): Promise<void> {
   }
 
   printSummary(summary);
+
+  // This failure class — the vault regenerates a digest/frontmatter source
+  // and the importer silently degrades to the first-paragraph heuristic —
+  // has hit three times. A `--only` re-import of a single article is exempt;
+  // it can't move the corpus-wide ratio anyway.
+  if (!opts.onlySlug && toEmit.length > 0) {
+    const fallbackRatio = summary.fallbackDescriptions.length / toEmit.length;
+    if (fallbackRatio > 0.1) {
+      const examples = summary.fallbackDescriptions.slice(0, 5).join(", ");
+      throw new Error(
+        `${summary.fallbackDescriptions.length}/${toEmit.length} article descriptions ` +
+          `(${Math.round(fallbackRatio * 100)}%) fell back to the first-paragraph ` +
+          "heuristic — likely vault frontmatter/digest drift (missing `summary:` " +
+          `frontmatter or index.md entries). Examples: ${examples}`
+      );
+    }
+  }
 }
 
 interface ImportContext {
@@ -257,6 +280,7 @@ function createSummary(): ImportSummary {
     articlesWritten: [],
     domainDisagreements: new Map(),
     entityTypeDisagreements: new Map(),
+    fallbackDescriptions: [],
     graphPath: null,
     imagesGenerated: [],
     imagesCached: [],
@@ -327,6 +351,9 @@ async function processArticle(
     indexSummary ||
     mocDescription ||
     stripWikilinksToText(firstParagraph(parsed.body));
+  if (!(frontmatterSummary || indexSummary || mocDescription)) {
+    summary.fallbackDescriptions.push(slug);
+  }
   const explicitOverride = ctx.overrides[slug];
   const defaultTag: WikiTag =
     source.folder === "concepts" ? "Concept" : "Essay";
@@ -660,6 +687,9 @@ async function assertExists(path: string, label: string): Promise<void> {
 function printSummary(summary: ImportSummary): void {
   console.log("\n=== Import summary ===");
   console.log(`Articles written: ${summary.articlesWritten.length}`);
+  console.log(
+    `Descriptions from first-paragraph fallback: ${summary.fallbackDescriptions.length}`
+  );
   console.log(`Images generated: ${summary.imagesGenerated.length}`);
   console.log(`Images cached:    ${summary.imagesCached.length}`);
   if (summary.graphPath) {

--- a/apps/cli/src/import-wiki/index.ts
+++ b/apps/cli/src/import-wiki/index.ts
@@ -20,7 +20,7 @@ import {
   resolveDomain,
 } from "./domains.ts";
 import { type ArticleMeta, emitArticle } from "./emit.ts";
-import { buildEntityTypeMembership } from "./entity-types.ts";
+import { buildEntityTypeMembership, isEntityNote } from "./entity-types.ts";
 import { buildManifests, writeManifests } from "./pages/manifests.ts";
 import {
   buildSlugTitleMap,
@@ -321,11 +321,14 @@ async function processArticle(
   const defaultTag: WikiTag =
     source.folder === "concepts" ? "Concept" : "Essay";
 
-  // Always strip the editorial `_Entity._` marker. If the article is otherwise
-  // a default-tagged Concept (no explicit override), promote it to Entity.
-  // An explicit override wins over everything — that's the manual escape hatch.
-  const { description: cleanedDescription, isEntity } =
+  // Always strip the editorial `_Entity._` marker (it also drives the legacy
+  // fallback signal); frontmatter `type: entity` is the primary signal now.
+  // If the article is otherwise a default-tagged Concept (no explicit
+  // override), promote it to Entity. An explicit override wins over
+  // everything — that's the manual escape hatch.
+  const { description: cleanedDescription, isEntity: hasEntityMarker } =
     detectEntityPrefix(rawDescription);
+  const isEntity = isEntityNote(frontmatter.type, hasEntityMarker);
   const tag = resolveTag({
     explicitOverride,
     isIndexPage,

--- a/apps/cli/src/import-wiki/parse.ts
+++ b/apps/cli/src/import-wiki/parse.ts
@@ -27,6 +27,7 @@ export interface WikiFrontmatter {
    */
   archived?: boolean;
   created?: string;
+  date?: string;
   domain?: string;
   generated?: string;
   kind?: string;
@@ -115,7 +116,7 @@ export async function parseWikiFile(
 
 function normaliseFrontmatter(data: Record<string, unknown>): WikiFrontmatter {
   const result: Record<string, unknown> = { ...data };
-  for (const key of ["created", "updated", "generated"] as const) {
+  for (const key of ["created", "updated", "generated", "date"] as const) {
     const value = result[key];
     if (value instanceof Date) {
       result[key] = value.toISOString().slice(0, 10);
@@ -341,14 +342,18 @@ export function normaliseTags(tags: readonly string[] | undefined): string[] {
 /**
  * Resolve the article's publish date:
  *   concepts → created → updated → mtime
- *   derived  → generated → updated → mtime
+ *   derived  → date → generated → created → updated → mtime
  * Always `YYYY-MM-DD`.
  */
 export function resolveDate(file: ParsedWikiFile): string {
   const { frontmatter, source, mtime } = file;
-  const primary =
-    source.folder === "concepts" ? frontmatter.created : frontmatter.generated;
-  const candidate = primary ?? frontmatter.updated;
+  const candidate =
+    source.folder === "concepts"
+      ? (frontmatter.created ?? frontmatter.updated)
+      : (frontmatter.date ??
+        frontmatter.generated ??
+        frontmatter.created ??
+        frontmatter.updated);
   if (candidate) {
     return normaliseDate(candidate);
   }

--- a/apps/cli/src/import-wiki/parse.ts
+++ b/apps/cli/src/import-wiki/parse.ts
@@ -27,7 +27,9 @@ export interface WikiFrontmatter {
    */
   archived?: boolean;
   created?: string;
+  domain?: string;
   generated?: string;
+  kind?: string;
   question?: string;
   sources?: string[];
   summary?: string;

--- a/apps/cli/src/import-wiki/parse.ts
+++ b/apps/cli/src/import-wiki/parse.ts
@@ -30,6 +30,7 @@ export interface WikiFrontmatter {
   generated?: string;
   question?: string;
   sources?: string[];
+  summary?: string;
   tags?: string[];
   title?: string;
   type?: string;


### PR DESCRIPTION
## Background

The Obsidian wiki vault this importer reads has moved its metadata out of generated digests and into first-class note frontmatter — `summary` on 353 of 368 notes, `domain` 281, `type` 125, `kind` 72, `date` 38 — and reformatted `index.md`'s Concepts tables into plain bullet lists. The importer was still scraping the digests, so it degraded silently. This change makes it read the frontmatter, keeping the digest scraping as a fallback.

This is the third time a vault regeneration has silently gutted importer output — that is what the description-coverage tripwire (last commit) exists to catch.

## Commits

1. Description from the vault's `summary:` frontmatter — fixes 305 regressed descriptions.
2. Entity tag from `type: entity` — fixes 69 articles that would have silently become `Concept`.
3. `domain`/`entityType` from frontmatter with MOC scraping as fallback, disagreements reported. Derived essays deliberately keep the `syntheses` fallback.
4. Derived publish date from `date:`/`created:` instead of the churning `updated:`.
5. Description-coverage tripwire: count first-paragraph fallbacks, print the count, throw above 10%.

## Verification

- `bun run lint`, `bun run type-check`, `bun test` in `apps/cli`: clean; 498 pass / 0 fail.
- Live-vault import into isolated output directories (`WIKI_PATH` pointed at the real vault, `SKIP_IMAGES=1`), then a frontmatter diff of the 373 generated articles against the 349 committed ones: `tag` differences 69 → 0; `domain` differences 0 (`syntheses` stays at 40 articles); `description` differences 305 → 52 (genuine vault edits since the 2026-08-04 import, plus the 15 notes with no `summary:`); 21 `date` changes, all on derived essays. `readingTime`/`sources` differences are unrelated content drift.
- Repo-root build and `content:check` were NOT run. No committed article or manifest is touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
