### PR TITLE
⚡️ perf(ci): fold content checks into tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,35 +20,6 @@ jobs:
       run-test: true
       run-build: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
-  translations:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version-file: package.json
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      # Fails the build on broken wiki-generated content: hero-image imports with
-      # no PNG, manifest slug references to deleted articles, or missing required
-      # frontmatter. Orphan articles/PNGs and domains without a MOC are emitted as
-      # non-fatal GitHub annotations.
-      - name: Check content integrity
-        run: bun apps/cli/src/content-check.ts
-
-      # Warns (GitHub annotations) — does not fail the build — if any committed
-      # zh-TW translation is stale/drifted/orphaned vs its source. Never-translated
-      # articles are ignored (translation is opt-in). Drop --warn to hard-fail.
-      - name: Check zh-TW translations are fresh
-        run: bun apps/cli/src/translate/index.ts --check --warn
-
   release:
     needs: ci
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "format": "ultracite fix",
     "type-check": "turbo run type-check",
     "typecheck": "turbo run type-check",
-    "test": "turbo run test",
+    "test": "turbo run test && bun apps/cli/src/content-check.ts && bun apps/cli/src/translate/index.ts --check --warn",
     "prepare": "husky",
     "check": "ultracite check",
     "fix": "ultracite fix",


### PR DESCRIPTION
## Summary
- run content integrity and translation freshness through the existing root Test step
- remove the separately allocated translations runner
- preserve fail-hard integrity and warning-only translation behavior

## Evidence
The removed Ubuntu job had a median elapsed runtime of 15.5 seconds across the 10 most recent successful main pushes (range 10–51 s). Its two checks consume 0–1 hosted seconds together; local integrated execution adds about 0.2–0.4 s after cached tests. This is a runner-allocation efficiency claim, not a PR critical-path or billing claim.

## Verification
- pinned reusable workflow executes `bun run test` on PRs and main
- integrated root test passed with the exact checks
- direct and integrated warning sets matched: 274 annotations
- required branch checks/rulesets do not reference `translations`
- package JSON, Ultracite, actionlint, and diff checks passed
- pre-push gate: 8/8 tasks passed

Independent verification accepted the bounded runner-consumption claim. Hosted candidate CI must confirm the single-job shape before this leaves draft.