### PR TITLE
⚡️ perf(blog): trim internal-link preview payloads

### DIFF
--- a/apps/blog/mdx-components.tsx
+++ b/apps/blog/mdx-components.tsx
@@ -2,9 +2,10 @@ import type { MDXComponents } from "mdx/types";
 import Link from "next/link";
 import type { AnchorHTMLAttributes, ReactNode } from "react";
 
-import { type ArticleMeta, getArticles } from "@/app/(blog)/articles/service";
+import { getArticles } from "@/app/(blog)/articles/service";
 import {
   ARTICLES_PREFIX,
+  type ArticlePreviewMeta,
   extractArticleSlug,
   InternalLink,
 } from "@/components/internal-link";
@@ -43,7 +44,7 @@ async function ArticleLinkResolver({
   }
 
   const slug = extractArticleSlug(href);
-  const previewMeta = slug ? await resolveArticleMeta(slug) : undefined;
+  const previewMeta = slug ? await resolveArticlePreviewMeta(slug) : undefined;
 
   return (
     <InternalLink href={href} previewMeta={previewMeta} {...rest}>
@@ -52,11 +53,19 @@ async function ArticleLinkResolver({
   );
 }
 
-async function resolveArticleMeta(
+async function resolveArticlePreviewMeta(
   slug: string
-): Promise<ArticleMeta | undefined> {
+): Promise<ArticlePreviewMeta | undefined> {
   const articles = await getArticles();
-  return articles.entities[slug]?.meta;
+  const meta = articles.entities[slug]?.meta;
+  if (!meta) {
+    return;
+  }
+  return {
+    description: meta.description,
+    tag: meta.tag,
+    title: meta.title,
+  };
 }
 
 export function useMDXComponents(components: MDXComponents): MDXComponents {

--- a/apps/blog/src/app/(blog)/articles/[slug]/article-link-row.tsx
+++ b/apps/blog/src/app/(blog)/articles/[slug]/article-link-row.tsx
@@ -19,7 +19,11 @@ export function ArticleLinkRow({ link }: ArticleLinkRowProps) {
         <InternalLink
           className="font-display font-medium text-[0.95rem] text-foreground no-underline hover:text-[var(--article-accent)]"
           href={`/articles/${slug}`}
-          previewMeta={meta}
+          previewMeta={{
+            description: meta.description,
+            tag: meta.tag,
+            title: meta.title,
+          }}
         >
           {meta.title}
         </InternalLink>

--- a/apps/blog/src/app/(blog)/articles/index-row.tsx
+++ b/apps/blog/src/app/(blog)/articles/index-row.tsx
@@ -84,7 +84,11 @@ export function IndexRow({
             compact ? "text-[16px] leading-[1.25]" : "text-[19px] leading-[1.2]"
           )}
           href={`/articles/${slug}`}
-          previewMeta={meta}
+          previewMeta={{
+            description: meta.description,
+            tag: meta.tag,
+            title: meta.title,
+          }}
         >
           {meta.title}
         </InternalLink>

--- a/apps/blog/src/components/internal-link.tsx
+++ b/apps/blog/src/components/internal-link.tsx
@@ -21,13 +21,18 @@ const SLUG_TERMINATOR_RE = /[?#/]/;
 
 type LinkProps = ComponentProps<typeof Link>;
 
+export type ArticlePreviewMeta = Pick<
+  ArticleMeta,
+  "description" | "tag" | "title"
+>;
+
 export interface InternalLinkProps extends Omit<LinkProps, "href"> {
   href: string;
   /**
    * Pre-resolved frontmatter for the destination. When provided, the
    * hover-card renders without an extra client-side fetch.
    */
-  previewMeta?: ArticleMeta;
+  previewMeta?: ArticlePreviewMeta;
 }
 
 export function InternalLink({
@@ -84,7 +89,7 @@ export function InternalLink({
 }
 
 interface InternalLinkPreviewBodyProps {
-  meta: ArticleMeta;
+  meta: ArticlePreviewMeta;
 }
 
 /**


### PR DESCRIPTION
## What changed

Project internal-link hover previews to the only fields the client renders—`description`, `tag`, and `title`—at all three server-to-client boundaries.

This keeps full article metadata on the server while avoiding serialization of unused dates, sources, tags, reading time, domain, entity type, and image fields into embedded RSC data.

## Evidence

Measured on the 373-article content snapshot at `e1d28434` using a production build + `next start`, one warm-up then 10 serial localhost requests per route. Response sizes were deterministic within each state. The four touched source files were byte-identical to `main`; the final single commit was rebased onto current `main` and its full pre-push gate reran successfully.

| Route | Baseline gzip | Candidate gzip | Reduction |
|---|---:|---:|---:|
| `/` | 57,042 B | 50,369 B | 11.70% |
| `/articles` | 100,126 B | 90,101 B | 10.01% |
| `/articles/effective-compute-scaling` | 36,311 B | 34,290 B | 5.57% |
| `/articles/compounding-data-moat` | 58,074 B | 56,000 B | 3.57% |

Median gzip reduction across the four representative non-outlier routes: **7.79%**, above the declared 3% acceptance threshold.

The max-link stress page `/articles/open-questions` improved 112,262 → 109,913 B (2.09%) but was explicitly excluded from the primary acceptance metric.

This is a bounded claim for local production HTML responses including embedded RSC metadata. TTFB samples were non-interleaved and inconclusive; this PR makes no claim about TTFB, Core Web Vitals, standalone RSC navigation payloads, or build time.

## Correctness

- Production build passed (232 static pages)
- 241/241 blog tests passed
- TypeScript and Ultracite passed (existing oversized graph warning only)
- Post-rebase pre-push monorepo gate passed 8/8 tasks
- Saved stress-page HTML retained identical visible text and all 631 links
- Browser QA retained the preview tag/title/description/Read affordance with zero console errors
- `git diff --check` passed
