### PR TITLE
⚡️ perf(blog): gate WebMCP client code

### DIFF
--- a/apps/blog/src/__tests__/search/search-provider.test.tsx
+++ b/apps/blog/src/__tests__/search/search-provider.test.tsx
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+
+import { SearchProvider } from "@/components/search/search-provider";
+
+afterEach(() => {
+  cleanup();
+  Reflect.deleteProperty(document, "modelContext");
+});
+
+describe("SearchProvider WebMCP gate", () => {
+  it("leaves WebMCP tools unmounted in an unsupported browser", async () => {
+    render(<SearchProvider>content</SearchProvider>);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId("dynamic-component")).toHaveLength(1);
+    });
+  });
+
+  it("mounts WebMCP tools after hydration in a supported browser", async () => {
+    Object.defineProperty(document, "modelContext", {
+      configurable: true,
+      value: { registerTool: () => undefined },
+    });
+
+    render(<SearchProvider>content</SearchProvider>);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId("dynamic-component")).toHaveLength(2);
+    });
+  });
+});

--- a/apps/blog/src/components/search/search-provider.tsx
+++ b/apps/blog/src/components/search/search-provider.tsx
@@ -6,6 +6,7 @@ import {
   type ReactNode,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useState,
 } from "react";
@@ -35,7 +36,12 @@ const SearchContext = createContext<SearchContextValue | null>(null);
  */
 export function SearchProvider({ children }: { children: ReactNode }) {
   const [open, setOpen] = useState(false);
+  const [webMcpAvailable, setWebMcpAvailable] = useState(false);
   const openSearch = useCallback(() => setOpen(true), []);
+
+  useEffect(() => {
+    setWebMcpAvailable(Boolean(document.modelContext));
+  }, []);
 
   useKeyboardShortcut("k", openSearch, { ctrlOrMeta: true });
 
@@ -45,7 +51,7 @@ export function SearchProvider({ children }: { children: ReactNode }) {
     <SearchContext value={value}>
       {children}
       <SearchPalette onOpenChange={setOpen} open={open} />
-      <WebMcpTools />
+      {webMcpAvailable && <WebMcpTools />}
     </SearchContext>
   );
 }


### PR DESCRIPTION
## Summary
- load the WebMCP client module only when `document.modelContext` exists
- preserve hydration parity with a mount-only capability check
- cover supported and unsupported provider behavior

## Evidence
Across 120 cold headless-browser contexts (10 per route/variant/capability state), unsupported baseline clients fetched the 26,889-byte decoded WebMCP chunk on all three representative routes; candidate clients fetched it 0/10 times. Net decoded initial JS fell 26,808 bytes (3.00–3.03%). Recomputed gzip artifact savings were 9,590 bytes net (3.47–3.51%).

Supported baseline and candidate contexts fetched the module 10/10 and eventually registered exactly `search_articles` and `get_article`; both tool executions returned valid equivalent results and deferred their additional index request until execution. Registration-readiness timing was not established, so this PR makes no latency/CPU claim.

## Verification
- 243 blog tests
- blog type-check and Ultracite
- production Next build (217 routes)
- browser cold-load traces for `/`, `/articles`, and a representative article
- supported WebMCP registration and execution parity
- `git diff --check`
- pre-push gate: 8/8 tasks passed

Independent verification accepted the bounded transfer claim.