### PR TITLE
⚡️ perf(blog): disable desktop nav prefetch

### DIFF
--- a/apps/blog/src/app/(blog)/(layout)/header.tsx
+++ b/apps/blog/src/app/(blog)/(layout)/header.tsx
@@ -43,6 +43,7 @@ function NavLink({ href, label }: { href: string; label: string }) {
       aria-current={isActive ? "page" : undefined}
       className="rounded-full px-4 py-2 font-body font-medium text-[0.9rem] text-muted-foreground transition-colors hover:text-foreground aria-[current=page]:bg-brand/10 aria-[current=page]:text-brand"
       href={href}
+      prefetch={false}
     >
       {label}
     </Link>


### PR DESCRIPTION
## Summary
- disable automatic viewport/hover prefetch only for the persistent desktop primary navigation
- keep normal client-side navigation and all mobile/article/footer link behavior unchanged

## Evidence
Across 10 interleaved cold browser contexts on both `/` and a representative article, the candidate removed 14 initial requests and 1,386,882 decoded response-body bytes (33.8–34.1%): 11 RSC requests / 1,310,253 bytes and 3 JS requests / 76,629 bytes. These are decoded local-production bytes, not gzip/network-wire measurements.

Local click-to-visible medians rose 7.8–18.7 ms across Articles, Questions, and Shelf; p95 changed -8.7 to +45.8 ms, within the predeclared +100 ms guard. No general real-user latency claim is made.

## Verification
- 10 cold contexts per start/variant
- 10 navigation trials per destination/variant
- desktop route/content parity and mobile menu parity
- 241 blog tests, type-check, Ultracite
- production Next build (217 routes)
- pre-push gate: 8/8 tasks passed

Independent verification accepted the bounded transfer/latency tradeoff.