### PR TITLE
⚡️ perf(tooling): parallelize independent type checks

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -12,7 +12,6 @@
       "inputs": ["$TURBO_DEFAULT$", "biome.json", "../../biome.json"]
     },
     "type-check": {
-      "dependsOn": ["^type-check"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "tsconfig.json",


### PR DESCRIPTION
## What changed

Remove Turbo's topological `^type-check` dependency so the four independent `tsc --noEmit` tasks can run concurrently.

## Evidence

Representative command:

```sh
bunx turbo run type-check --force --output-logs=none
```

On the same Apple arm64 worktree with Bun 1.3.14, Turbo 2.9.14, and 10 serial samples after one warm-up:

| State | Median | Range |
|---|---:|---:|
| Baseline | 1.802 s | 1.714–2.455 s |
| Candidate | 1.134 s | 1.098–1.173 s |

The candidate was **37.1% faster** (bootstrap 95% CI: 35.8–43.9%). Under `--concurrency=2`, the result was neutral/inconclusive (0.5%, CI -3.1–5.0%) and did not breach the 3% regression guard.

This is a bounded claim for forced local monorepo type-check wall time only; it is not a claim about cached CI, CPU/RSS, build time, or website runtime.

## Correctness

The dry graph retains the same four executable tasks—article-contract, blog, CLI, and UI—and each still runs `tsc --noEmit`; only dependency ordering changes. No package uses TypeScript project references or consumes generated type-check artifacts.

- `bun run type-check`
- `bun run test` (241 blog + 484 CLI tests)
- `bun run lint`
- pre-push `turbo run lint type-check test` (8/8 tasks)
- `git diff --check`
