### PR TITLE
⚡️ perf(tooling): keep content edits cached

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -9,12 +9,18 @@
     },
     "lint": {
       "dependsOn": ["^lint"],
-      "inputs": ["$TURBO_DEFAULT$", "biome.json", "../../biome.json"]
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "!src/content/**",
+        "biome.json",
+        "../../biome.json"
+      ]
     },
     "type-check": {
       "dependsOn": ["^type-check"],
       "inputs": [
         "$TURBO_DEFAULT$",
+        "!src/content/**",
         "tsconfig.json",
         "../../packages/tsconfig/**"
       ]


### PR DESCRIPTION
## Summary
- exclude blog `src/content/**` from Turbo lint and type-check inputs
- keep content changes sensitive to build/test
- retain public and TypeScript invalidation

## Evidence
For a controlled content-only MDX edit across five serial pairs with local-only caches, baseline reran blog lint/type-check while the candidate preserved all cache hits. Median wall time fell from 1.67 s to 0.15 s (91.0%, 11.1x). This is a content-only workflow claim, not cold lint/type-check execution speed or full wiki imports that also update `src/data/*.json`.

## Verification
- all 5 baseline trials: 2/4 cached; blog lint/type-check reran
- all 5 candidate trials: 4/4 cached
- content edits still changed blog build/test hashes
- public and TS edits still changed lint/type-check hashes
- `bun run lint`, `bun run type-check`, 241 blog tests
- production `next build` (217 routes)
- `bunx ultracite check turbo.json`
- `git diff --check`
- pre-push gate: 8/8 tasks passed

Independent verification accepted the bounded claim.