### PR TITLE
⚡️ perf(tooling): exclude Next dev cache outputs

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -5,7 +5,7 @@
     "build": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": ["dist/**", ".next/**", "!.next/cache/**"]
+      "outputs": ["dist/**", ".next/**", "!.next/cache/**", "!.next/dev/**"]
     },
     "lint": {
       "dependsOn": ["^lint"],


### PR DESCRIPTION
## What changed

Exclude `.next/dev/**` from Turbo's production `build` outputs. Next regenerates that tree in development; it is not a production build artifact.

## Evidence

A fixed dev fixture was generated by compiling five representative routes with Next dev:

- SHA-256: `c12c75635393c1eaaa4f5f794f3a7448439ee752d5926403dc966a4ef11b40a2`
- tar size: 775,128,576 bytes
- 2,678 dev-tree entries (2,651 files)

Three serial baseline/candidate production build pairs restored this exact fixture and wrote to fresh local-only Turbo caches.

| Metric | Baseline median | Candidate median | Effect |
|---|---:|---:|---:|
| Turbo cache archive | 499,714,834 B | 56,195,704 B | 88.8% smaller |
| Observed local cache restore | 2.03 s | 0.99 s | 51.2% faster |

The candidate archive was within 0.005% of a clean production artifact (56,193,268 B) and contained zero `.next/dev` paths.

This claim applies when stale `.next/dev` output exists before a production build. It does not claim faster build execution, CI, upload/download, or gains for clean repositories.

## Correctness

- Production path inventories matched after removing dev paths and normalizing Next's random build-ID directory
- Clean candidate cache hit restored `BUILD_ID`, server manifests/chunks, and static chunks without `.next/dev`
- An existing `.next/dev` sentinel survived candidate cache restoration
- Restored `next start` returned 200 with correct content types for `/`, `/articles`, a representative article, RSS, and `llms.txt`
- Type-check, 725 tests, Ultracite, dry graph, and `git diff --check` passed
- Pre-push monorepo gate passed 8/8 tasks
